### PR TITLE
cleanup QRC20

### DIFF
--- a/api_ids/coingecko_ids.json
+++ b/api_ids/coingecko_ids.json
@@ -445,7 +445,6 @@
     "SOLVE-ERC20": "solve-care",
     "SOULJA": "test-coin",
     "SPACE": "test-coin",
-    "SPC": "spacechain-erc-20",
     "SRM-ERC20": "serum",
     "SRM-PLG20": "serum",
     "STFIRO": "stakehound",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -445,7 +445,6 @@
     "SOLVE-ERC20": "solve-solve",
     "SOULJA": "test-coin",
     "SPACE": "space-spacecoin7367",
-    "SPC": "spc-spacechain",
     "SRM-ERC20": "srm-serum",
     "SRM-PLG20": "srm-serum",
     "STFIRO": "test-coin",

--- a/api_ids/nomics_ids.json
+++ b/api_ids/nomics_ids.json
@@ -410,7 +410,6 @@
     "SOL-PLG20": "SOL",
     "SOLVE-ERC20": "SOLVE",
     "SPACE": "SPACE7",
-    "SPC": "SPC",
     "SRM-ERC20": "SRM",
     "SRM-PLG20": "SRM",
     "STORJ-ERC20": "STORJ",

--- a/coins
+++ b/coins
@@ -2956,7 +2956,7 @@
   },
   {
     "coin": "DIMI-QRC20",
-    "name": "dimi_qrc20",
+    "name": "qtum",
     "fname": "Diminutive Coin",
     "rpcport": 3889,
     "pubtype": 58,
@@ -6518,7 +6518,7 @@
   },
   {
     "coin": "NVC-QRC20",
-    "name": "nvc_qrc20",
+    "name": "qtum",
     "fname": "Novacoin",
     "rpcport": 3889,
     "pubtype": 58,
@@ -10072,7 +10072,7 @@
   },
   {
     "coin": "XVC-QRC20",
-    "name": "xvc_qrc20",
+    "name": "qtum",
     "fname": "VanillaCash",
     "rpcport": 3889,
     "pubtype": 58,
@@ -10434,7 +10434,6 @@
   },
   {
     "coin": "INK",
-    "gui_coin": "INK",
     "name": "qtum",
     "fname": "INK",
     "rpcport": 3889,
@@ -10514,33 +10513,7 @@
     }
   },
   {
-    "coin": "SPC",
-    "gui_coin": "SPC",
-    "name": "qtum",
-    "fname": "SpaceChain",
-    "rpcport": 3889,
-    "mm2": 1,
-    "required_confirmations": 3,
-    "mature_confirmations": 2000,
-    "avg_blocktime": 0.53,
-    "txfee": 0,
-    "dust": 72800,
-    "protocol": {
-      "type": "QRC20",
-      "protocol_data": {
-        "platform": "QTUM",
-        "contract_address": "0x57931faffdec114056a49adfcaa1caac159a1a25"
-      }
-    },
-    "pubtype": 58,
-    "p2shtype": 50,
-    "wiftype": 128,
-    "segwit": false,
-    "decimals": 8
-  },
-  {
     "coin": "HPY",
-    "gui_coin": "HPY",
     "name": "qtum",
     "fname": "HyperPay",
     "rpcport": 3889,
@@ -10565,7 +10538,6 @@
   },
   {
     "coin": "HLC",
-    "gui_coin": "HLC",
     "name": "qtum",
     "fname": "HalalChain",
     "rpcport": 3889,
@@ -10590,7 +10562,7 @@
   },
   {
     "coin": "MED",
-    "name": "med_qrc20",
+    "name": "qtum",
     "fname": "Medibloc",
     "rpcport": 3889,
     "mm2": 1,
@@ -10614,7 +10586,6 @@
   },
   {
     "coin": "LSTR",
-    "gui_coin": "LSTR",
     "name": "qtum",
     "fname": "Luna Stars",
     "rpcport": 3889,
@@ -10639,7 +10610,6 @@
   },
   {
     "coin": "QBT",
-    "gui_coin": "QBT",
     "name": "qtum",
     "fname": "Qbao",
     "rpcport": 3889,
@@ -10664,7 +10634,6 @@
   },
   {
     "coin": "TSL",
-    "gui_coin": "TSL",
     "name": "qtum",
     "fname": "Energo TSL",
     "rpcport": 3889,
@@ -10689,7 +10658,6 @@
   },
   {
     "coin": "OC",
-    "gui_coin": "OC",
     "name": "qtum",
     "fname": "OceanChain",
     "rpcport": 3889,
@@ -10714,7 +10682,6 @@
   },
   {
     "coin": "PUT",
-    "gui_coin": "PUT",
     "name": "qtum",
     "fname": "Profile Utility Token",
     "rpcport": 3889,
@@ -10729,31 +10696,6 @@
       "protocol_data": {
         "platform": "QTUM",
         "contract_address": "0x4060e21ac01b5c5d2a3f01cecd7cbf820f50be95"
-      }
-    },
-    "pubtype": 58,
-    "p2shtype": 50,
-    "wiftype": 128,
-    "segwit": false,
-    "decimals": 8
-  },
-  {
-    "coin": "ZAT",
-    "gui_coin": "ZAT",
-    "name": "qtum",
-    "fname": "zatgo token",
-    "rpcport": 3889,
-    "mm2": 1,
-    "required_confirmations": 3,
-    "mature_confirmations": 2000,
-    "avg_blocktime": 0.53,
-    "txfee": 0,
-    "dust": 72800,
-    "protocol": {
-      "type": "QRC20",
-      "protocol_data": {
-        "platform": "QTUM",
-        "contract_address": "0xdd8ef078a5699ea3dac26b12cb5c5d8f0a2f6e4f"
       }
     },
     "pubtype": 58,


### PR DESCRIPTION
SPC moved to ERC20: https://medium.com/blogspacechain/spacechain-may-2021-report-732bd86bb2d3
ZAT last tx almost 2 years ago: https://qtum.info/qrc20/dd8ef078a5699ea3dac26b12cb5c5d8f0a2f6e4f/
`name` of QRC20 tokens must be "qtum", for native mode
`gui_coin` is not used