### PR TITLE
Add sTST to help testing the SLP implementation

### DIFF
--- a/coins
+++ b/coins
@@ -5652,5 +5652,18 @@
                 }
             },
             "mm2": 1
+        },
+	{
+            "coin":"sTST",
+            "protocol":{
+                "type":"SLPTOKEN",
+                "protocol_data":{
+                    "decimals":4,
+                    "token_id":"037eb9fc8a5f0faed4e5c15c15e69cd9f5d8a87b5f11e0ba3dce17b562705d6c",
+                    "platform":"tBCH",
+                    "required_confirmations": 1
+                }
+            },
+            "mm2": 1
         }
 ]


### PR DESCRIPTION
As not much available of the USDF, it was necessary to create another token that we can test swaps with.