### PR TITLE
Update config format for QRC20 integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ You need the following info in JSON format added to the [coins](coins) file:
     "txfee": 10000,
     "segwit": true,
     "mm2": 1,
-    "required_confirmations": 2
+    "required_confirmations": 2,
+    "protocol": {
+      "type": "UTXO"
+    }
   }
 ```
 
@@ -72,7 +75,10 @@ You need the following info in JSON format added to the [coins](coins) file:
     "overwintered": 1,
     "mm2": 1,
     "required_confirmations": 2,
-    "requires_notarization": true
+    "requires_notarization": true,
+    "protocol": {
+      "type": "UTXO"
+    }
   }
 ```
 
@@ -92,7 +98,10 @@ You need the following info in JSON format added to the [coins](coins) file:
     "txversion": 7,
     "mm2":1,
     "confpath": "USERHOME/.electra/Electra.conf",
-    "required_confirmations": 10
+    "required_confirmations": 10,
+    "protocol": {
+      "type": "UTXO"
+    }
   }
 ```
 
@@ -104,11 +113,39 @@ You need the following info in JSON format added to the [coins](coins) file:
     "coin": "BAT",
     "name": "basic-attention-token",
     "fname": "Basic Attention Token",
-    "etomic": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
     "rpcport": 80,
     "mm2": 1,
-    "required_confirmations": 3
+    "required_confirmations": 3,
+    "protocol": {
+      "type": "ERC20",
+      "protocol_data": {
+          "platform": "ETH",
+          "contract_address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
+      }
+    }
   }
+```
+
+### Example 5 (QRC20 testnet)
+
+```json
+
+{
+  "coin": "QRC20",
+  "pubtype": 120,
+  "p2shtype": 50,
+  "wiftype": 128,
+  "segwit": true,
+  "mm2": 1,
+  "mature_confirmations": 500,
+  "protocol": {
+    "type": "QRC20",
+    "protocol_data": {
+      "platform": "QTUM",
+      "contract_address": "0xd362e096e873eb7907e205fadc6175c6fec7bc44"
+    }
+  }
+}
 ```
 
 ## General parameters
