### PR TITLE
add missing "bech32_hrp"  address type for BTE

### DIFF
--- a/coins
+++ b/coins
@@ -817,6 +817,7 @@
 		"p2shtype": 30,
 		"wiftype": 128,
 		"segwit": true,
+		"bech32_hrp": "web",
 		"txfee": 20000,
 		"mm2": 1,
 		"required_confirmations": 3,


### PR DESCRIPTION
add missing "bech32_hrp"  address type for BTE