### PR TITLE
add electrum and api_ids for VTC

### DIFF
--- a/api_ids/coingecko_ids.json
+++ b/api_ids/coingecko_ids.json
@@ -539,6 +539,7 @@
     "VRA-ERC20": "verasity",
     "VRM": "test-coin",
     "VRSC": "verus-coin",
+    "VTC": "vertcoin",
     "WAVES-BEP20": "waves",
     "WBTC-ERC20": "wrapped-bitcoin",
     "WBTC-HRC20": "wrapped-bitcoin",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -539,6 +539,7 @@
     "VRA-ERC20": "vra-verasity",
     "VRM": "vrm-veriumreserve",
     "VRSC": "vrsc-verus-coin",
+    "VTC": "vtc-vertcoin",
     "WAVES-BEP20": "waves-waves",
     "WBTC-ERC20": "wbtc-wrapped-bitcoin",
     "WBTC-HRC20": "wbtc-wrapped-bitcoin",

--- a/api_ids/nomics_ids.json
+++ b/api_ids/nomics_ids.json
@@ -497,6 +497,7 @@
     "VRA-ERC20": "VRA",
     "VRM": "VRM",
     "VRSC": "VRSC",
+    "VTC": "VTC",
     "WAVES-BEP20": "WAVES",
     "WBTC-ERC20": "WBTC",
     "WBTC-HRC20": "WBTC",

--- a/electrums/VTC
+++ b/electrums/VTC
@@ -1,0 +1,5 @@
+[
+  {
+    "url": "electrumx.javerity.com:5885"
+  }
+]

--- a/explorers/VTC
+++ b/explorers/VTC
@@ -1,1 +1,1 @@
-["https://www.coinexplorer.net/VTC/"]
+["https://chainz.cryptoid.info/vtc/"]


### PR DESCRIPTION
this actually lists VTC, because it had 0 electrums before
![image](https://user-images.githubusercontent.com/32116761/200135167-488534f1-dbf8-4295-b0cc-65ec8f42dc4f.png)