@@ -117,6 +154,7 @@ You need the following info in JSON format added to the [coins](coins) file:
 - `"required_confirmations"` the number of confirmations AtomicDEX will wait for during the swap. Default value is 1. WARNING, this setting affects the security of the atomic swap. 51% attacks (double spending) are a threat and have been succesfully conducted in the past. Read more about it [here](https://komodoplatform.com/51-attack-how-komodo-can-help-prevent-one/). You can find a collection of coins and the theoretical cost of a 51% attack [here](https://www.crypto51.app/). Please be aware that some of the coins supported by AtomicDEX are vulnerable to such attacks, so consider using higher values for them, especially when dealing with high amounts.
 - `"requires_notarization"` tells AtomicDEX to wait for a notarization during the swap. This only works with dPoW coins and `"required_confirmations"` must be set to `2` or higher.
 - `"decimals"` defines the number of digits after the decimal point that should be used to display the orderbook amounts, balance, and the value of inputs to be used in the case of order creation or a `withdraw` transaction. The default value used for a UTXO type coin (Bitcoin Protocol) is `8` and the default value used for a ERC20 Token is `18`. It is very important for this value to be set correctly. For example, if this value was set as `9` for BTC, a command to withdraw `1 BTC` tries to withdraw `10^9` satoshis of Bitcoin, i.e., `10 BTC`
+- `"protocol"` contains the coin protocol `"type"` (UTXO, ETH, etc.) and specific protocol configuration - `"protocol_data"` object that can have arbitrary format. 
 
 ## Bitcoin Protocol specific JSON
 
@@ -137,12 +175,18 @@ You need the following info in JSON format added to the [coins](coins) file:
 - `segwit` - is a boolean value, if set to true, AtomicDEX-API will allow withdrawal to `P2SH` addresses. Will possibly mean full segwit support in the future.
 - `version_group_id` - sets the `version_group_id` used by Zcash (and its forks') transactions. Determined automatically by tx version and `overwintered` if not set.
 - `consensus_branch_id` - sets the `consensus_branch_id` used in Zcash (and its forks') transactions' signature hash calculation. Determined automatically by tx version and `overwintered` if not set.
+- `mature_confirmations` - number of blockchain confirmations required for coinbase output to be considered mature (spendable).
 
 ## Ethereum Protocol specific JSON
 
 - Ethereum protocol specific coin/project add request are the simplest. `"coin"`, `"name"`, and `"fname"` information is same as explained in bitcoin protocol specific json section.
-- `"rpcport"` must remain default for all ERC20 token/coins. Make sure its only specified as `80`.
-- `"etomic"` must be the ERC20 token/coin's [checksummed](https://coincodex.com/article/2078/ethereum-address-checksum-explained/) smart contract address.
+- Protocol `"type"` field: `"ETH"` or `"ERC20"`
+- Protocol `"protocol_data"` field (ERC20 only): `"platform"` - `"ETH"`, `"ETC"` or other Ethereum forks. `"contract_address"` - ERC20 token [checksummed](https://coincodex.com/article/2078/ethereum-address-checksum-explained/) smart contract address.
+
+## QRC20 Protocol specific JSON
+- Supports all fields of UTXO specific config.
+- Protocol `"type"` field: `"QRC20"`.
+- Protocol `"protocol_data"` field: `"platform"` - `"QTUM"` or QTUM forks. `"contract_address"` - QRC20 token smart contract address.
 
 ## 2. Icon file (Required)
 

--- a/coins
+++ b/coins
@@ -3,8 +3,13 @@
 		"coin": "1ST",
 		"name": "firstblood",
 		"fname": "FirstBlood",
-		"etomic": "0xAf30D2a7E90d7DC361c8C4585e9BB7D2F6f15bc7",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xAf30D2a7E90d7DC361c8C4585e9BB7D2F6f15bc7"
+			}
+		}
 	},
 	{
 		"coin": "ABY",
@@ -14,28 +19,44 @@
 		"pubtype": 23,
 		"p2shtype": 5,
 		"wiftype": 151,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ADT",
 		"name": "adtoken",
 		"fname": "adToken",
-		"etomic": "0xD0D6D6C5Fe4a677D343cC433536BB717bAe167dD",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xD0D6D6C5Fe4a677D343cC433536BB717bAe167dD"
+			}
+		}
 	},
 	{
 		"coin": "AMB",
 		"name": "amber",
 		"fname": "Ambrosus",
-		"etomic": "0x4DC3643DbC642b72C158E7F3d2ff232df61cb6CE",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x4DC3643DbC642b72C158E7F3d2ff232df61cb6CE"
+			}
+		}
 	},
 	{
 		"coin": "ANT",
 		"name": "aragon",
 		"fname": "Aragon",
-		"etomic": "0x960b236A07cf122663c4303350609A66A7B288C0",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x960b236A07cf122663c4303350609A66A7B288C0"
+			}
+		}
 	},
 	{
 		"coin": "ARC",
@@ -46,23 +67,34 @@
 		"pubtype": 23,
 		"p2shtype": 8,
 		"wiftype": 176,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ARPA",
 		"name": "arpa-chain",
 		"fname": "ARPA Chain",
-		"etomic": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a"
+			}
+		}
 	},
 	{
 		"coin": "AST",
 		"name": "airswap",
 		"fname": "AirSwap",
-		"etomic": "0x27054b13b1B798B345b591a4d22e6562d47eA75a",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a"
+			}
+		}
 	},
 	{
 		"coin": "ATB",
@@ -73,17 +105,23 @@
 		"p2shtype": 83,
 		"wiftype": 128,
 		"txfee": 10000,
-		"confpath": "USERHOME/.ATBCoinWallet/atbcoin.conf"
+		"confpath": "USERHOME/.ATBCoinWallet/atbcoin.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "AWC",
 		"name": "atomic-wallet-coin",
 		"fname": "Atomic Wallet Coin",
-		"etomic": "0xaD22f63404f7305e4713CcBd4F296f34770513f4",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xaD22f63404f7305e4713CcBd4F296f34770513f4"
+			}
+		}
 	},
 	{
 		"coin": "AXE",
@@ -97,7 +135,8 @@
 		"confpath": "USERHOME/.axecore/axe.conf",
 		"mm2": 1,
 		"required_confirmations": 5,
-		"avg_blocktime": 2.6
+		"avg_blocktime": 2.6,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "AXO",
@@ -108,7 +147,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "AYA",
@@ -121,17 +161,23 @@
 		"txfee": 100000,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BAT",
 		"name": "basic-attention-token",
 		"fname": "Basic Attention Token",
-		"etomic": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
+			}
+		}
 	},
 	{
 		"coin": "BAY",
@@ -142,14 +188,20 @@
 		"pubtype": 25,
 		"p2shtype": 85,
 		"wiftype": 153,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BBT",
 		"name": "bitboost",
 		"fname": "Bitboost",
-		"etomic": "0x1500205f50bf3FD976466d0662905c9ff254fc9c",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x1500205f50bf3FD976466d0662905c9ff254fc9c"
+			}
+		}
 	},
 	{
 		"coin": "BCH",
@@ -161,10 +213,14 @@
 		"wiftype": 128,
 		"txfee": 0,
 		"segwit": true,
-		"address_format": {"format":"cashaddress","network":"bitcoincash"},
+		"address_format": {
+			"format": "cashaddress",
+			"network": "bitcoincash"
+		},
 		"mm2": 1,
 		"required_confirmations": 1,
-		"avg_blocktime": 10
+		"avg_blocktime": 10,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BEER",
@@ -173,7 +229,8 @@
 		"rpcport": 8923,
 		"txversion": 4,
 		"overwintered": 1,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BET",
@@ -185,14 +242,20 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BFT",
 		"name": "bnktothefuture",
 		"fname": "BnkToTheFuture",
-		"etomic": "0x01fF50f8b7f74E4f00580d9596cd3D0d6d6E326f",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x01fF50f8b7f74E4f00580d9596cd3D0d6d6E326f"
+			}
+		}
 	},
 	{
 		"coin": "BITS",
@@ -203,7 +266,8 @@
 		"pubtype": 25,
 		"p2shtype": 8,
 		"wiftype": 153,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BLK",
@@ -215,7 +279,8 @@
 		"p2shtype": 85,
 		"wiftype": 153,
 		"txfee": 100000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BLOCK",
@@ -225,21 +290,32 @@
 		"pubtype": 26,
 		"p2shtype": 28,
 		"wiftype": 154,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BLZ",
 		"name": "bluzelle",
 		"fname": "Bluzelle",
-		"etomic": "0x5732046A883704404F284Ce41FfADd5b007FD668",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x5732046A883704404F284Ce41FfADd5b007FD668"
+			}
+		}
 	},
 	{
 		"coin": "BNT",
 		"name": "bancor",
 		"fname": "Bancor",
-		"etomic": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"
+			}
+		}
 	},
 	{
 		"coin": "BOTS",
@@ -251,7 +327,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BSD",
@@ -261,7 +338,8 @@
 		"pubtype": 102,
 		"p2shtype": 5,
 		"wiftype": 204,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTA",
@@ -271,7 +349,8 @@
 		"pubtype": 25,
 		"p2shtype": 5,
 		"wiftype": 188,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTC",
@@ -286,7 +365,8 @@
 		"estimate_fee_mode": "ECONOMICAL",
 		"mm2": 1,
 		"required_confirmations": 1,
-		"avg_blocktime": 10
+		"avg_blocktime": 10,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTCH",
@@ -297,14 +377,20 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTCL",
 		"name": "btclite",
 		"fname": "BTC Lite",
-		"etomic": "0x5acD19b9c91e596b1f062f18e3D02da7eD8D1e50",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x5acD19b9c91e596b1f062f18e3D02da7eD8D1e50"
+			}
+		}
 	},
 	{
 		"coin": "BTCP",
@@ -315,7 +401,8 @@
 		"pubtype": 37,
 		"p2shtype": 175,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTCZ",
@@ -326,7 +413,8 @@
 		"pubtype": 184,
 		"p2shtype": 189,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTG",
@@ -336,14 +424,20 @@
 		"pubtype": 38,
 		"p2shtype": 23,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BTO",
 		"name": "bottos",
 		"fname": "Bottos",
-		"etomic": "0x36905Fc93280f52362A1CBAB151F25DC46742Fb5",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x36905Fc93280f52362A1CBAB151F25DC46742Fb5"
+			}
+		}
 	},
 	{
 		"coin": "BTX",
@@ -354,7 +448,8 @@
 		"p2shtype": 125,
 		"wiftype": 128,
 		"txfee": 50000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BUCK",
@@ -365,17 +460,23 @@
 		"pubtype": 184,
 		"p2shtype": 189,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "BUSD",
 		"name": "binance-usd",
 		"fname": "Binance USD",
-		"etomic": "0x4Fabb145d64652a948d72533023f6E7A623C7C53",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
+			}
+		}
 	},
 	{
 		"coin": "BZC",
@@ -387,7 +488,8 @@
 		"p2shtype": 189,
 		"wiftype": 128,
 		"txversion": 4,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CCL",
@@ -399,14 +501,20 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CDT",
 		"name": "blox",
 		"fname": "Blox",
-		"etomic": "0x177d39AC676ED1C67A2b268AD7F1E58826E5B0af",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x177d39AC676ED1C67A2b268AD7F1E58826E5B0af"
+			}
+		}
 	},
 	{
 		"coin": "CEAL",
@@ -415,14 +523,20 @@
 		"rpcport": 11116,
 		"txversion": 4,
 		"overwintered": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CENNZ",
 		"name": "centrality",
 		"fname": "Centrality",
-		"etomic": "0x1122B6a0E00DCe0563082b6e2953f3A943855c1F",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x1122B6a0E00DCe0563082b6e2953f3A943855c1F"
+			}
+		}
 	},
 	{
 		"coin": "CHAIN",
@@ -432,7 +546,8 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CHIPS",
@@ -447,7 +562,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 0.166
+		"avg_blocktime": 0.166,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CMM",
@@ -457,7 +573,8 @@
 		"pubtype": 28,
 		"p2shtype": 50,
 		"wiftype": 140,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "COLX",
@@ -468,7 +585,8 @@
 		"p2shtype": 13,
 		"wiftype": 212,
 		"txfee": 1000000000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "COMMOD",
@@ -478,7 +596,8 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "COQUI",
@@ -489,16 +608,22 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CRO",
 		"name": "cryptocom",
 		"fname": "Crypto.com",
-		"etomic": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b"
+			}
+		}
 	},
 	{
 		"coin": "CRW",
@@ -508,7 +633,8 @@
 		"pubtype": 0,
 		"p2shtype": 28,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CRYPTO",
@@ -520,21 +646,32 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "CS",
 		"name": "credits",
 		"fname": "Credits",
-		"etomic": "0x46b9Ad944d1059450Da1163511069C718F699D31",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x46b9Ad944d1059450Da1163511069C718F699D31"
+			}
+		}
 	},
 	{
 		"coin": "CVC",
 		"name": "civic",
 		"fname": "Civic",
-		"etomic": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45"
+			}
+		}
 	},
 	{
 		"coin": "D",
@@ -545,17 +682,23 @@
 		"pubtype": 30,
 		"p2shtype": 90,
 		"wiftype": 158,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DAI",
 		"name": "multi-collateral-dai",
 		"fname": "Multi-collateral DAI",
-		"etomic": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+			}
+		}
 	},
 	{
 		"coin": "DASH",
@@ -569,47 +712,73 @@
 		"txfee": 0,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"avg_blocktime": 2.633
+		"avg_blocktime": 2.633,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DATA",
 		"name": "streamr-datacoin",
 		"fname": "Streamr DATAcoin",
-		"etomic": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023"
+			}
+		}
 	},
 	{
 		"coin": "DCN",
 		"name": "dentacoin",
 		"fname": "Dentacoin",
-		"etomic": "0x08d32b0da63e2C3bcF8019c9c5d849d7a9d791e6",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x08d32b0da63e2C3bcF8019c9c5d849d7a9d791e6"
+			}
+		}
 	},
 	{
 		"coin": "DDD",
 		"name": "scryinfo",
 		"fname": "Scry.info",
-		"etomic": "0x9F5F3CFD7a32700C93F971637407ff17b91c7342",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x9F5F3CFD7a32700C93F971637407ff17b91c7342"
+			}
+		}
 	},
 	{
 		"coin": "DEC8",
 		"name": "DEC8",
 		"fname": "DEC8 (TESTCOIN)",
-		"etomic": "0x3aB100442484Dc2414Aa75B2952A0a6f03f8aBFd",
+		"mm2": 1,
 		"rpcport": 80,
-		"mm2": 1
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x3aB100442484Dc2414Aa75B2952A0a6f03f8aBFd"
+			}
+		}
 	},
 	{
 		"coin": "DENT",
 		"name": "dent",
 		"fname": "Dent Coin",
-		"etomic": "0x3597bfD533a99c9aa083587B074434E61Eb0A258",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258"
+			}
+		}
 	},
 	{
 		"coin": "DEX",
@@ -621,7 +790,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DGB",
@@ -635,22 +805,33 @@
 		"segwit": true,
 		"mm2": 1,
 		"required_confirmations": 7,
-		"avg_blocktime": 1.25
+		"avg_blocktime": 1.25,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DGD",
 		"name": "digixdao",
 		"fname": "DigixDAO",
-		"etomic": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A",
+		"rpcport": 80,
 		"decimals": 9,
-		"rpcport": 80
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A"
+			}
+		}
 	},
 	{
 		"coin": "DICE",
 		"name": "etheroll",
 		"fname": "Etheroll",
-		"etomic": "0x2e071D2966Aa7D8dECB1005885bA1977D6038A65",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x2e071D2966Aa7D8dECB1005885bA1977D6038A65"
+			}
+		}
 	},
 	{
 		"coin": "DIN",
@@ -661,7 +842,8 @@
 		"p2shtype": 13,
 		"wiftype": 204,
 		"txfee": 10000,
-		"confpath": "USERHOME/.dinerocore/dinero.conf"
+		"confpath": "USERHOME/.dinerocore/dinero.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DION",
@@ -670,14 +852,20 @@
 		"rpcport": 23895,
 		"txversion": 4,
 		"overwintered": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DNT",
 		"name": "district0x",
 		"fname": "District0x",
-		"etomic": "0x0AbdAce70D3790235af448C88547603b945604ea",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x0AbdAce70D3790235af448C88547603b945604ea"
+			}
+		}
 	},
 	{
 		"coin": "DOGE",
@@ -691,7 +879,8 @@
 		"force_min_relay_fee": true,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DOPE",
@@ -702,7 +891,8 @@
 		"pubtype": 30,
 		"p2shtype": 5,
 		"wiftype": 158,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DP",
@@ -712,28 +902,44 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DRGN",
 		"name": "dragonchain",
 		"fname": "Dragonchain",
-		"etomic": "0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E"
+			}
+		}
 	},
 	{
 		"coin": "DROP",
 		"name": "dropil",
 		"fname": "Dropil",
-		"etomic": "0x4672bAD527107471cB5067a887f4656D585a8A31",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x4672bAD527107471cB5067a887f4656D585a8A31"
+			}
+		}
 	},
 	{
 		"coin": "DRT",
 		"name": "domraider",
 		"fname": "DomRaider",
-		"etomic": "0x9AF4f26941677C706cfEcf6D3379FF01bB85D5Ab",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x9AF4f26941677C706cfEcf6D3379FF01bB85D5Ab"
+			}
+		}
 	},
 	{
 		"coin": "DSEC",
@@ -742,7 +948,8 @@
 		"rpcport": 11557,
 		"txversion": 4,
 		"overwintered": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DSR",
@@ -753,7 +960,8 @@
 		"pubtype": 30,
 		"p2shtype": 16,
 		"wiftype": 204,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "DYN",
@@ -763,7 +971,8 @@
 		"pubtype": 30,
 		"p2shtype": 10,
 		"wiftype": 140,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ECA",
@@ -778,14 +987,20 @@
 		"mm2": 1,
 		"confpath": "USERHOME/.electra/Electra.conf",
 		"required_confirmations": 5,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "EDG",
 		"name": "edgeless",
 		"fname": "Edgeless",
-		"etomic": "0x08711D3B02C8758F2FB3ab4e80228418a7F8e39c",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x08711D3B02C8758F2FB3ab4e80228418a7F8e39c"
+			}
+		}
 	},
 	{
 		"coin": "EFL",
@@ -796,14 +1011,20 @@
 		"pubtype": 48,
 		"p2shtype": 5,
 		"wiftype": 176,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ELF",
 		"name": "aelf",
 		"fname": "aelf",
-		"etomic": "0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e"
+			}
+		}
 	},
 	{
 		"coin": "ELI",
@@ -813,14 +1034,20 @@
 		"pubtype": 33,
 		"p2shtype": 102,
 		"wiftype": 205,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ELY",
 		"name": "elysian",
 		"fname": "Elysian",
-		"etomic": "0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8"
+			}
+		}
 	},
 	{
 		"coin": "EMC2",
@@ -834,23 +1061,34 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1.1
+		"avg_blocktime": 1.1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ENG",
 		"name": "enigma-project",
 		"fname": "Enigma",
-		"etomic": "0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4"
+			}
+		}
 	},
 	{
 		"coin": "ENJ",
 		"name": "enjin-coin",
 		"fname": "Enjin Coin",
-		"etomic": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c"
+			}
+		}
 	},
 	{
 		"coin": "EQLI",
@@ -860,31 +1098,42 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ETH",
 		"name": "ethereum",
 		"fname": "Ethereum",
-		"etomic": "0x0000000000000000000000000000000000000000",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": "ETH"
 	},
 	{
 		"coin": "ETHOS",
 		"name": "ethos",
 		"fname": "Ethos",
-		"etomic": "0x5Af2Be193a6ABCa9c8817001F45744777Db30756",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x5Af2Be193a6ABCa9c8817001F45744777Db30756"
+			}
+		}
 	},
 	{
 		"coin": "ETK",
 		"name": "energitoken",
 		"fname": "EnergiToken",
-		"etomic": "0x3c4a3ffd813a107febd57B2f01BC344264D90FdE",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x3c4a3ffd813a107febd57B2f01BC344264D90FdE"
+			}
+		}
 	},
 	{
 		"coin": "ETOMIC",
@@ -893,7 +1142,8 @@
 		"rpcport": 10271,
 		"txversion": 4,
 		"overwintered": 1,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "FJC",
@@ -903,7 +1153,8 @@
 		"pubtype": 36,
 		"p2shtype": 16,
 		"wiftype": 164,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "FLASH",
@@ -915,7 +1166,8 @@
 		"wiftype": 196,
 		"txfee": 10000000,
 		"decimals": 10,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "FLO",
@@ -926,7 +1178,8 @@
 		"p2shtype": 8,
 		"wiftype": 176,
 		"txfee": 100000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "FTC",
@@ -940,14 +1193,20 @@
 		"segwit": true,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"avg_blocktime": 1.033
+		"avg_blocktime": 1.033,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "FUN",
 		"name": "funfair",
 		"fname": "FunFair",
-		"etomic": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b"
+			}
+		}
 	},
 	{
 		"coin": "GBX",
@@ -958,7 +1217,8 @@
 		"pubtype": 38,
 		"p2shtype": 10,
 		"wiftype": 198,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GIN",
@@ -970,7 +1230,8 @@
 		"wiftype": 198,
 		"txfee": 10000,
 		"confpath": "USERHOME/.gincoincore/gincoin.conf",
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GLD",
@@ -980,7 +1241,8 @@
 		"pubtype": 32,
 		"p2shtype": 5,
 		"wiftype": 160,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GLEEC",
@@ -994,7 +1256,8 @@
 		"txfee": 1000,
 		"mm2": 1,
 		"required_confirmations": 1,
-		"avg_blocktime": 5
+		"avg_blocktime": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GLT",
@@ -1004,7 +1267,8 @@
 		"pubtype": 38,
 		"p2shtype": 5,
 		"wiftype": 166,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GLXT",
@@ -1014,14 +1278,20 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GNO",
 		"name": "gnosis-gno",
 		"fname": "Gnosis",
-		"etomic": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+			}
+		}
 	},
 	{
 		"coin": "GRLC",
@@ -1031,7 +1301,8 @@
 		"pubtype": 38,
 		"p2shtype": 5,
 		"wiftype": 176,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GRS",
@@ -1041,28 +1312,44 @@
 		"pubtype": 36,
 		"p2shtype": 5,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "GTC",
 		"name": "game",
 		"fname": "Game.com",
-		"etomic": "0xB70835D7822eBB9426B56543E391846C107bd32C",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xB70835D7822eBB9426B56543E391846C107bd32C"
+			}
+		}
 	},
 	{
 		"coin": "GTO",
 		"name": "gifto",
 		"fname": "Gifto",
-		"etomic": "0xC5bBaE50781Be1669306b9e001EFF57a2957b09d",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xC5bBaE50781Be1669306b9e001EFF57a2957b09d"
+			}
+		}
 	},
 	{
 		"coin": "GUP",
 		"name": "guppy",
 		"fname": "Matchpool",
-		"etomic": "0xf7B098298f7C69Fc14610bf71d5e02c60792894C",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xf7B098298f7C69Fc14610bf71d5e02c60792894C"
+			}
+		}
 	},
 	{
 		"coin": "GXX",
@@ -1072,21 +1359,32 @@
 		"pubtype": 40,
 		"p2shtype": 10,
 		"wiftype": 210,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "HGT",
 		"name": "hellogold",
 		"fname": "HelloGold",
-		"etomic": "0xba2184520A1cC49a6159c57e61E1844E085615B6",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xba2184520A1cC49a6159c57e61E1844E085615B6"
+			}
+		}
 	},
 	{
 		"coin": "HMQ",
 		"name": "humaniq",
 		"fname": "Humaniq",
-		"etomic": "0xcbCC0F036ED4788F63FC0fEE32873d6A7487b908",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xcbCC0F036ED4788F63FC0fEE32873d6A7487b908"
+			}
+		}
 	},
 	{
 		"coin": "HODL",
@@ -1097,7 +1395,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "HODLC",
@@ -1107,25 +1406,36 @@
 		"pubtype": 40,
 		"p2shtype": 5,
 		"wiftype": 168,
-		"txfee": 5000
+		"txfee": 5000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "HOT",
 		"name": "holo-token",
 		"fname": "Holo Token",
-		"etomic": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2"
+			}
+		}
 	},
 	{
 		"coin": "HT",
 		"name": "huobi-token",
 		"fname": "Huobi Token",
-		"etomic": "0x6f259637dcD74C767781E37Bc6133cd6A68aa161",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x6f259637dcD74C767781E37Bc6133cd6A68aa161"
+			}
+		}
 	},
 	{
 		"coin": "HTML",
@@ -1135,7 +1445,8 @@
 		"pubtype": 41,
 		"p2shtype": 100,
 		"wiftype": 169,
-		"txfee": 400000
+		"txfee": 400000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "HUSH",
@@ -1147,7 +1458,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 2.5
+		"avg_blocktime": 2.5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "I0C",
@@ -1157,7 +1469,8 @@
 		"pubtype": 105,
 		"p2shtype": 5,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ILN",
@@ -1172,7 +1485,8 @@
 		"nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "IMG",
@@ -1182,14 +1496,20 @@
 		"pubtype": 63,
 		"p2shtype": 5,
 		"wiftype": 204,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "IND",
 		"name": "indorse-token",
 		"fname": "Indorse Token",
-		"etomic": "0xf8e386EDa857484f5a12e4B5DAa9984E06E73705",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xf8e386EDa857484f5a12e4B5DAa9984E06E73705"
+			}
+		}
 	},
 	{
 		"coin": "INN",
@@ -1200,7 +1520,8 @@
 		"pubtype": 102,
 		"p2shtype": 20,
 		"wiftype": 195,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "IOP",
@@ -1210,22 +1531,33 @@
 		"pubtype": 117,
 		"p2shtype": 174,
 		"wiftype": 49,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ITL",
 		"name": "italian-lira",
 		"fname": "Italian Lira",
-		"etomic": "0x122A86b5DFF2D085AfB49600b4cd7375D0d94A5f",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x122A86b5DFF2D085AfB49600b4cd7375D0d94A5f"
+			}
+		}
 	},
 	{
 		"coin": "JST",
 		"name": "JST",
 		"fname": "JST (TESTCOIN)",
-		"etomic": "0x996a8ae0304680f6a69b8a9d7c6e37d65ab5ab56",
+		"mm2": 1,
 		"rpcport": 80,
-		"mm2": 1
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x996a8ae0304680f6a69b8a9d7c6e37d65ab5ab56"
+			}
+		}
 	},
 	{
 		"coin": "JUMBLR",
@@ -1237,7 +1569,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "K64",
@@ -1248,7 +1581,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "KMD",
@@ -1264,7 +1598,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "KMDICE",
@@ -1274,14 +1609,20 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "KNC",
 		"name": "kyber-network",
 		"fname": "Kyber Network",
-		"etomic": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"
+			}
+		}
 	},
 	{
 		"coin": "KOIN",
@@ -1292,7 +1633,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "KV",
@@ -1303,7 +1645,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "LABS",
@@ -1314,7 +1657,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "LBC",
@@ -1325,33 +1669,49 @@
 		"p2shtype": 122,
 		"wiftype": 28,
 		"txfee": 10000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "LINK",
 		"name": "chainlink",
 		"fname": "Chainlink",
-		"etomic": "0x514910771AF9Ca656af840dff83E8264EcF986CA",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
+			}
+		}
 	},
 	{
 		"coin": "LOOM",
 		"name": "loom-network",
 		"fname": "Loom Network",
-		"etomic": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0"
+			}
+		}
 	},
 	{
 		"coin": "LRC",
 		"name": "loopring",
 		"fname": "Loopring",
-		"etomic": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD",
+		"required_confirmations": 3,
 		"decimals": 18,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
+			}
+		}
 	},
 	{
 		"coin": "LTC",
@@ -1365,7 +1725,8 @@
 		"segwit": true,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"avg_blocktime": 2.5
+		"avg_blocktime": 2.5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "LTZ",
@@ -1377,7 +1738,8 @@
 		"p2shtype": 184,
 		"wiftype": 128,
 		"txversion": 4,
-		"txfee": 1000
+		"txfee": 1000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "LUMBER",
@@ -1386,14 +1748,20 @@
 		"rpcport": 26301,
 		"txversion": 4,
 		"overwintered": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "LUN",
 		"name": "lunyr",
 		"fname": "Lunyr",
-		"etomic": "0xfa05A73FfE78ef8f1a739473e462c54bae6567D9",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xfa05A73FfE78ef8f1a739473e462c54bae6567D9"
+			}
+		}
 	},
 	{
 		"coin": "LUX",
@@ -1405,16 +1773,22 @@
 		"p2shtype": 63,
 		"wiftype": 155,
 		"txfee": 10000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MANA",
 		"name": "decentraland",
 		"fname": "Decentraland",
-		"etomic": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942"
+			}
+		}
 	},
 	{
 		"coin": "MCL",
@@ -1426,21 +1800,32 @@
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 1,
-		"requires_notarization": false
+		"requires_notarization": false,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MCO",
 		"name": "monaco",
 		"fname": "Monaco",
-		"etomic": "0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d"
+			}
+		}
 	},
 	{
 		"coin": "MDS",
 		"name": "medishares",
 		"fname": "MediShares",
-		"etomic": "0x66186008C1050627F979d464eABb258860563dbE",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x66186008C1050627F979d464eABb258860563dbE"
+			}
+		}
 	},
 	{
 		"coin": "MESH",
@@ -1451,7 +1836,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MGNX",
@@ -1460,14 +1846,20 @@
 		"rpcport": 20731,
 		"txversion": 4,
 		"overwintered": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MGO",
 		"name": "mobilego",
 		"fname": "MobileGo",
-		"etomic": "0x40395044Ac3c0C57051906dA938B54BD6557F212",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x40395044Ac3c0C57051906dA938B54BD6557F212"
+			}
+		}
 	},
 	{
 		"coin": "MGW",
@@ -1479,16 +1871,22 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MKR",
 		"name": "maker",
 		"fname": "Maker",
-		"etomic": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
+			}
+		}
 	},
 	{
 		"coin": "MLM",
@@ -1498,14 +1896,20 @@
 		"pubtype": 110,
 		"p2shtype": 115,
 		"wiftype": 238,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MLN",
 		"name": "melon",
 		"fname": "Melon",
-		"etomic": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892"
+			}
+		}
 	},
 	{
 		"coin": "MNX",
@@ -1515,7 +1919,8 @@
 		"pubtype": 75,
 		"p2shtype": 5,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MONA",
@@ -1526,7 +1931,8 @@
 		"p2shtype": 5,
 		"wiftype": 176,
 		"txfee": 100000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MOON",
@@ -1536,7 +1942,8 @@
 		"pubtype": 3,
 		"p2shtype": 22,
 		"wiftype": 131,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MORTY",
@@ -1547,23 +1954,34 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 1,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MOVI",
 		"name": "movitoken",
 		"fname": "MoviToken",
-		"etomic": "0x06F979E4F04ec565Ae8d7479a94C60dEF8846832",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x06F979E4F04ec565Ae8d7479a94C60dEF8846832"
+			}
+		}
 	},
 	{
 		"coin": "MRPH",
 		"name": "morpheusnetwork",
 		"fname": "Morpheus Network",
-		"etomic": "0x7B0C06043468469967DBA22d1AF33d77d44056c8",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x7B0C06043468469967DBA22d1AF33d77d44056c8"
+			}
+		}
 	},
 	{
 		"coin": "MSHARK",
@@ -1574,14 +1992,20 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MTL",
 		"name": "metal",
 		"fname": "Metal",
-		"etomic": "0xF433089366899D83a9f26A773D59ec7eCF30355e",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xF433089366899D83a9f26A773D59ec7eCF30355e"
+			}
+		}
 	},
 	{
 		"coin": "MUE",
@@ -1591,14 +2015,20 @@
 		"pubtype": 16,
 		"p2shtype": 76,
 		"wiftype": 126,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "MYB",
 		"name": "mybit-token",
 		"fname": "MyBit Token",
-		"etomic": "0x5d60d8d7eF6d37E16EBABc324de3bE57f135e0BC",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x5d60d8d7eF6d37E16EBABc324de3bE57f135e0BC"
+			}
+		}
 	},
 	{
 		"coin": "NAV",
@@ -1614,7 +2044,8 @@
 		"txfee": 10000,
 		"mm2": 1,
 		"required_confirmations": 10,
-		"avg_blocktime": 0.5
+		"avg_blocktime": 0.5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "NIX",
@@ -1625,7 +2056,8 @@
 		"p2shtype": 53,
 		"wiftype": 128,
 		"txfee": 10000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "NMC",
@@ -1637,21 +2069,32 @@
 		"wiftype": 180,
 		"txfee": 100000,
 		"segwit": true,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "NMR",
 		"name": "numeraire",
 		"fname": "Numeraire",
-		"etomic": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671"
+			}
+		}
 	},
 	{
 		"coin": "NOAH",
 		"name": "noah-coin",
 		"fname": "Noah Coin",
-		"etomic": "0x58a4884182d9E835597f405e5F258290E46ae7C2",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x58a4884182d9E835597f405e5F258290E46ae7C2"
+			}
+		}
 	},
 	{
 		"coin": "NOR",
@@ -1661,16 +2104,22 @@
 		"pubtype": 80,
 		"p2shtype": 7,
 		"wiftype": 208,
-		"txfee": 1000
+		"txfee": 1000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "NPXS",
 		"name": "pundi-x",
 		"fname": "Pundi X",
-		"etomic": "0xA15C7Ebe1f07CaF6bFF097D8a589fb8AC49Ae5B3",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xA15C7Ebe1f07CaF6bFF097D8a589fb8AC49Ae5B3"
+			}
+		}
 	},
 	{
 		"coin": "OOT",
@@ -1680,7 +2129,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ORE",
@@ -1690,7 +2140,8 @@
 		"pubtype": 38,
 		"p2shtype": 16,
 		"wiftype": 204,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "OURC",
@@ -1701,7 +2152,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PAC",
@@ -1712,7 +2164,8 @@
 		"p2shtype": 10,
 		"wiftype": 204,
 		"txfee": 10000,
-		"confpath": "USERHOME/.paccoincore/paccoin.conf"
+		"confpath": "USERHOME/.paccoincore/paccoin.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PANGEA",
@@ -1724,24 +2177,35 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PAX",
 		"name": "paxos",
 		"fname": "Paxos",
-		"etomic": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1"
+			}
+		}
 	},
 	{
 		"coin": "PAY",
 		"name": "tenx",
 		"fname": "TenX",
-		"etomic": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280"
+			}
+		}
 	},
 	{
 		"coin": "PEO",
@@ -1753,7 +2217,8 @@
 		"p2shtype": 33,
 		"wiftype": 115,
 		"txfee": 10000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PGN",
@@ -1763,7 +2228,8 @@
 		"pubtype": 55,
 		"p2shtype": 122,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PGT",
@@ -1774,7 +2240,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PIZZA",
@@ -1783,14 +2250,20 @@
 		"rpcport": 11116,
 		"txversion": 4,
 		"overwintered": 1,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PLU",
 		"name": "pluton",
 		"fname": "Pluton",
-		"etomic": "0xD8912C10681D8B21Fd3742244f44658dBA12264E",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E"
+			}
+		}
 	},
 	{
 		"coin": "POLIS",
@@ -1801,30 +2274,46 @@
 		"p2shtype": 56,
 		"wiftype": 60,
 		"txfee": 10000,
-		"confpath": "USERHOME/.poliscore/polis.conf"
+		"confpath": "USERHOME/.poliscore/polis.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "POLY",
 		"name": "polymath-network",
 		"fname": "Polymath",
-		"etomic": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC"
+			}
+		}
 	},
 	{
 		"coin": "POWR",
 		"name": "power-ledger",
 		"fname": "Power Ledger",
-		"etomic": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269"
+			}
+		}
 	},
 	{
 		"coin": "PPT",
 		"name": "populous",
 		"fname": "Populous",
-		"etomic": "0xd4fa1460F537bb9085d22C7bcCB5DD450Ef28e3a",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xd4fa1460F537bb9085d22C7bcCB5DD450Ef28e3a"
+			}
+		}
 	},
 	{
 		"coin": "PTX",
@@ -1834,42 +2323,68 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 5
+		"required_confirmations": 5,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "PXT",
 		"name": "populous-xbrl-token",
 		"fname": "Populous XBRL Token",
-		"etomic": "0xc14830E53aA344E8c14603A91229A0b925b0B262",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xc14830E53aA344E8c14603A91229A0b925b0B262"
+			}
+		}
 	},
 	{
 		"coin": "QASH",
 		"name": "qash",
 		"fname": "Qash",
-		"etomic": "0x618E75Ac90b12c6049Ba3b27f5d5F8651b0037F6",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x618E75Ac90b12c6049Ba3b27f5d5F8651b0037F6"
+			}
+		}
 	},
 	{
 		"coin": "QBIT",
 		"name": "qubitica",
 		"fname": "Qubitica",
-		"etomic": "0x1602af2C782cC03F9241992E243290Fccf73Bb13",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x1602af2C782cC03F9241992E243290Fccf73Bb13"
+			}
+		}
 	},
 	{
 		"coin": "QKC",
 		"name": "quarkchain",
 		"fname": "QuarkChain",
-		"etomic": "0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664"
+			}
+		}
 	},
 	{
 		"coin": "QSP",
 		"name": "quantstamp",
 		"fname": "Quantstamp",
-		"etomic": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d"
+			}
+		}
 	},
 	{
 		"coin": "QTUM",
@@ -1883,7 +2398,8 @@
 		"txfee": 0,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 2.133
+		"avg_blocktime": 2.133,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RADIUS",
@@ -1894,7 +2410,8 @@
 		"p2shtype": 16,
 		"wiftype": 15,
 		"txfee": 10000,
-		"confpath": "USERHOME/.radiuscore/radius.conf"
+		"confpath": "USERHOME/.radiuscore/radius.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RAP",
@@ -1905,37 +2422,58 @@
 		"p2shtype": 16,
 		"wiftype": 204,
 		"txfee": 10000,
-		"confpath": "USERHOME/.rapturecore/rapture.conf"
+		"confpath": "USERHOME/.rapturecore/rapture.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RCN",
 		"name": "ripio-credit-network",
 		"fname": "Ripio Credit Network",
-		"etomic": "0xF970b8E36e23F7fC3FD752EeA86f8Be8D83375A6",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xF970b8E36e23F7fC3FD752EeA86f8Be8D83375A6"
+			}
+		}
 	},
 	{
 		"coin": "RDN",
 		"name": "raiden-network-token",
 		"fname": "Raiden Network Token",
-		"etomic": "0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6"
+			}
+		}
 	},
 	{
 		"coin": "REP",
 		"name": "augur",
 		"fname": "Augur",
-		"etomic": "0x1985365e9f78359a9B6AD760e32412f4a445E862",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x1985365e9f78359a9B6AD760e32412f4a445E862"
+			}
+		}
 	},
 	{
 		"coin": "REQ",
 		"name": "request-network",
 		"fname": "Request Network",
-		"etomic": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a"
+			}
+		}
 	},
 	{
 		"coin": "REVS",
@@ -1947,7 +2485,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RFOX",
@@ -1959,7 +2498,8 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RICK",
@@ -1970,14 +2510,20 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 1,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RLC",
 		"name": "rlc",
 		"fname": "iExec RLC",
-		"etomic": "0x607F4C5BB672230e8672085532f7e901544a7375",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x607F4C5BB672230e8672085532f7e901544a7375"
+			}
+		}
 	},
 	{
 		"coin": "ROGER",
@@ -1987,7 +2533,8 @@
 		"pubtype": 61,
 		"p2shtype": 70,
 		"wiftype": 176,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ROI",
@@ -1997,14 +2544,20 @@
 		"pubtype": 60,
 		"p2shtype": 122,
 		"wiftype": 128,
-		"txfee": 200000
+		"txfee": 200000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RUFF",
 		"name": "ruff",
 		"fname": "Ruff",
-		"etomic": "0xf278c1CA969095ffddDED020290cf8B5C424AcE2",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xf278c1CA969095ffddDED020290cf8B5C424AcE2"
+			}
+		}
 	},
 	{
 		"coin": "RVN",
@@ -2017,37 +2570,58 @@
 		"txfee": 0,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "RVT",
 		"name": "rivetz",
 		"fname": "Rivetz",
-		"etomic": "0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244"
+			}
+		}
 	},
 	{
 		"coin": "SAI",
 		"name": "single-collateral-dai",
 		"fname": "Single Collateral DAI",
-		"etomic": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359"
+			}
+		}
 	},
 	{
 		"coin": "SALT",
 		"name": "salt",
 		"fname": "Salt",
-		"etomic": "0x4156D3342D5c385a87D264F90653733592000581",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x4156D3342D5c385a87D264F90653733592000581"
+			}
+		}
 	},
 	{
 		"coin": "SAN",
 		"name": "santiment",
 		"fname": "Santiment",
-		"etomic": "0x7C5A0CE9267ED19B22F8cae653F198e3E8daf098",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x7C5A0CE9267ED19B22F8cae653F198e3E8daf098"
+			}
+		}
 	},
 	{
 		"coin": "SBTC",
@@ -2058,7 +2632,8 @@
 		"p2shtype": 5,
 		"wiftype": 128,
 		"txfee": 10000,
-		"confpath": "USERHOME/.sbtc/sbtc.conf"
+		"confpath": "USERHOME/.sbtc/sbtc.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SCRIV",
@@ -2069,7 +2644,8 @@
 		"pubtype": 125,
 		"p2shtype": 16,
 		"wiftype": 204,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SIB",
@@ -2079,7 +2655,8 @@
 		"pubtype": 63,
 		"p2shtype": 40,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SIRX",
@@ -2090,7 +2667,8 @@
 		"p2shtype": 50,
 		"wiftype": 128,
 		"txfee": 200000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SMART",
@@ -2100,7 +2678,8 @@
 		"pubtype": 63,
 		"p2shtype": 18,
 		"wiftype": 191,
-		"txfee": 200000
+		"txfee": 200000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SMC",
@@ -2110,37 +2689,58 @@
 		"pubtype": 63,
 		"p2shtype": 5,
 		"wiftype": 191,
-		"txfee": 1000000
+		"txfee": 1000000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SNGLS",
 		"name": "singulardtv",
 		"fname": "SingularDTV",
-		"etomic": "0xaeC2E87E0A235266D9C5ADc9DEb4b2E29b54D009",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xaeC2E87E0A235266D9C5ADc9DEb4b2E29b54D009"
+			}
+		}
 	},
 	{
 		"coin": "SNT",
 		"name": "status",
 		"fname": "Status",
-		"etomic": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E"
+			}
+		}
 	},
 	{
 		"coin": "SOLVE",
 		"name": "care-solve",
 		"fname": "Solve Token",
-		"etomic": "0x446C9033E7516D820cc9a2ce2d0B7328b579406F",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x446C9033E7516D820cc9a2ce2d0B7328b579406F"
+			}
+		}
 	},
 	{
 		"coin": "SPANK",
 		"name": "spankchain",
 		"fname": "SpankChain",
-		"etomic": "0x42d6622deCe394b54999Fbd73D108123806f6a18",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x42d6622deCe394b54999Fbd73D108123806f6a18"
+			}
+		}
 	},
 	{
 		"coin": "SPK",
@@ -2151,14 +2751,20 @@
 		"p2shtype": 10,
 		"wiftype": 198,
 		"txfee": 10000,
-		"confpath": "USERHOME/.sparkscore/sparks.conf"
+		"confpath": "USERHOME/.sparkscore/sparks.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SRN",
 		"name": "sirin-labs-token",
 		"fname": "SIRIN LABS Token",
-		"etomic": "0x68d57c9a1C35f63E2c83eE8e49A64e9d70528D25",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x68d57c9a1C35f63E2c83eE8e49A64e9d70528D25"
+			}
+		}
 	},
 	{
 		"coin": "STAK",
@@ -2168,21 +2774,32 @@
 		"pubtype": 63,
 		"p2shtype": 5,
 		"wiftype": 204,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "STORJ",
 		"name": "storj",
 		"fname": "Storj",
-		"etomic": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC"
+			}
+		}
 	},
 	{
 		"coin": "SUB",
 		"name": "substratum",
 		"fname": "Substratum",
-		"etomic": "0x8D75959f1E61EC2571aa72798237101F084DE63a",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x8D75959f1E61EC2571aa72798237101F084DE63a"
+			}
+		}
 	},
 	{
 		"coin": "SUDO",
@@ -2193,7 +2810,8 @@
 		"p2shtype": 13,
 		"wiftype": 39,
 		"txfee": 10000,
-		"confpath": "USERHOME/.sudocore/sudo.conf"
+		"confpath": "USERHOME/.sudocore/sudo.conf",
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SUPERNET",
@@ -2205,22 +2823,33 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SVD",
 		"name": "savedroid",
 		"fname": "Savedroid",
-		"etomic": "0xbdEB4b83251Fb146687fa19D1C660F99411eefe3",
+		"rpcport": 80,
 		"decimals": 18,
-		"rpcport": 80
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xbdEB4b83251Fb146687fa19D1C660F99411eefe3"
+			}
+		}
 	},
 	{
 		"coin": "SWT",
 		"name": "swarm-city",
 		"fname": "Swarm City",
-		"etomic": "0xB9e7F8568e08d5659f5D29C4997173d84CdF2607",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xB9e7F8568e08d5659f5D29C4997173d84CdF2607"
+			}
+		}
 	},
 	{
 		"coin": "SXC",
@@ -2230,7 +2859,8 @@
 		"pubtype": 62,
 		"p2shtype": 5,
 		"wiftype": 190,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "SYS",
@@ -2241,28 +2871,35 @@
 		"p2shtype": 5,
 		"wiftype": 128,
 		"txfee": 10000,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "TAAS",
 		"name": "taas",
 		"fname": "TaaS",
-		"etomic": "0xE7775A6e9Bcf904eb39DA2b68c5efb4F9360e08C",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xE7775A6e9Bcf904eb39DA2b68c5efb4F9360e08C"
+			}
+		}
 	},
 	{
-	      	"coin": "tBTC",
-	      	"name": "tbitcoin",
-	      	"fname": "tBitcoin",
-	      	"rpcport": 18332,
-	      	"pubtype": 111,
-	      	"p2shtype": 196,
-	      	"wiftype": 239,
-	      	"segwit": true,
-	      	"txfee": 0,
-	      	"estimate_fee_mode": "ECONOMICAL",
-	      	"mm2": 1,
-	      	"required_confirmations": 0
+		"coin": "tBTC",
+		"name": "tbitcoin",
+		"fname": "tBitcoin",
+		"rpcport": 18332,
+		"pubtype": 111,
+		"p2shtype": 196,
+		"wiftype": 239,
+		"segwit": true,
+		"txfee": 0,
+		"estimate_fee_mode": "ECONOMICAL",
+		"mm2": 1,
+		"required_confirmations": 0,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "THC",
@@ -2273,28 +2910,44 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "TIME",
 		"name": "chronobank",
 		"fname": "Chronobank",
-		"etomic": "0x6531f133e6DeeBe7F2dcE5A0441aA7ef330B4e53",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x6531f133e6DeeBe7F2dcE5A0441aA7ef330B4e53"
+			}
+		}
 	},
 	{
 		"coin": "TKN",
 		"name": "tokencard",
 		"fname": "TokenCard",
-		"etomic": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a"
+			}
+		}
 	},
 	{
 		"coin": "TRAT",
 		"name": "tratok",
 		"fname": "Tratok",
-		"etomic": "0x0cbC9b02B8628AE08688b5cC8134dc09e36C443b",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x0cbC9b02B8628AE08688b5cC8134dc09e36C443b"
+			}
+		}
 	},
 	{
 		"coin": "TRC",
@@ -2305,38 +2958,59 @@
 		"pubtype": 0,
 		"p2shtype": 5,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "TRET",
 		"name": "touristreview",
 		"fname": "Tourist Review",
-		"etomic": "0xC6D603A9Df53D1542552058c382bf115AACE70C7",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xC6D603A9Df53D1542552058c382bf115AACE70C7"
+			}
+		}
 	},
 	{
 		"coin": "TRST",
 		"name": "trust",
 		"fname": "Trust",
-		"etomic": "0xCb94be6f13A1182E4A4B6140cb7bf2025d28e41B",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xCb94be6f13A1182E4A4B6140cb7bf2025d28e41B"
+			}
+		}
 	},
 	{
 		"coin": "TUSD",
 		"name": "tusd",
 		"fname": "TrueUSD",
-		"etomic": "0x0000000000085d4780B73119b644AE5ecd22b376",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x0000000000085d4780B73119b644AE5ecd22b376"
+			}
+		}
 	},
 	{
 		"coin": "UCASH",
 		"name": "ucash",
 		"fname": "U.CASH",
-		"etomic": "0x92e52a1A235d9A103D970901066CE910AAceFD37",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x92e52a1A235d9A103D970901066CE910AAceFD37"
+			}
+		}
 	},
 	{
 		"coin": "UFO",
@@ -2347,7 +3021,8 @@
 		"pubtype": 27,
 		"p2shtype": 5,
 		"wiftype": 155,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "UIS",
@@ -2357,27 +3032,38 @@
 		"pubtype": 68,
 		"p2shtype": 10,
 		"wiftype": 132,
-		"txfee": 2000000
+		"txfee": 2000000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "USDC",
 		"name": "usdc",
 		"fname": "USD Coin",
-		"etomic": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+			}
+		}
 	},
 	{
 		"coin": "VRA",
 		"name": "verasity",
 		"fname": "Verasity",
-		"etomic": "0xdF1D6405df92d981a2fB3ce68F6A03baC6C0E41F",
+		"avg_blocktime": 0.25,
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 0.25
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xdF1D6405df92d981a2fB3ce68F6A03baC6C0E41F"
+			}
+		}
 	},
 	{
 		"coin": "VIA",
@@ -2389,7 +3075,8 @@
 		"wiftype": 199,
 		"txfee": 100000,
 		"segwit": true,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "VIVO",
@@ -2400,7 +3087,8 @@
 		"pubtype": 70,
 		"p2shtype": 10,
 		"wiftype": 198,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "VOT",
@@ -2412,9 +3100,10 @@
 		"p2shtype": 189,
 		"wiftype": 128,
 		"txversion": 4,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
-  	{
+	{
 		"coin": "VOTE2020",
 		"asset": "VOTE2020",
 		"rpcport": 44249,
@@ -2422,8 +3111,9 @@
 		"txfee": 10000,
 		"txversion": 4,
 		"overwintered": 1,
-    		"required_confirmations": 2,
-		"requires_notarization": true
+		"required_confirmations": 2,
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "VRSC",
@@ -2434,15 +3124,21 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"avg_blocktime": 1
+		"avg_blocktime": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "VSL",
 		"name": "vslice",
 		"fname": "vSlice",
-		"etomic": "0x5c543e7AE0A1104f78406C340E9C64FD9fCE5170",
+		"rpcport": 80,
 		"decimals": 18,
-		"rpcport": 80
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x5c543e7AE0A1104f78406C340E9C64FD9fCE5170"
+			}
+		}
 	},
 	{
 		"coin": "VTC",
@@ -2455,14 +3151,20 @@
 		"txfee": 0,
 		"segwit": true,
 		"mm2": 1,
-		"required_confirmations": 4
+		"required_confirmations": 4,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "WINGS",
 		"name": "wings",
 		"fname": "Wings",
-		"etomic": "0x667088b212ce3d06a1b553a7221E1fD19000d9aF",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x667088b212ce3d06a1b553a7221E1fD19000d9aF"
+			}
+		}
 	},
 	{
 		"coin": "WLC",
@@ -2473,14 +3175,20 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "WTC",
 		"name": "waltonchain",
 		"fname": "Waltonchain",
-		"etomic": "0xb7cB1C96dB6B22b0D3d9536E0108d062BD488F74",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xb7cB1C96dB6B22b0D3d9536E0108d062BD488F74"
+			}
+		}
 	},
 	{
 		"coin": "X0Z",
@@ -2490,14 +3198,20 @@
 		"pubtype": 28,
 		"p2shtype": 5,
 		"wiftype": 156,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "XAUR",
 		"name": "xaurum",
 		"fname": "Xarum",
-		"etomic": "0x4DF812F6064def1e5e029f1ca858777CC98D2D81",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x4DF812F6064def1e5e029f1ca858777CC98D2D81"
+			}
+		}
 	},
 	{
 		"coin": "XBC",
@@ -2508,7 +3222,8 @@
 		"pubtype": 25,
 		"p2shtype": 85,
 		"wiftype": 153,
-		"txfee": 100000
+		"txfee": 100000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "XMY",
@@ -2518,14 +3233,20 @@
 		"pubtype": 50,
 		"p2shtype": 9,
 		"wiftype": 178,
-		"txfee": 5000
+		"txfee": 5000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "XOV",
 		"name": "xovbank",
 		"fname": "XOVBank",
-		"etomic": "0x153eD9CC1b792979d2Bde0BBF45CC2A7e436a5F9",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x153eD9CC1b792979d2Bde0BBF45CC2A7e436a5F9"
+			}
+		}
 	},
 	{
 		"coin": "XSG",
@@ -2537,7 +3258,8 @@
 		"p2shtype": 45,
 		"wiftype": 128,
 		"txversion": 4,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "XSN",
@@ -2549,7 +3271,8 @@
 		"wiftype": 204,
 		"txfee": 10000,
 		"confpath": "USERHOME/.xsncore/xsn.conf",
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "XZC",
@@ -2562,7 +3285,8 @@
 		"txfee": 0,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 5.65
+		"avg_blocktime": 5.65,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "YCE",
@@ -2574,14 +3298,20 @@
 		"wiftype": 153,
 		"txfee": 10000,
 		"txversion": 3,
-		"mm2": 1
+		"mm2": 1,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "YLC",
 		"name": "yolocash",
 		"fname": "YoloCash",
-		"etomic": "0x21d5678A62DFe63a47062469Ebb2fAc2817D8832",
-		"rpcport": 80
+		"rpcport": 80,
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0x21d5678A62DFe63a47062469Ebb2fAc2817D8832"
+			}
+		}
 	},
 	{
 		"coin": "ZCL",
@@ -2592,7 +3322,8 @@
 		"pubtype": 184,
 		"p2shtype": 189,
 		"wiftype": 128,
-		"txfee": 1000
+		"txfee": 1000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZEC",
@@ -2610,7 +3341,8 @@
 		"txfee": 10000,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"avg_blocktime": 1.25
+		"avg_blocktime": 1.25,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZEL",
@@ -2621,7 +3353,8 @@
 		"pubtype": 184,
 		"p2shtype": 189,
 		"wiftype": 128,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZER",
@@ -2639,7 +3372,8 @@
 		"txfee": 1000,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"avg_blocktime": 2
+		"avg_blocktime": 2,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZET",
@@ -2649,7 +3383,8 @@
 		"p2shtype": 9,
 		"rpcport": 8332,
 		"wiftype": 224,
-		"txfee": 10000
+		"txfee": 10000,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZEXO",
@@ -2660,7 +3395,8 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZILLA",
@@ -2669,15 +3405,21 @@
 		"rpcport": 10041,
 		"mm2": 1,
 		"required_confirmations": 2,
-		"requires_notarization": true
+		"requires_notarization": true,
+		"protocol": "UTXO"
 	},
 	{
 		"coin": "ZRX",
 		"name": "0x",
 		"fname": "0x",
-		"etomic": "0xE41d2489571d322189246DaFA5ebDe1F4699F498",
+		"required_confirmations": 3,
 		"rpcport": 80,
 		"mm2": 1,
-		"required_confirmations": 3
+		"protocol": {
+			"ERC20": {
+				"platform": "ETH",
+				"contract_address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
+			}
+		}
 	}
 ]

