### PR TITLE
Fujicoin: Add WebSocket port to electrum backend

### DIFF
--- a/electrums/FJC
+++ b/electrums/FJC
@@ -4,35 +4,39 @@
         "protocol": "SSL",
         "contact": [
             {
-                "github": "https://github.com/fujicoin/electrum-fjc/issues"
+                "discord": "motty#8318"
             }
-        ]
+        ],
+        "ws_url": "electrumx1.fujicoin.org:50005"
     },
     {
         "url": "electrumx2.fujicoin.org:50003",
         "protocol": "SSL",
         "contact": [
             {
-                "github": "https://github.com/fujicoin/electrum-fjc/issues"
+                "discord": "motty#8318"
             }
-        ]
+        ],
+        "ws_url": "electrumx2.fujicoin.org:50005"
     },
     {
         "url": "electrumx1.fujicoin.org:50001",
         "protocol": "TCP",
         "contact": [
             {
-                "github": "https://github.com/fujicoin/electrum-fjc/issues"
+                "discord": "motty#8318"
             }
-        ]
+        ],
+        "ws_url": "electrumx1.fujicoin.org:50004"
     },
     {
         "url": "electrumx2.fujicoin.org:50001",
         "protocol": "TCP",
         "contact": [
             {
-                "github": "https://github.com/fujicoin/electrum-fjc/issues"
+                "discord": "motty#8318"
             }
-        ]
+        ],
+        "ws_url": "electrumx2.fujicoin.org:50004"
     }
 ]

--- a/electrums/FJC
+++ b/electrums/FJC
@@ -26,8 +26,7 @@
             {
                 "discord": "motty#8318"
             }
-        ],
-        "ws_url": "electrumx1.fujicoin.org:50004"
+        ]
     },
     {
         "url": "electrumx2.fujicoin.org:50001",
@@ -36,7 +35,6 @@
             {
                 "discord": "motty#8318"
             }
-        ],
-        "ws_url": "electrumx2.fujicoin.org:50004"
+        ]
     }
 ]


### PR DESCRIPTION
WebSocket ports for the fujicoin electrum backend have been opened.
