### PR TITLE
add new explorer urls

### DIFF
--- a/explorers/ARRR
+++ b/explorers/ARRR
@@ -1,1 +1,1 @@
-["https://pirate.explorer.dexstats.info/"]
+["https://explorer.pirate.black/", "https://pirate.explorer.dexstats.info/", "https://pirate.komodo.earth/"]

--- a/explorers/CCL
+++ b/explorers/CCL
@@ -1,1 +1,1 @@
-["https://ccl.kmdexplorer.io/", "https://ccl.explorer.dexstats.info/"]
+["https://ccl.komodo.earth/", "https://ccl.kmdexplorer.io/", "https://ccl.explorer.dexstats.info/"]

--- a/explorers/CLC
+++ b/explorers/CLC
@@ -1,1 +1,1 @@
-["https://clc.explorer.dexstats.info/"]
+["https://clc.komodo.earth/", "https://clc.explorer.dexstats.info/"]

--- a/explorers/DOC
+++ b/explorers/DOC
@@ -1,1 +1,1 @@
-["https://doc.dragonhound.info/"]
+["https://doc.komodo.earth/", "https://doc.dragonhound.info/"]

--- a/explorers/GLEEC
+++ b/explorers/GLEEC
@@ -1,1 +1,1 @@
-["https://gleec.explorer.dexstats.info/"]
+["https://gleec.komodo.earth/", "https://gleec.explorer.dexstats.info/"]

--- a/explorers/ILN
+++ b/explorers/ILN
@@ -1,1 +1,1 @@
-["https://explorer.ilien.io/", "https://iln.explorer.dexstats.info/"]
+["https://iln.komodo.earth/", "https://explorer.ilien.io/", "https://iln.explorer.dexstats.info/"]

--- a/explorers/KOIN
+++ b/explorers/KOIN
@@ -1,1 +1,1 @@
-["https://block.koinon.cloud/", "https://koin.explorer.dexstats.info/"]
+["https://koin.komodo.earth/", "https://block.koinon.cloud/", "https://koin.explorer.dexstats.info/"]

--- a/explorers/SUPERNET
+++ b/explorers/SUPERNET
@@ -1,1 +1,1 @@
-["https://supernet.kmdexplorer.io/", "https://supernet.explorer.dexstats.info/"]
+["https://supernet.komodo.earth/", "https://supernet.kmdexplorer.io/", "https://supernet.explorer.dexstats.info/"]

--- a/explorers/THC
+++ b/explorers/THC
@@ -1,1 +1,1 @@
-["https://thc.explorer.dexstats.info/"]
+["https://thc.komodo.earth/", "https://thc.explorer.dexstats.info/"]


### PR DESCRIPTION
Adds new explorers from "group-one" in https://github.com/smk762/notary_docker_main/blob/notary-explorer-group-one/coins_data.json
- DOC
- MARTY
- NINJA
- PIRATE
- ZOMBIE

These explorers run in docker alongside their daemons within the domains
- *.komodo.earth
- *.explorer.dragonhound.info
and configured with rate limiting and load balancing via NGINX.

Additional explorers from the other groups will be added in future PRs to cover all notary node smartchains.