### PR TITLE
Update THC

### DIFF
--- a/electrums/THC
+++ b/electrums/THC
@@ -1,4 +1,15 @@
-[
+[{
+    "url": "1.eu.thc.electrum.dexstats.info:10002",
+    "contact": [
+      { "discord": "CHMEX#0686" }
+    ]
+  },
+  {
+    "url": "2.eu.thc.electrum.dexstats.info:10002",
+    "contact": [
+      { "discord": "CHMEX#0686" }
+    ]
+  },
   {
     "url": "165.22.52.123:10022",
     "contact": [


### PR DESCRIPTION
Update THC electrum servers keep the two currently dead ones in there in case they come back offline 157.230.45.184 & 165.22.52.123