### PR TITLE
fixed fee for RTM

### DIFF
--- a/coins
+++ b/coins
@@ -6709,7 +6709,7 @@
     "pubtype": 60,
     "p2shtype": 16,
     "wiftype": 128,
-    "txfee": 0,
+    "txfee": 1000,
     "mm2": 1,
     "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
     "required_confirmations": 3,


### PR DESCRIPTION
https://dexapi.cipig.net/public/error.php?uuid=9f502d10-16dd-4ad3-a3e3-a33192adc67e
`absurdly-high-fee` error because
```
raptoreum-cli estimatesmartfee 1
{
  "feerate": 0.00001014,
  "blocks": 2
}
```
but sometimes it returns a 10x higher fee, like
```
raptoreum-cli estimatesmartfee 1
{
  "feerate": 0.00010115,
  "blocks": 2
}
```