--- a/coins
+++ b/coins
@@ -5,7 +5,8 @@
 		"fname": "FirstBlood",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xAf30D2a7E90d7DC361c8C4585e9BB7D2F6f15bc7"
 			}
@@ -20,7 +21,9 @@
 		"p2shtype": 5,
 		"wiftype": 151,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ADT",
@@ -28,7 +31,8 @@
 		"fname": "adToken",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xD0D6D6C5Fe4a677D343cC433536BB717bAe167dD"
 			}
@@ -40,7 +44,8 @@
 		"fname": "Ambrosus",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x4DC3643DbC642b72C158E7F3d2ff232df61cb6CE"
 			}
@@ -52,7 +57,8 @@
 		"fname": "Aragon",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x960b236A07cf122663c4303350609A66A7B288C0"
 			}
@@ -68,7 +74,9 @@
 		"p2shtype": 8,
 		"wiftype": 176,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ARPA",
@@ -78,7 +86,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xBA50933C268F567BDC86E1aC131BE072C6B0b71a"
 			}
@@ -90,7 +99,8 @@
 		"fname": "AirSwap",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x27054b13b1B798B345b591a4d22e6562d47eA75a"
 			}
@@ -106,7 +116,9 @@
 		"wiftype": 128,
 		"txfee": 10000,
 		"confpath": "USERHOME/.ATBCoinWallet/atbcoin.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "AWC",
