### PR TITLE
update ETC RPC endpoint

### DIFF
--- a/ethereum/ETC
+++ b/ethereum/ETC
@@ -2,7 +2,10 @@
   "swap_contract_address": "0x6d9ce4BD298DE38bAfEFD15f5C6f5c95313B1d94",
   "rpc_nodes": [
     {
-      "url": "https://www.ethercluster.com/etc"
+      "url": "https://geth-de.etc-network.info"
+    },
+    {
+      "url": "https://besu-at.etc-network.info"
     }
   ]
 }


### PR DESCRIPTION
the old endpoint is showing error `01 13:14:50, coins:eth:4553] ERROR Couldn't get client version for url https://www.ethercluster.com/etc: Got invalid response: https://www.ethercluster.com/etc: data did not match any variant of untagged enum Response` on `enable`