### PR TITLE
Removes obsolete zhtlc fields, adds zhtlc derivation paths

### DIFF
--- a/coins
+++ b/coins
@@ -657,16 +657,12 @@
             189
           ]
         },
-        "check_point_block": {
-          "height": 1900000,
-          "time": 1652512363,
-          "hash": "44797f3bb78323a7717007f1e289a3689e0b5b3433385dbd8e6f6a1700000000",
-          "sapling_tree": "01e40c26f4a28071535b95ae637d30a209531e92a33de0a649e51183771025fd0f016cdc51442fcb328d047a709dc0f41e0173953404711045b3ef3036d7fd4151271501d6c94c5ce6787826af809aaee83768c4b7d4f02c8dc2d24cf60ed5f127a5d730018a752ea9d9efb3e1ac0e6e705ac9f7f9863cfa8f612ad43802175338d8d7cc6000000001fc3542434eff03075ea5f0a64f1dfb2f042d281b1a057e9f6c765b533ce51219013ad9484b1e901e62b93e7538f913dcb27695380c3bc579e79f5cc900f28e596e0001431da5f01fe11d58300134caf5ac76e0b1b7486fd02425dd8871bca4afa94d4b01bb39de1c1d10a25ce0cc775bc74b6b0f056c28639e7c5b7651bb8460060085530000000001732ddf661e68c9e335599bb0b18b048d2f1c06b20eabd18239ad2f3cc45fa910014496bab5eedab205b5f2a206bd1db30c5bc8bc0c1914a102f87010f3431be21a0000010b5fd8e7610754075f936463780e85841f3ab8ca2978f9afdf7c2c250f16a75f01db56bc66eb1cd54ec6861e5cf24af2f4a17991556a52ca781007569e95b9842401c03877ecdd98378b321250640a1885604d675aaa50380e49da8cfa6ff7deaf15"
-        }
-      }
-    },
-    "required_confirmations": 2,
-    "requires_notarization": true
+        "z_derivation_path": "m/32'/141'"
+      },
+      "required_confirmations": 2,
+      "requires_notarization": true,
+      "derivation_path": "m/44'/141'"
+    }
   },
   {
     "coin": "ARRR-BEP20",
@@ -13808,9 +13804,11 @@
             189
           ]
         }
-      }
+      },
+      "z_derivation_path": "m/32'/141'"
     },
-    "required_confirmations": 3
+    "required_confirmations": 3,
+    "derivation_path": "m/44'/141'"
   },
   {
     "coin": "ZINU-BEP20",

--- a/coins
+++ b/coins
@@ -13803,9 +13803,9 @@
             28,
             189
           ]
-        }
-      },
-      "z_derivation_path": "m/32'/141'"
+        },
+        "z_derivation_path": "m/32'/141'"
+      }
     },
     "required_confirmations": 3,
     "derivation_path": "m/44'/141'"

--- a/coins
+++ b/coins
@@ -13783,31 +13783,31 @@
     "avg_blocktime": 60,
     "mm2": 1,
     "protocol": {
-      "type": "ZHTLC",
-      "protocol_data": {
-        "consensus_params": {
-          "overwinter_activation_height": 0,
-          "sapling_activation_height": 1,
-          "blossom_activation_height": null,
-          "heartwood_activation_height": null,
-          "canopy_activation_height": null,
-          "coin_type": 133,
-          "hrp_sapling_extended_spending_key": "secret-extended-key-main",
-          "hrp_sapling_extended_full_viewing_key": "zxviews",
-          "hrp_sapling_payment_address": "zs",
-          "b58_pubkey_address_prefix": [
-            28,
-            184
-          ],
-          "b58_script_address_prefix": [
-            28,
-            189
-          ]
-        },
-        "z_derivation_path": "m/32'/141'"
-      }
+        "type": "ZHTLC",
+        "protocol_data": {
+            "consensus_params": {
+                "overwinter_activation_height": 0,
+                "sapling_activation_height": 1,
+                "blossom_activation_height": null,
+                "heartwood_activation_height": null,
+                "canopy_activation_height": null,
+                "coin_type": 133,
+                "hrp_sapling_extended_spending_key": "secret-extended-key-main",
+                "hrp_sapling_extended_full_viewing_key": "zxviews",
+                "hrp_sapling_payment_address": "zs",
+                "b58_pubkey_address_prefix": [
+                    28,
+                    184
+                ],
+                "b58_script_address_prefix": [
+                    28,
+                    189
+                ]
+            },
+            "z_derivation_path": "m/32'/141'"
+        }
     },
-    "required_confirmations": 3,
+    "required_confirmations": 1,
     "derivation_path": "m/44'/141'"
   },
   {


### PR DESCRIPTION
Note: Derivation paths are unconfirmed, PR will remain draft for now. 
- Removes obsolete fields (superseded by https://github.com/KomodoPlatform/komodo-defi-framework/pull/1922)
- Adds `derivation_path` and `z_derivation_path` which are required for HD wallets (https://github.com/KomodoPlatform/komodo-defi-framework/pull/1933)