@@ -117,7 +129,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xaD22f63404f7305e4713CcBd4F296f34770513f4"
 			}
@@ -136,7 +149,9 @@
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 2.6,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "AXO",
@@ -148,7 +163,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "AYA",
@@ -162,7 +179,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BAT",
@@ -173,7 +192,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF"
 			}
@@ -189,7 +209,9 @@
 		"p2shtype": 85,
 		"wiftype": 153,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BBT",
@@ -197,7 +219,8 @@
 		"fname": "Bitboost",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x1500205f50bf3FD976466d0662905c9ff254fc9c"
 			}
@@ -220,7 +243,9 @@
 		"mm2": 1,
 		"required_confirmations": 1,
 		"avg_blocktime": 10,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BEER",
@@ -230,7 +255,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BET",
@@ -243,7 +270,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BFT",
@@ -251,7 +280,8 @@
 		"fname": "BnkToTheFuture",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x01fF50f8b7f74E4f00580d9596cd3D0d6d6E326f"
 			}
@@ -267,7 +297,9 @@
 		"p2shtype": 8,
 		"wiftype": 153,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BLK",
@@ -280,7 +312,9 @@
 		"wiftype": 153,
 		"txfee": 100000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BLOCK",
@@ -291,7 +325,9 @@
 		"p2shtype": 28,
 		"wiftype": 154,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BLZ",
