### PR TITLE
remove bad NAV electrums

### DIFF
--- a/electrums/NAV
+++ b/electrums/NAV
@@ -1,10 +1,5 @@
 [
   {
-    "url": "electrum.nav.community:40002",
-    "protocol": "SSL",
-    "ws_url": "electrum.nav.community:40004"
-  },
-  {
     "url": "electrum2.nav.community:40002",
     "protocol": "SSL",
     "ws_url": "electrum2.nav.community:40004"
@@ -18,8 +13,5 @@
     "url": "electrum4.nav.community:40002",
     "protocol": "SSL",
     "ws_url": "electrum4.nav.community:40004"
-  },
-  {
-    "url": "88.99.26.209:5061"
   }
 ]


### PR DESCRIPTION
- 88.99.26.209:5061 is responsible for https://github.com/KomodoPlatform/komodo-wallet-desktop/issues/2330
- electrum.nav.community:40002 is always lagging behind the other electrums couple of blocks (see https://1209k.com/bitcoin-eye/ele.php?chain=nav) because the operator stakes NAV on that one... this can cause swaps to fail