### PR TITLE
fix param

### DIFF
--- a/coins
+++ b/coins
@@ -11432,7 +11432,7 @@
   },
   {
     "coin": "ATOM",
-    "avg_block_time": 7,
+    "avg_blocktime": 0.12,
     "name": "cosmos",
     "fname": "Cosmos",
     "mm2": 1,
@@ -11449,7 +11449,7 @@
   },
   {
     "coin": "IRIS",
-    "avg_block_time": 7,
+    "avg_blocktime": 0.12,
     "name": "iris",
     "fname": "Iris",
     "mm2": 1,
@@ -11466,7 +11466,7 @@
   },
   {
     "coin": "OSMO",
-    "avg_block_time": 6,
+    "avg_blocktime": 0.12,
     "name": "osmosis",
     "fname": "Osmosis",
     "mm2": 1,
@@ -11486,7 +11486,7 @@
     "coin": "ATOM-IBC_IRIS",
     "name": "cosmos_ibc_iris",
     "fname": "Cosmos IBC-IRIS",
-    "avg_block_time": 7,
+    "avg_blocktime": 0.12,
     "mm2": 1,
     "protocol": {
       "type": "TENDERMINTTOKEN",

--- a/coins
+++ b/coins
@@ -11432,7 +11432,7 @@
   },
   {
     "coin": "ATOM",
-    "avg_blocktime": 0.12,
+    "avg_blocktime": 7,
     "name": "cosmos",
     "fname": "Cosmos",
     "mm2": 1,
@@ -11449,7 +11449,7 @@
   },
   {
     "coin": "IRIS",
-    "avg_blocktime": 0.12,
+    "avg_blocktime": 7,
     "name": "iris",
     "fname": "Iris",
     "mm2": 1,
@@ -11466,7 +11466,7 @@
   },
   {
     "coin": "OSMO",
-    "avg_blocktime": 0.12,
+    "avg_blocktime": 7,
     "name": "osmosis",
     "fname": "Osmosis",
     "mm2": 1,
@@ -11486,7 +11486,7 @@
     "coin": "ATOM-IBC_IRIS",
     "name": "cosmos_ibc_iris",
     "fname": "Cosmos IBC-IRIS",
-    "avg_blocktime": 0.12,
+    "avg_blocktime": 7,
     "mm2": 1,
     "protocol": {
       "type": "TENDERMINTTOKEN",


### PR DESCRIPTION
ATOM / IRIS assets were set using `avg_block_time` param, this should be `avg_blocktime`

Value was also set as seconds, but currently everything else is in minutes (until https://github.com/KomodoPlatform/coins/pull/573 is merged)