### PR TITLE
restore second OSMO rpc node

### DIFF
--- a/ethereum/OSMO
+++ b/ethereum/OSMO
@@ -1,6 +1,9 @@
 {
   "rpc_nodes": [
     {
+      "url": "https://rpc.osmosis.zone/"
+    },
+    {
       "url": "https://osmosis-mainnet-rpc.allthatnode.com:26657/"
     }
   ]


### PR DESCRIPTION
This node was previously used but then removed and replaced with the other node that is currently not working. 

