### PR TITLE
Updatesd coins

### DIFF
--- a/coins
+++ b/coins
@@ -11463,5 +11463,37 @@
         "gas_price": 0.50
       }
     }
-  }
+  },
+  {
+      "coin": "NATURE",
+     	"asset": "NATURE",
+     	"fname": "Nature Digital Currency
+      "rpcport": 63380,
+     	"txversion": 4,
+     	"overwintered": 1,
+     	"mm2": 1,
+      "required_confirmations": 2,
+     	"requires_notarization": false,
+     	"avg_blocktime": 2
+      "protocol": {
+     		"type": "UTXO"
+        }
+      }
+  },
+  {
+     	"coin": "SIX",
+     	"asset": "SIX",
+     	"fname": "End Time Currency",
+     	"rpcport": 20020,
+     	"txversion": 4,
+     	"overwintered": 1,
+     	"mm2": 1,
+     	"required_confirmations": 2,
+     	"requires_notarization": false,
+     	"avg_blocktime": 2,
+     	"protocol": {
+     		"type": "UTXO"
+        }
+      }
+   }
 ]


### PR DESCRIPTION
Notarization for both "NATURE" & "SIXCOIN" is set to false pending the chains' notarization, after which the coins files will be finally updated and set to true.