### PR TITLE
nota off for RICK/MORTY

### DIFF
--- a/coins
+++ b/coins
@@ -936,6 +936,7 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 1,
+		"requires_notarization": false,
 		"avg_blocktime": 1,
 		"protocol": {
 			"type": "UTXO"
@@ -1301,6 +1302,7 @@
 		"overwintered": 1,
 		"mm2": 1,
 		"required_confirmations": 1,
+		"requires_notarization": false,
 		"avg_blocktime": 1,
 		"protocol": {
 			"type": "UTXO"


### PR DESCRIPTION
because
`"rel_confs":1,"rel_nota":true`
and
`rpc_clients:145] Waiting for tx 93115e60142ca37035b946bf73a427f2653c9365ad77c60d66166c6300155069 confirmations, now 0, required 1, requires_notarization true`
make no sense
notas are only used if confirmations > 1