### PR TITLE
fix MIL name, update JPYC contracts, disable dPoW for MESH and ZILLA

### DIFF
--- a/coins
+++ b/coins
@@ -4644,20 +4644,20 @@
     }
   },
   {
-    "coin": "JPYC-ERC20",
-    "name": "jpyc_erc20",
+    "coin": "JPYC-AVX20",
+    "name": "jpyc_avx20",
     "fname": "JPY Coin",
     "rpcport": 80,
     "mm2": 1,
-    "chain_id": 1,
+    "chain_id": 43114,
     "decimals": 18,
-    "avg_blocktime": 0.25,
+    "avg_blocktime": 0.04,
     "required_confirmations": 3,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
-        "platform": "ETH",
-        "contract_address": "0x2370f9d504c7a6E775bf6E14B3F12846b594cD53"
+        "platform": "AVAX",
+        "contract_address": "0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB"
       }
     }
   },
@@ -4675,7 +4675,7 @@
       "type": "ERC20",
       "protocol_data": {
         "platform": "MATIC",
-        "contract_address": "0x6AE7Dfc73E0dDE2aa99ac063DcF7e8A63265108c"
+        "contract_address": "0x431D5dfF03120AFA4bDf332c61A6e1766eF37BDB"
       }
     }
   },

--- a/coins
+++ b/coins
@@ -5693,7 +5693,7 @@
   },
   {
     "coin": "MIL",
-    "name": "Milevium",
+    "name": "mil",
     "fname": "Milevium",
     "rpcport": 41889,
     "pubtype": 50,

--- a/coins
+++ b/coins
@@ -5650,8 +5650,8 @@
     "overwintered": 1,
     "mm2": 1,
     "enable_spv_proof": true,
-    "required_confirmations": 2,
-    "requires_notarization": true,
+    "required_confirmations": 4,
+    "requires_notarization": false,
     "avg_blocktime": 1,
     "protocol": {
       "type": "UTXO"
@@ -10056,8 +10056,8 @@
     "rpcport": 10041,
     "mm2": 1,
     "enable_spv_proof": true,
-    "required_confirmations": 2,
-    "requires_notarization": true,
+    "required_confirmations": 4,
+    "requires_notarization": false,
     "avg_blocktime": 1,
     "protocol": {
       "type": "UTXO"


### PR DESCRIPTION
name needs to be `mil` because the path to chain data is `~/.mil`