@@ -299,7 +335,8 @@
 		"fname": "Bluzelle",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x5732046A883704404F284Ce41FfADd5b007FD668"
 			}
@@ -311,7 +348,8 @@
 		"fname": "Bancor",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x1F573D6Fb3F13d689FF844B4cE37794d79a7FF1C"
 			}
@@ -328,7 +366,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BSD",
@@ -339,7 +379,9 @@
 		"p2shtype": 5,
 		"wiftype": 204,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTA",
@@ -350,7 +392,9 @@
 		"p2shtype": 5,
 		"wiftype": 188,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTC",
@@ -366,7 +410,9 @@
 		"mm2": 1,
 		"required_confirmations": 1,
 		"avg_blocktime": 10,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTCH",
@@ -378,7 +424,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTCL",
@@ -386,7 +434,8 @@
 		"fname": "BTC Lite",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x5acD19b9c91e596b1f062f18e3D02da7eD8D1e50"
 			}
@@ -402,7 +451,9 @@
 		"p2shtype": 175,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTCZ",
@@ -414,7 +465,9 @@
 		"p2shtype": 189,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTG",
@@ -425,7 +478,9 @@
 		"p2shtype": 23,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BTO",
@@ -433,7 +488,8 @@
 		"fname": "Bottos",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x36905Fc93280f52362A1CBAB151F25DC46742Fb5"
 			}
