### PR TITLE
update consensus_branch_id for ZEC

### DIFF
--- a/coins
+++ b/coins
@@ -10195,7 +10195,7 @@
     "txversion": 4,
     "overwintered": 1,
     "version_group_id": "0x892f2085",
-    "consensus_branch_id": "0xe9ff75a6",
+    "consensus_branch_id": "0xc2d6d0b4",
     "txfee": 10000,
     "mm2": 1,
     "required_confirmations": 3,


### PR DESCRIPTION
https://z.cash/upgrade/nu5/

![image](https://user-images.githubusercontent.com/32116761/193583545-ff9a831d-464c-4427-9d6c-47886cd9737a.png)

needed to avoid failing swaps like https://dexapi.cipig.net/public/error.php?uuid=4e772a3c-15ab-423c-bc85-81564d6476fb