### PR TITLE
fix coinpaprika api_id for LNC, DOI

### DIFF
--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -166,7 +166,7 @@
     "DOGE": "doge-dogecoin",
     "DOGEDASH-BEP20": "dogedash-doge-dash",
     "DOGGY-BEP20": "doggy-doggy",
-    "DOI": "doi-doicoin",
+    "DOI": "doi-doichain",
     "DOT-BEP20": "dot-polkadot",
     "DOT-HCO20": "dot-polkadot",
     "DP": "dp-digitalprice",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -303,7 +303,7 @@
     "LINK-HRC20": "link-chainlink",
     "LINK-KRC20": "link-chainlink",
     "LINK-PLG20": "link-chainlink",
-    "LNC": "lnc-lightningcash",
+    "LNC": "ltncg-lightningcash-gold",
     "LOOP-BEP20": "loop-loopnetwork",
     "LOOM-BEP20": "loom-loom-network",
     "LOOM-ERC20": "loom-loom-network",


### PR DESCRIPTION
see https://discord.com/channels/412898016371015680/428673045767520260/1050499593252634634 so URL not necessarily = api id any more, like in this case
important is the api id shown on the page of the respective coin (https://coinpaprika.com/coin/lnc-lightning-cash/)
![image](https://user-images.githubusercontent.com/32116761/206557044-6e3c1231-2a3e-426c-a9a4-ea5fb911705c.png)

![image](https://user-images.githubusercontent.com/32116761/206602189-92e28ebf-b41b-4c80-8b84-93740281d3fd.png)