@@ -449,7 +505,9 @@
 		"wiftype": 128,
 		"txfee": 50000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BUCK",
@@ -461,7 +519,9 @@
 		"p2shtype": 189,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "BUSD",
@@ -472,7 +532,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x4Fabb145d64652a948d72533023f6E7A623C7C53"
 			}
@@ -489,7 +550,9 @@
 		"wiftype": 128,
 		"txversion": 4,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CCL",
@@ -502,7 +565,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CDT",
@@ -510,7 +575,8 @@
 		"fname": "Blox",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x177d39AC676ED1C67A2b268AD7F1E58826E5B0af"
 			}
@@ -524,7 +590,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CENNZ",
@@ -532,7 +600,8 @@
 		"fname": "Centrality",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x1122B6a0E00DCe0563082b6e2953f3A943855c1F"
 			}
@@ -547,7 +616,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CHIPS",
@@ -563,7 +634,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 0.166,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CMM",
@@ -574,7 +647,9 @@
 		"p2shtype": 50,
 		"wiftype": 140,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "COLX",
@@ -586,7 +661,9 @@
 		"wiftype": 212,
 		"txfee": 1000000000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "COMMOD",
@@ -597,7 +674,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "COQUI",
@@ -609,7 +688,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CRO",
@@ -619,7 +700,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xA0b73E1Ff0B80914AB6fe0444E65848C4C34450b"
 			}
@@ -634,7 +716,9 @@
 		"p2shtype": 28,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CRYPTO",
@@ -647,7 +731,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "CS",
@@ -655,7 +741,8 @@
 		"fname": "Credits",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x46b9Ad944d1059450Da1163511069C718F699D31"
 			}
@@ -667,7 +754,8 @@
 		"fname": "Civic",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x41e5560054824eA6B0732E656E3Ad64E20e94E45"
 			}
@@ -683,7 +771,9 @@
 		"p2shtype": 90,
 		"wiftype": 158,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DAI",
@@ -694,7 +784,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x6B175474E89094C44Da98b954EedeAC495271d0F"
 			}
@@ -713,7 +804,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"avg_blocktime": 2.633,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DATA",
@@ -721,7 +814,8 @@
 		"fname": "Streamr DATAcoin",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x0Cf0Ee63788A0849fE5297F3407f701E122cC023"
 			}
@@ -733,7 +827,8 @@
 		"fname": "Dentacoin",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x08d32b0da63e2C3bcF8019c9c5d849d7a9d791e6"
 			}
@@ -747,7 +842,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x9F5F3CFD7a32700C93F971637407ff17b91c7342"
 			}
@@ -760,7 +856,8 @@
 		"mm2": 1,
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x3aB100442484Dc2414Aa75B2952A0a6f03f8aBFd"
 			}
@@ -774,7 +871,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x3597bfD533a99c9aa083587B074434E61Eb0A258"
 			}
@@ -791,7 +889,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DGB",
@@ -806,7 +906,9 @@
 		"mm2": 1,
 		"required_confirmations": 7,
 		"avg_blocktime": 1.25,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DGD",
@@ -815,7 +917,8 @@
 		"rpcport": 80,
 		"decimals": 9,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xE0B7927c4aF23765Cb51314A0E0521A9645F0E2A"
 			}
@@ -827,7 +930,8 @@
 		"fname": "Etheroll",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x2e071D2966Aa7D8dECB1005885bA1977D6038A65"
 			}
@@ -843,7 +947,9 @@
 		"wiftype": 204,
 		"txfee": 10000,
 		"confpath": "USERHOME/.dinerocore/dinero.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DION",
@@ -853,7 +959,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DNT",
@@ -861,7 +969,8 @@
 		"fname": "District0x",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x0AbdAce70D3790235af448C88547603b945604ea"
 			}
@@ -880,7 +989,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DOPE",
@@ -892,7 +1003,9 @@
 		"p2shtype": 5,
 		"wiftype": 158,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DP",
@@ -903,7 +1016,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DRGN",
@@ -911,7 +1026,8 @@
 		"fname": "Dragonchain",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x419c4dB4B9e25d6Db2AD9691ccb832C8D9fDA05E"
 			}
@@ -923,7 +1039,8 @@
 		"fname": "Dropil",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x4672bAD527107471cB5067a887f4656D585a8A31"
 			}
@@ -935,7 +1052,8 @@
 		"fname": "DomRaider",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x9AF4f26941677C706cfEcf6D3379FF01bB85D5Ab"
 			}
@@ -949,7 +1067,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DSR",
@@ -961,7 +1081,9 @@
 		"p2shtype": 16,
 		"wiftype": 204,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "DYN",
@@ -972,7 +1094,9 @@
 		"p2shtype": 10,
 		"wiftype": 140,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ECA",
@@ -988,7 +1112,9 @@
 		"confpath": "USERHOME/.electra/Electra.conf",
 		"required_confirmations": 5,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "EDG",
@@ -996,7 +1122,8 @@
 		"fname": "Edgeless",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x08711D3B02C8758F2FB3ab4e80228418a7F8e39c"
 			}
@@ -1012,7 +1139,9 @@
 		"p2shtype": 5,
 		"wiftype": 176,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ELF",
@@ -1020,7 +1149,8 @@
 		"fname": "aelf",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xbf2179859fc6D5BEE9Bf9158632Dc51678a4100e"
 			}
@@ -1035,7 +1165,9 @@
 		"p2shtype": 102,
 		"wiftype": 205,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ELY",
@@ -1043,7 +1175,8 @@
 		"fname": "Elysian",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xa95592DCFfA3C080B4B40E459c5f5692F67DB7F8"
 			}
@@ -1062,7 +1195,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1.1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ENG",
@@ -1070,7 +1205,8 @@
 		"fname": "Enigma",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xf0Ee6b27b759C9893Ce4f094b49ad28fd15A23e4"
 			}
@@ -1084,7 +1220,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xF629cBd94d3791C9250152BD8dfBDF380E2a3B9c"
 			}
@@ -1099,7 +1236,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ETH",
@@ -1109,7 +1248,9 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"required_confirmations": 3,
-		"protocol": "ETH"
+		"protocol": {
+			"type": "ETH"
+		}
 	},
 	{
 		"coin": "ETHOS",
@@ -1117,7 +1258,8 @@
 		"fname": "Ethos",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x5Af2Be193a6ABCa9c8817001F45744777Db30756"
 			}
@@ -1129,7 +1271,8 @@
 		"fname": "EnergiToken",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x3c4a3ffd813a107febd57B2f01BC344264D90FdE"
 			}
@@ -1143,7 +1286,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "FJC",
@@ -1154,7 +1299,9 @@
 		"p2shtype": 16,
 		"wiftype": 164,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "FLASH",
@@ -1167,7 +1314,9 @@
 		"txfee": 10000000,
 		"decimals": 10,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "FLO",
@@ -1179,7 +1328,9 @@
 		"wiftype": 176,
 		"txfee": 100000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "FTC",
@@ -1194,7 +1345,9 @@
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 1.033,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "FUN",
@@ -1202,7 +1355,8 @@
 		"fname": "FunFair",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x419D0d8BdD9aF5e606Ae2232ed285Aff190E711b"
 			}
