### PR TITLE
MONA dust

### DIFF
--- a/coins
+++ b/coins
@@ -2187,6 +2187,7 @@
 		"p2shtype": 5,
 		"wiftype": 176,
 		"txfee": 0,
+                "dust": 100000,
 		"mm2": 1,
 		"required_confirmations": 5,
 		"avg_blocktime": 1.5,


### PR DESCRIPTION
https://github.com/monacoinproject/monacoin/blob/d15e0a75ef898cbea3fcbe07a63006619d43fb7a/doc/monacoin-release-notes/release-notes-0.10.2.2.md

> Bitcoin's IsDust() is disabled in favor of Monacoin's fee-based dust penalty.
> Fee-based Dust Penalty: For each transaction output smaller than DUST_THRESHOLD (currently 0.001 MONA) the default relay/mining policy will expect an additional 1000 bytes of fee. Otherwise the transaction will be rejected from relay/mining. Such transactions are also disqualified from the free/high-priority transaction rule.

https://dexapi.cipig.net/public/error.php?uuid=935ba592-3471-4716-af32-2c4d71520112