### PR TITLE
required_confirmations 20 for MATIC

### DIFF
--- a/coins
+++ b/coins
@@ -7289,7 +7289,7 @@
     "mm2": 1,
     "chain_id": 137,
     "avg_blocktime": 1.8,
-    "required_confirmations": 3,
+    "required_confirmations": 20,
     "protocol": {
       "type": "ETH"
     },


### PR DESCRIPTION
set required_confirmations to 20 for MATIC itself, just like for all PLG20 tokens