### PR TITLE
Add notary-group-one explorers

### DIFF
--- a/explorers/ARRR
+++ b/explorers/ARRR
@@ -1,1 +1,6 @@
-["https://pirate.explorer.dexstats.info/"]
+[
+    "https://pirate.komodo.earth/",
+    "https://pirate.explorer.dragonhound.info/",
+    "https://pirate.explorer.dexstats.info/",
+    "https://explorer.pirate.black/"
+]

--- a/explorers/DOC
+++ b/explorers/DOC
@@ -1,1 +1,5 @@
-["https://doc.dragonhound.info/"]
+[
+    "https://doc.komodo.earth/",
+    "https://doc.explorer.dragonhound.info/",
+    "https://doc.explorer.dexstats.info/"
+]

--- a/explorers/MARTY
+++ b/explorers/MARTY
@@ -1,1 +1,5 @@
-["https://marty.dragonhound.info/"]
+[
+    "https://marty.komodo.earth/",
+    "https://marty.explorer.dragonhound.info/",
+    "https://marty.explorer.dexstats.info/"
+]

--- a/explorers/NINJA
+++ b/explorers/NINJA
@@ -1,1 +1,7 @@
- ["https://ninja.kmdexplorer.io/", "https://ninja.explorer.dexstats.info/"]
+[
+
+    "https://ninja.komodo.earth/",
+    "https://ninja.explorer.dragonhound.info/",
+    "https://ninja.kmdexplorer.io/",
+    "https://ninja.explorer.dexstats.info/"
+]

--- a/explorers/ZOMBIE
+++ b/explorers/ZOMBIE
@@ -1,1 +1,5 @@
-["https://zombie.explorer.lordofthechains.com/"]
+[
+    "https://zombie.komodo.earth/",
+    "https://zombie.explorer.dragonhound.info/",
+    "https://zombie.explorer.lordofthechains.com/"
+]


### PR DESCRIPTION
Adds new explorers from "group-one" in https://github.com/smk762/notary_docker_main/blob/notary-explorer-group-one/coins_data.json

- DOC
- MARTY
- NINJA
- PIRATE
- ZOMBIE

These explorers run in docker alongside their daemons within the domains

- *.komodo.earth
- *.explorer.dragonhound.info

and configured with rate limiting and load balancing via NGINX.
Additional explorers from the other groups will be added in future PRs to cover all notary node smartchains.