### PR TITLE
use TCP for PND electrum

### DIFF
--- a/electrums/PND
+++ b/electrums/PND
@@ -1,7 +1,6 @@
 [
   {
-    "url": "electrum.thepandacoin.net:50002",
-    "protocol": "SSL",
+    "url": "electrum.thepandacoin.net:50001",
     "ws_url": "electrum.thepandacoin.net:443"
   }
 ]


### PR DESCRIPTION
SSL cert expired and no answer from PND... with TCP it at least works in Desktop and Mobile