### PR TITLE
Xvs api ids

### DIFF
--- a/api_ids/coingecko_ids.json
+++ b/api_ids/coingecko_ids.json
@@ -581,7 +581,7 @@
     "XVC-OLD": "vcash",
     "XVC-QRC20": "vcash",
     "XVC": "vcash",
-    "XVS": "venus",
+    "XVS-BEP20": "venus",
     "YFI-AVX20": "yearn-finance",
     "YFI-BEP20": "yearn-finance",
     "YFI-ERC20": "yearn-finance",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -580,7 +580,7 @@
     "XVC-OLD": "xvc-vcash",
     "XVC-QRC20": "xvc-vcash",
     "XVC": "xvc-vcash",
-    "XVS": "xvs-venus",
+    "XVS-BEP20": "xvs-venus",
     "YFI-AVX20": "yfi-yearnfinance",
     "YFI-BEP20": "yfi-yearnfinance",
     "YFI-ERC20": "yfi-yearnfinance",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -398,7 +398,7 @@
     "PRCY-PLG20": "prcy-privacy-coin",
     "PRUX": "prux-prux-coin",
     "PUT-QRC20": "put-profile-utility-token",
-    "QBT": "qbt-qbao",
+    "QBT-QRC20": "qbt-qbao",
     "QC-QRC20": "qc-qcash",
     "QI-QRC20": "qi-qiswap",
     "QIAIR-QRC20": "test-coin",

--- a/api_ids/nomics_ids.json
+++ b/api_ids/nomics_ids.json
@@ -527,7 +527,7 @@
     "XVC-BEP20": "XVC",
     "XVC-OLD": "XVC",
     "XVC-QRC20": "XVC",
-    "XVS": "XVS",
+    "XVS-BEP20": "XVS",
     "YFI-AVX20": "YFI",
     "YFI-BEP20": "YFI",
     "YFI-ERC20": "YFI",


### PR DESCRIPTION
Reviewing https://github.com/KomodoPlatform/coins/pull/603/files I noticed a couple of API entries were missing due to recent addition for `-BEP20` / `-QRC20` suffix to ticker names. 