@@ -1218,7 +1372,9 @@
 		"p2shtype": 10,
 		"wiftype": 198,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GIN",
@@ -1231,7 +1387,9 @@
 		"txfee": 10000,
 		"confpath": "USERHOME/.gincoincore/gincoin.conf",
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GLD",
@@ -1242,7 +1400,9 @@
 		"p2shtype": 5,
 		"wiftype": 160,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GLEEC",
@@ -1257,7 +1417,9 @@
 		"mm2": 1,
 		"required_confirmations": 1,
 		"avg_blocktime": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GLT",
@@ -1268,7 +1430,9 @@
 		"p2shtype": 5,
 		"wiftype": 166,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GLXT",
@@ -1279,7 +1443,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GNO",
@@ -1287,7 +1453,8 @@
 		"fname": "Gnosis",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x6810e776880C02933D47DB1b9fc05908e5386b96"
 			}
@@ -1302,7 +1469,9 @@
 		"p2shtype": 5,
 		"wiftype": 176,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GRS",
@@ -1313,7 +1482,9 @@
 		"p2shtype": 5,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "GTC",
@@ -1321,7 +1492,8 @@
 		"fname": "Game.com",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xB70835D7822eBB9426B56543E391846C107bd32C"
 			}
@@ -1333,7 +1505,8 @@
 		"fname": "Gifto",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xC5bBaE50781Be1669306b9e001EFF57a2957b09d"
 			}
@@ -1345,7 +1518,8 @@
 		"fname": "Matchpool",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xf7B098298f7C69Fc14610bf71d5e02c60792894C"
 			}
@@ -1360,7 +1534,9 @@
 		"p2shtype": 10,
 		"wiftype": 210,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "HGT",
@@ -1368,7 +1544,8 @@
 		"fname": "HelloGold",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xba2184520A1cC49a6159c57e61E1844E085615B6"
 			}
@@ -1380,7 +1557,8 @@
 		"fname": "Humaniq",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xcbCC0F036ED4788F63FC0fEE32873d6A7487b908"
 			}
@@ -1396,7 +1574,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "HODLC",
@@ -1407,7 +1587,9 @@
 		"p2shtype": 5,
 		"wiftype": 168,
 		"txfee": 5000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "HOT",
@@ -1417,7 +1599,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x6c6EE5e31d828De241282B9606C8e98Ea48526E2"
 			}
@@ -1431,7 +1614,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x6f259637dcD74C767781E37Bc6133cd6A68aa161"
 			}
@@ -1446,7 +1630,9 @@
 		"p2shtype": 100,
 		"wiftype": 169,
 		"txfee": 400000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "HUSH",
@@ -1459,7 +1645,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 2.5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "I0C",
@@ -1470,7 +1658,9 @@
 		"p2shtype": 5,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ILN",
@@ -1486,7 +1676,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "IMG",
@@ -1497,7 +1689,9 @@
 		"p2shtype": 5,
 		"wiftype": 204,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "IND",
@@ -1505,7 +1699,8 @@
 		"fname": "Indorse Token",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xf8e386EDa857484f5a12e4B5DAa9984E06E73705"
 			}
@@ -1521,7 +1716,9 @@
 		"p2shtype": 20,
 		"wiftype": 195,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "IOP",
@@ -1532,7 +1729,9 @@
 		"p2shtype": 174,
 		"wiftype": 49,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ITL",
@@ -1540,7 +1739,8 @@
 		"fname": "Italian Lira",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x122A86b5DFF2D085AfB49600b4cd7375D0d94A5f"
 			}
@@ -1553,7 +1753,8 @@
 		"mm2": 1,
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x996a8ae0304680f6a69b8a9d7c6e37d65ab5ab56"
 			}
@@ -1570,7 +1771,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "K64",
@@ -1582,7 +1785,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "KMD",
@@ -1599,7 +1804,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "KMDICE",
@@ -1610,7 +1817,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "KNC",
@@ -1618,7 +1827,8 @@
 		"fname": "Kyber Network",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xdd974D5C2e2928deA5F71b9825b8b646686BD200"
 			}
@@ -1634,7 +1844,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "KV",
@@ -1646,7 +1858,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "LABS",
@@ -1658,7 +1872,9 @@
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "LBC",
@@ -1670,7 +1886,9 @@
 		"wiftype": 28,
 		"txfee": 10000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "LINK",
@@ -1680,7 +1898,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x514910771AF9Ca656af840dff83E8264EcF986CA"
 			}
@@ -1692,7 +1911,8 @@
 		"fname": "Loom Network",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xA4e8C3Ec456107eA67d3075bF9e3DF3A75823DB0"
 			}
@@ -1707,7 +1927,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD"
 			}
@@ -1726,7 +1947,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"avg_blocktime": 2.5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "LTZ",
@@ -1739,7 +1962,9 @@
 		"wiftype": 128,
 		"txversion": 4,
 		"txfee": 1000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "LUMBER",
@@ -1749,7 +1974,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "LUN",
@@ -1757,7 +1984,8 @@
 		"fname": "Lunyr",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xfa05A73FfE78ef8f1a739473e462c54bae6567D9"
 			}
@@ -1774,7 +2002,9 @@
 		"wiftype": 155,
 		"txfee": 10000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MANA",
@@ -1784,7 +2014,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x0F5D2fB29fb7d3CFeE444a200298f468908cC942"
 			}
@@ -1801,7 +2032,9 @@
 		"required_confirmations": 5,
 		"avg_blocktime": 1,
 		"requires_notarization": false,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MCO",
@@ -1809,7 +2042,8 @@
 		"fname": "Monaco",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xB63B606Ac810a52cCa15e44bB630fd42D8d1d83d"
 			}
@@ -1821,7 +2055,8 @@
 		"fname": "MediShares",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x66186008C1050627F979d464eABb258860563dbE"
 			}
@@ -1837,7 +2072,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MGNX",
@@ -1847,7 +2084,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MGO",
@@ -1855,7 +2094,8 @@
 		"fname": "MobileGo",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x40395044Ac3c0C57051906dA938B54BD6557F212"
 			}
@@ -1872,7 +2112,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MKR",
@@ -1882,7 +2124,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2"
 			}
@@ -1897,7 +2140,9 @@
 		"p2shtype": 115,
 		"wiftype": 238,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MLN",
@@ -1905,7 +2150,8 @@
 		"fname": "Melon",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xec67005c4E498Ec7f55E092bd1d35cbC47C91892"
 			}
@@ -1920,7 +2166,9 @@
 		"p2shtype": 5,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MONA",
@@ -1932,7 +2180,9 @@
 		"wiftype": 176,
 		"txfee": 100000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MOON",
@@ -1943,7 +2193,9 @@
 		"p2shtype": 22,
 		"wiftype": 131,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MORTY",
@@ -1955,7 +2207,9 @@
 		"mm2": 1,
 		"required_confirmations": 1,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MOVI",
@@ -1965,7 +2219,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x06F979E4F04ec565Ae8d7479a94C60dEF8846832"
 			}
@@ -1977,7 +2232,8 @@
 		"fname": "Morpheus Network",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x7B0C06043468469967DBA22d1AF33d77d44056c8"
 			}
@@ -1993,7 +2249,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MTL",
@@ -2001,7 +2259,8 @@
 		"fname": "Metal",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xF433089366899D83a9f26A773D59ec7eCF30355e"
 			}
@@ -2016,7 +2275,9 @@
 		"p2shtype": 76,
 		"wiftype": 126,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "MYB",
@@ -2024,7 +2285,8 @@
 		"fname": "MyBit Token",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x5d60d8d7eF6d37E16EBABc324de3bE57f135e0BC"
 			}
@@ -2045,7 +2307,9 @@
 		"mm2": 1,
 		"required_confirmations": 10,
 		"avg_blocktime": 0.5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "NIX",
@@ -2057,7 +2321,9 @@
 		"wiftype": 128,
 		"txfee": 10000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "NMC",
@@ -2070,7 +2336,9 @@
 		"txfee": 100000,
 		"segwit": true,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "NMR",
@@ -2078,7 +2346,8 @@
 		"fname": "Numeraire",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x1776e1F26f98b1A5dF9cD347953a26dd3Cb46671"
 			}
@@ -2090,7 +2359,8 @@
 		"fname": "Noah Coin",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x58a4884182d9E835597f405e5F258290E46ae7C2"
 			}
@@ -2105,7 +2375,9 @@
 		"p2shtype": 7,
 		"wiftype": 208,
 		"txfee": 1000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "NPXS",
@@ -2115,7 +2387,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xA15C7Ebe1f07CaF6bFF097D8a589fb8AC49Ae5B3"
 			}
@@ -2130,7 +2403,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ORE",
@@ -2141,7 +2416,9 @@
 		"p2shtype": 16,
 		"wiftype": 204,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "OURC",
@@ -2153,7 +2430,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PAC",
@@ -2165,7 +2444,9 @@
 		"wiftype": 204,
 		"txfee": 10000,
 		"confpath": "USERHOME/.paccoincore/paccoin.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PANGEA",
@@ -2178,7 +2459,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PAX",
@@ -2189,7 +2472,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x8E870D67F660D95d5be530380D0eC0bd388289E1"
 			}
@@ -2201,7 +2485,8 @@
 		"fname": "TenX",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xB97048628DB6B661D4C2aA833e95Dbe1A905B280"
 			}
@@ -2218,7 +2503,9 @@
 		"wiftype": 115,
 		"txfee": 10000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PGN",
@@ -2229,7 +2516,9 @@
 		"p2shtype": 122,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PGT",
@@ -2241,7 +2530,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PIZZA",
@@ -2251,7 +2542,9 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PLU",
@@ -2259,7 +2552,8 @@
 		"fname": "Pluton",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xD8912C10681D8B21Fd3742244f44658dBA12264E"
 			}
@@ -2275,7 +2569,9 @@
 		"wiftype": 60,
 		"txfee": 10000,
 		"confpath": "USERHOME/.poliscore/polis.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "POLY",
@@ -2283,7 +2579,8 @@
 		"fname": "Polymath",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x9992eC3cF6A55b00978cdDF2b27BC6882d88D1eC"
 			}
@@ -2297,7 +2594,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x595832F8FC6BF59c85C527fEC3740A1b7a361269"
 			}
@@ -2309,7 +2607,8 @@
 		"fname": "Populous",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xd4fa1460F537bb9085d22C7bcCB5DD450Ef28e3a"
 			}
@@ -2324,7 +2623,9 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 5,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "PXT",
@@ -2332,7 +2633,8 @@
 		"fname": "Populous XBRL Token",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xc14830E53aA344E8c14603A91229A0b925b0B262"
 			}
@@ -2344,7 +2646,8 @@
 		"fname": "Qash",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x618E75Ac90b12c6049Ba3b27f5d5F8651b0037F6"
 			}
@@ -2356,7 +2659,8 @@
 		"fname": "Qubitica",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x1602af2C782cC03F9241992E243290Fccf73Bb13"
 			}
@@ -2368,7 +2672,8 @@
 		"fname": "QuarkChain",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xEA26c4aC16D4a5A106820BC8AEE85fd0b7b2b664"
 			}
@@ -2380,7 +2685,8 @@
 		"fname": "Quantstamp",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x99ea4dB9EE77ACD40B119BD1dC4E33e1C070b80d"
 			}
@@ -2399,7 +2705,9 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"avg_blocktime": 2.133,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RADIUS",
@@ -2411,7 +2719,9 @@
 		"wiftype": 15,
 		"txfee": 10000,
 		"confpath": "USERHOME/.radiuscore/radius.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RAP",
