### PR TITLE
Update KOIN

### DIFF
--- a/coins
+++ b/coins
@@ -734,8 +734,8 @@
 		"txversion": 4,
 		"overwintered": 1,
 		"mm2": 1,
-		"required_confirmations": 2,
-		"requires_notarization": true,
+		"required_confirmations": 1,
+		"requires_notarization": false,
 		"avg_blocktime": 1,
 		"protocol": {
 			"type": "UTXO"


### PR DESCRIPTION
KOIN is an on demand chain, and as a result swaps in AtomicDEX have failed from timeouts as subsequent blocks were not being produced after swap steps.
This issue likely affects other on-demand chains also, unless a dedicated tx generator is active set to produce blocks regularly enough for swaps to achieve a notarization if `"requires_notarization": true`