### PR TITLE
update workflow, gen script

### DIFF
--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -18,15 +18,25 @@ jobs:
       - name: Generate configs
         shell: bash
         run:  ${GITHUB_WORKSPACE}/utils/generate_app_configs.py
-            
-      - name: Update files in repo
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add ${GITHUB_WORKSPACE}/utils/coins_config.json ${GITHUB_WORKSPACE}/utils/electrum_scan_report.json
-          git commit -m "Update coin configs"
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: update coins json file
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          branch: json-config-update
+          delete-branch: true
+          title: '[BOT] Update coins config json'
+          body: |
+            - Coins JSON config auto-generated on merge to master
+            - Electrum scan report updated
+          labels: |
+            config-update
+          assignees: cipig, smk762, gcharang
+          reviewers: cipig, smk762, gcharang
+          team-reviewers: |
+            owners
+            maintainers
+          draft: false

--- a/light_wallet_d/ZOMBIE
+++ b/light_wallet_d/ZOMBIE
@@ -1,0 +1,1 @@
+["https://zombie.sirseven.me:443"]

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -122,6 +122,10 @@ class CoinConfig:
                 self.data[self.ticker].update({
                     "light_wallet_d_servers": lightwallet_servers
                 })
+            else:
+                self.data[self.ticker].update({
+                    "light_wallet_d_servers": []
+                })
 
     def get_protocol_info(self):
         if "protocol_data" in self.coin_data["protocol"]:
@@ -346,7 +350,7 @@ class CoinConfig:
                 for p in explorer_paths:
                     if x.find(p) > -1:
                         self.data[self.ticker].update(explorer_paths[p])
-            self.data[self.ticker].update({"explorer_url": explorers})
+            self.data[self.ticker].update({"explorer_url": explorers[0]})
 
 def parse_coins_repo():
 
@@ -386,6 +390,9 @@ def parse_coins_repo():
                     nodata.append(coin)
             if "electrum" in coins_config[coin]:
                 if not coins_config[coin]["electrum"]:
+                    nodata.append(coin)
+            if "light_wallet_d_servers" in coins_config[coin]:
+                if not coins_config[coin]["light_wallet_d_servers"]:
                     nodata.append(coin)
             if "nodes" not in coins_config[coin] and "electrum" not in coins_config[coin]:
                 nodata.append(coin)

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -11,7 +11,7 @@ os.chdir(script_path)
 
 # TODO: Check all coins have an icon.
 icons = [f for f in os.listdir(f"{repo_path}/icons") if os.path.isfile(f"{repo_path}/icons/{f}.png")]
-lightwallet_coins = [f for f in os.listdir(f"{repo_path}/electrums") if os.path.isfile(f"{repo_path}/light_wallet_d/{f}")]
+lightwallet_coins = [f for f in os.listdir(f"{repo_path}/light_wallet_d") if os.path.isfile(f"{repo_path}/light_wallet_d/{f}")]
 electrum_coins = [f for f in os.listdir(f"{repo_path}/electrums") if os.path.isfile(f"{repo_path}/electrums/{f}")]
 ethereum_coins = [f for f in os.listdir(f"{repo_path}/ethereum") if os.path.isfile(f"{repo_path}/ethereum/{f}")]
 explorer_coins = [f for f in os.listdir(f"{repo_path}/explorers") if os.path.isfile(f"{repo_path}/explorers/{f}")]


### PR DESCRIPTION
Once `parse_repo` branch was merged and set to run on merge to master, it returned errors due to protected branch without review. I've changed the workflow to create a PR instead, with @gcharang @cipig and @smk762 as reviewers.

After some feedback from @Canialon in the desktop repo it was also identified that explorer links were not working - this was due to there being  more than one item in the list of explorers for a coin. Now only the first item in the list will be in the json output. This will also ensure that the correct address / tx suffixes are applied.

There was also an issue where ZOMBIE was included in output though it had no value for `light_wallet_d_servers`. After this PR, coins in this state will not be included in the JSON outpput.

@SirSevenG please create a PR to add a file for ZOMBIE's `light_wallet_d_servers` in https://github.com/KomodoPlatform/coins/tree/master/light_wallet_d

cc: @yurii-khi @tonymorony @ologunB