@@ -2423,7 +2733,9 @@
 		"wiftype": 204,
 		"txfee": 10000,
 		"confpath": "USERHOME/.rapturecore/rapture.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RCN",
@@ -2431,7 +2743,8 @@
 		"fname": "Ripio Credit Network",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xF970b8E36e23F7fC3FD752EeA86f8Be8D83375A6"
 			}
@@ -2443,7 +2756,8 @@
 		"fname": "Raiden Network Token",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x255Aa6DF07540Cb5d3d297f0D0D4D84cb52bc8e6"
 			}
@@ -2457,7 +2771,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x1985365e9f78359a9B6AD760e32412f4a445E862"
 			}
@@ -2469,7 +2784,8 @@
 		"fname": "Request Network",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x8f8221aFbB33998d8584A2B05749bA73c37a938a"
 			}
@@ -2486,7 +2802,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RFOX",
@@ -2499,7 +2817,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RICK",
@@ -2511,7 +2831,9 @@
 		"mm2": 1,
 		"required_confirmations": 1,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RLC",
@@ -2519,7 +2841,8 @@
 		"fname": "iExec RLC",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x607F4C5BB672230e8672085532f7e901544a7375"
 			}
@@ -2534,7 +2857,9 @@
 		"p2shtype": 70,
 		"wiftype": 176,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ROI",
@@ -2545,7 +2870,9 @@
 		"p2shtype": 122,
 		"wiftype": 128,
 		"txfee": 200000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RUFF",
@@ -2553,7 +2880,8 @@
 		"fname": "Ruff",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xf278c1CA969095ffddDED020290cf8B5C424AcE2"
 			}
@@ -2571,7 +2899,9 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "RVT",
@@ -2579,7 +2909,8 @@
 		"fname": "Rivetz",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x3d1BA9be9f66B8ee101911bC36D3fB562eaC2244"
 			}
@@ -2593,7 +2924,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359"
 			}
@@ -2605,7 +2937,8 @@
 		"fname": "Salt",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x4156D3342D5c385a87D264F90653733592000581"
 			}
@@ -2617,7 +2950,8 @@
 		"fname": "Santiment",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x7C5A0CE9267ED19B22F8cae653F198e3E8daf098"
 			}
@@ -2633,7 +2967,9 @@
 		"wiftype": 128,
 		"txfee": 10000,
 		"confpath": "USERHOME/.sbtc/sbtc.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SCRIV",
@@ -2645,7 +2981,9 @@
 		"p2shtype": 16,
 		"wiftype": 204,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SIB",
@@ -2656,7 +2994,9 @@
 		"p2shtype": 40,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SIRX",
@@ -2668,7 +3008,9 @@
 		"wiftype": 128,
 		"txfee": 200000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SMART",
@@ -2679,7 +3021,9 @@
 		"p2shtype": 18,
 		"wiftype": 191,
 		"txfee": 200000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SMC",
@@ -2690,7 +3034,9 @@
 		"p2shtype": 5,
 		"wiftype": 191,
 		"txfee": 1000000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SNGLS",
@@ -2698,7 +3044,8 @@
 		"fname": "SingularDTV",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xaeC2E87E0A235266D9C5ADc9DEb4b2E29b54D009"
 			}
@@ -2710,7 +3057,8 @@
 		"fname": "Status",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x744d70FDBE2Ba4CF95131626614a1763DF805B9E"
 			}
@@ -2724,7 +3072,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x446C9033E7516D820cc9a2ce2d0B7328b579406F"
 			}
@@ -2736,7 +3085,8 @@
 		"fname": "SpankChain",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x42d6622deCe394b54999Fbd73D108123806f6a18"
 			}
@@ -2752,7 +3102,9 @@
 		"wiftype": 198,
 		"txfee": 10000,
 		"confpath": "USERHOME/.sparkscore/sparks.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SRN",
@@ -2760,7 +3112,8 @@
 		"fname": "SIRIN LABS Token",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x68d57c9a1C35f63E2c83eE8e49A64e9d70528D25"
 			}
@@ -2775,7 +3128,9 @@
 		"p2shtype": 5,
 		"wiftype": 204,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "STORJ",
@@ -2783,7 +3138,8 @@
 		"fname": "Storj",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xB64ef51C888972c908CFacf59B47C1AfBC0Ab8aC"
 			}
@@ -2795,7 +3151,8 @@
 		"fname": "Substratum",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x8D75959f1E61EC2571aa72798237101F084DE63a"
 			}
@@ -2811,7 +3168,9 @@
 		"wiftype": 39,
 		"txfee": 10000,
 		"confpath": "USERHOME/.sudocore/sudo.conf",
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SUPERNET",
@@ -2824,7 +3183,9 @@
 		"required_confirmations": 2,
 		"requires_notarization": true,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SVD",
@@ -2833,7 +3194,8 @@
 		"rpcport": 80,
 		"decimals": 18,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xbdEB4b83251Fb146687fa19D1C660F99411eefe3"
 			}
@@ -2845,7 +3207,8 @@
 		"fname": "Swarm City",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xB9e7F8568e08d5659f5D29C4997173d84CdF2607"
 			}
@@ -2860,7 +3223,9 @@
 		"p2shtype": 5,
 		"wiftype": 190,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "SYS",
@@ -2872,7 +3237,9 @@
 		"wiftype": 128,
 		"txfee": 10000,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "TAAS",
@@ -2880,7 +3247,8 @@
 		"fname": "TaaS",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xE7775A6e9Bcf904eb39DA2b68c5efb4F9360e08C"
 			}
@@ -2899,7 +3267,9 @@
 		"estimate_fee_mode": "ECONOMICAL",
 		"mm2": 1,
 		"required_confirmations": 0,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "THC",
@@ -2911,7 +3281,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "TIME",
@@ -2919,7 +3291,8 @@
 		"fname": "Chronobank",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x6531f133e6DeeBe7F2dcE5A0441aA7ef330B4e53"
 			}
@@ -2931,7 +3304,8 @@
 		"fname": "TokenCard",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xaAAf91D9b90dF800Df4F55c205fd6989c977E73a"
 			}
@@ -2943,7 +3317,8 @@
 		"fname": "Tratok",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x0cbC9b02B8628AE08688b5cC8134dc09e36C443b"
 			}
@@ -2959,7 +3334,9 @@
 		"p2shtype": 5,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "TRET",
@@ -2967,7 +3344,8 @@
 		"fname": "Tourist Review",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xC6D603A9Df53D1542552058c382bf115AACE70C7"
 			}
@@ -2979,7 +3357,8 @@
 		"fname": "Trust",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xCb94be6f13A1182E4A4B6140cb7bf2025d28e41B"
 			}
@@ -2994,7 +3373,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x0000000000085d4780B73119b644AE5ecd22b376"
 			}
@@ -3006,7 +3386,8 @@
 		"fname": "U.CASH",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x92e52a1A235d9A103D970901066CE910AAceFD37"
 			}
@@ -3022,7 +3403,9 @@
 		"p2shtype": 5,
 		"wiftype": 155,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "UIS",
@@ -3033,7 +3416,9 @@
 		"p2shtype": 10,
 		"wiftype": 132,
 		"txfee": 2000000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "USDC",
@@ -3044,7 +3429,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 			}
@@ -3059,7 +3445,8 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xdF1D6405df92d981a2fB3ce68F6A03baC6C0E41F"
 			}
@@ -3076,7 +3463,9 @@
 		"txfee": 100000,
 		"segwit": true,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "VIVO",
@@ -3088,7 +3477,9 @@
 		"p2shtype": 10,
 		"wiftype": 198,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "VOT",
@@ -3101,7 +3492,9 @@
 		"wiftype": 128,
 		"txversion": 4,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "VOTE2020",
@@ -3113,7 +3506,9 @@
 		"overwintered": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "VRSC",
@@ -3125,7 +3520,9 @@
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "VSL",
@@ -3134,7 +3531,8 @@
 		"rpcport": 80,
 		"decimals": 18,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x5c543e7AE0A1104f78406C340E9C64FD9fCE5170"
 			}
@@ -3152,7 +3550,9 @@
 		"segwit": true,
 		"mm2": 1,
 		"required_confirmations": 4,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "WINGS",
@@ -3160,7 +3560,8 @@
 		"fname": "Wings",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x667088b212ce3d06a1b553a7221E1fD19000d9aF"
 			}
@@ -3176,7 +3577,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "WTC",
@@ -3184,7 +3587,8 @@
 		"fname": "Waltonchain",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xb7cB1C96dB6B22b0D3d9536E0108d062BD488F74"
 			}
@@ -3199,7 +3603,9 @@
 		"p2shtype": 5,
 		"wiftype": 156,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "XAUR",
@@ -3207,7 +3613,8 @@
 		"fname": "Xarum",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x4DF812F6064def1e5e029f1ca858777CC98D2D81"
 			}
@@ -3223,7 +3630,9 @@
 		"p2shtype": 85,
 		"wiftype": 153,
 		"txfee": 100000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "XMY",
@@ -3234,7 +3643,9 @@
 		"p2shtype": 9,
 		"wiftype": 178,
 		"txfee": 5000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "XOV",
@@ -3242,7 +3653,8 @@
 		"fname": "XOVBank",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x153eD9CC1b792979d2Bde0BBF45CC2A7e436a5F9"
 			}
@@ -3259,7 +3671,9 @@
 		"wiftype": 128,
 		"txversion": 4,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "XSN",
@@ -3272,7 +3686,9 @@
 		"txfee": 10000,
 		"confpath": "USERHOME/.xsncore/xsn.conf",
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "XZC",
@@ -3286,7 +3702,9 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"avg_blocktime": 5.65,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "YCE",
@@ -3299,7 +3717,9 @@
 		"txfee": 10000,
 		"txversion": 3,
 		"mm2": 1,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "YLC",
@@ -3307,7 +3727,8 @@
 		"fname": "YoloCash",
 		"rpcport": 80,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0x21d5678A62DFe63a47062469Ebb2fAc2817D8832"
 			}
@@ -3323,7 +3744,9 @@
 		"p2shtype": 189,
 		"wiftype": 128,
 		"txfee": 1000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZEC",
@@ -3342,7 +3765,9 @@
 		"mm2": 1,
 		"required_confirmations": 3,
 		"avg_blocktime": 1.25,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZEL",
@@ -3354,7 +3779,9 @@
 		"p2shtype": 189,
 		"wiftype": 128,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZER",
@@ -3373,7 +3800,9 @@
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 2,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZET",
@@ -3384,7 +3813,9 @@
 		"rpcport": 8332,
 		"wiftype": 224,
 		"txfee": 10000,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZEXO",
@@ -3396,7 +3827,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZILLA",
@@ -3406,7 +3839,9 @@
 		"mm2": 1,
 		"required_confirmations": 2,
 		"requires_notarization": true,
-		"protocol": "UTXO"
+		"protocol": {
+			"type": "UTXO"
+		}
 	},
 	{
 		"coin": "ZRX",
@@ -3416,7 +3851,8 @@
 		"rpcport": 80,
 		"mm2": 1,
 		"protocol": {
-			"ERC20": {
+			"type": "ERC20",
+			"protocol_data": {
 				"platform": "ETH",
 				"contract_address": "0xE41d2489571d322189246DaFA5ebDe1F4699F498"
 			}


### PR DESCRIPTION
Old coins config format contained only `etomic` field which meant that the coin is ETH/ERC20. Such approach is not extensible so during QRC20 integration the `protocol` object was added to config. As this object can have arbitrary format it can represent any new coin protocol that will be added in the future.

IMPORTANT: this PR should be merged at same time with https://github.com/KomodoPlatform/atomicDEX-API/pull/672