### PR TITLE
Add HONK token

### DIFF
--- a/coins
+++ b/coins
@@ -530,6 +530,19 @@
 			"type": "UTXO"
 		}
 	},
+    {
+        "coin":"HONK",
+        "protocol":{
+            "type":"SLPTOKEN",
+            "protocol_data":{
+                "decimals":0,
+                "token_id":"7f8889682d57369ed0e32336f8b7e0ffec625a35cca183f4e81fde4e71a538a1",
+                "platform":"BCH",
+                "required_confirmations": 1
+            }
+        },
+        "mm2": 1
+    },
 	{
 		"coin": "BEER",
 		"asset": "BEER",


### PR DESCRIPTION
HONK token is a token on BCH main net, it has a high volume and low price. I think it will be beneficial to add it and test trading on something that has some value.
https://www.coingecko.com/tr/coins/honk-honk