### PR TITLE
set gala-bep20 to wallet-only

### DIFF
--- a/api_ids/coingecko_ids.json
+++ b/api_ids/coingecko_ids.json
@@ -221,7 +221,6 @@
     "FTM": "fantom",
     "FTMT": "test-coin",
     "FXS-BEP20": "frax-share",
-    "GALA-BEP20": "gala",
     "GALA-ERC20": "gala",
     "GLEEC": "gleec-coin",
     "GLM-ERC20": "golem",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -221,7 +221,6 @@
     "FTM": "ftm-fantom",
     "FTMT": "test-coin",
     "FXS-BEP20": "fxs-frax-share",
-    "GALA-BEP20": "gala-gala",
     "GALA-ERC20": "gala-gala",
     "GLEEC": "gleec-gleec-coin",
     "GLM-ERC20": "glm-golem",

--- a/api_ids/nomics_ids.json
+++ b/api_ids/nomics_ids.json
@@ -212,7 +212,6 @@
     "FXS-AVX20": "FXS",
     "FXS-MVR20": "FXS",
     "FXS-FTM20": "FXS",
-    "GALA-BEP20": "GALA",
     "GALA-ERC20": "GALA",
     "GLEEC": "GLEEC",
     "GLM-ERC20": "GLM",

--- a/coins
+++ b/coins
@@ -4613,6 +4613,26 @@
     "derivation_path": "m/44'/60'"
   },
   {
+    "coin": "GALA-BEP20",
+    "name": "gala_bep20",
+    "fname": "Gala",
+    "rpcport": 80,
+    "mm2": 1,
+    "chain_id": 56,
+    "decimals": 18,
+    "avg_blocktime": 0.05,
+    "required_confirmations": 3,
+    "protocol": {
+      "type": "ERC20",
+      "protocol_data": {
+        "platform": "BNB",
+        "contract_address": "0x7dDEE176F665cD201F93eEDE625770E2fD911990"
+      }
+    },
+    "wallet_only": true,
+    "derivation_path": "m/44'/714'"
+  },
+  {
     "coin": "GIN",
     "name": "gincoin",
     "fname": "GINcoin",

--- a/coins
+++ b/coins
@@ -4613,25 +4613,6 @@
     "derivation_path": "m/44'/60'"
   },
   {
-    "coin": "GALA-BEP20",
-    "name": "gala_bep20",
-    "fname": "Gala",
-    "rpcport": 80,
-    "mm2": 1,
-    "chain_id": 56,
-    "decimals": 18,
-    "avg_blocktime": 0.05,
-    "required_confirmations": 3,
-    "protocol": {
-      "type": "ERC20",
-      "protocol_data": {
-        "platform": "BNB",
-        "contract_address": "0x7dDEE176F665cD201F93eEDE625770E2fD911990"
-      }
-    },
-    "derivation_path": "m/44'/714'"
-  },
-  {
     "coin": "GIN",
     "name": "gincoin",
     "fname": "GINcoin",


### PR DESCRIPTION
ref: https://discord.com/channels/412898016371015680/429676282196787200/1074977656371679232
nomics has two prices for this. bscan / ethracker have same price. Seems after a [hack / misconfig](https://cryptopotato.com/gala-games-dismisses-hacking-speculations-after-gala-plunged-90/) late last year the bep token was devalued.

https://nomics.com/assets/gala-gala
https://nomics.com/assets/gala3-ptokens-gala