### PR TITLE
Update bchd_urls.json

### DIFF
--- a/slp/bchd_urls.json
+++ b/slp/bchd_urls.json
@@ -3,6 +3,6 @@
         "https://bchd-testnet.greyh.at:18335"
     ],
     "BCH": [
-        "https://bchd.fountainhead.cash:443"
+        "https://bchd.dragonhound.info"
     ]
 }


### PR DESCRIPTION
A user recently reported that SLP withdrawals were failing. The cause was that the third party bchdrpc server was offline, so I've set one up which is working. 

To test:
- Update your coins file to use the new bchd url 
- Enable BCH with tokens
- Confirm you can do a withdrawal

Send me a ping if you need funds to test or help with CLI / desktop config.