### PR TITLE
force_min_relay_fee for DASH

### DIFF
--- a/coins
+++ b/coins
@@ -3174,6 +3174,7 @@
     "p2shtype": 16,
     "wiftype": 204,
     "txfee": 1000,
+    "force_min_relay_fee": true,
     "mm2": 1,
     "required_confirmations": 2,
     "avg_blocktime": 2.5,


### PR DESCRIPTION
in order to avoid failed swaps like this: https://dexapi.cipig.net/public/error.php?uuid=2d8e0c53-ae3b-4965-9466-763b9527ee46