### PR TITLE
fix bech32_hrp for GRS

### DIFF
--- a/coins
+++ b/coins
@@ -4227,7 +4227,7 @@
     "wiftype": 128,
     "txfee": 0,
     "segwit": true,
-    "bech32_hrp": "bc",
+    "bech32_hrp": "grs",
     "mm2": 1,
     "required_confirmations": 5,
     "avg_blocktime": 1,
@@ -4245,7 +4245,7 @@
     "wiftype": 128,
     "txfee": 0,
     "segwit": true,
-    "bech32_hrp": "bc",
+    "bech32_hrp": "grs",
     "address_format": {
       "format": "segwit"
     },


### PR DESCRIPTION
tested with deposit to coinex:
![image](https://user-images.githubusercontent.com/32116761/199077874-235bdb19-edc8-4955-b18e-572a77d31a0e.png)
