### PR TITLE
generate SSL only coins_config.json

### DIFF
--- a/electrums/ARRR
+++ b/electrums/ARRR
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30008"
     },
     {
         "url": "electrum3.cipig.net:10008",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30008"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20008",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30008"
     },
     {
         "url": "electrum1.cipig.net:10008",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30008"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10008",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30008"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20008",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30008"
     }
 ]

--- a/electrums/AXE
+++ b/electrums/AXE
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30057"
     },
     {
         "url": "electrum3.cipig.net:20057",
@@ -21,7 +22,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30057"
     },
     {
         "url": "electrum2.cipig.net:20057",
@@ -33,7 +35,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30057"
     },
     {
         "url": "electrum3.cipig.net:10057",
@@ -44,8 +47,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30057"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10057",
@@ -56,8 +58,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30057"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10057",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30057"
+        ]
     }
 ]

--- a/electrums/BCH
+++ b/electrums/BCH
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30055"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20055",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30055"
     },
     {
         "url": "electrum2.cipig.net:10055",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30055"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20055",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30055"
     },
     {
         "url": "electrum3.cipig.net:20055",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30055"
     },
     {
         "url": "electrum3.cipig.net:10055",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30055"
+        ]
     }
 ]

--- a/electrums/BTC
+++ b/electrums/BTC
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30000"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10000",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30000"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20000",
@@ -33,7 +31,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30000"
     },
     {
         "url": "electrum2.cipig.net:20000",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30000"
     },
     {
         "url": "electrum2.cipig.net:10000",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30000"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20000",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30000"
     }
 ]

--- a/electrums/BTE
+++ b/electrums/BTE
@@ -13,9 +13,9 @@
     "url": "electrumx6.scalaris.info:20002",
     "protocol": "SSL",
     "contact": [
-	  { "email": "mraksoll@gmail.com" },
-	  { "discord": "mraksoll#0596" },
-	  { "github": "https://github.com/bitweb-project/electrumx/issues" }
+        { "email": "mraksoll@gmail.com" },
+        { "discord": "mraksoll#0596" },
+        { "github": "https://github.com/bitweb-project/electrumx/issues" }
     ],
     "ws_url": "electrumx6.scalaris.info:20003"
   },
@@ -23,9 +23,9 @@
     "url": "electrumx7.scalaris.info:20002",
     "protocol": "SSL",
     "contact": [
-	  { "email": "mraksoll@gmail.com" },
-	  { "discord": "mraksoll#0596" },
-	  { "github": "https://github.com/bitweb-project/electrumx/issues" }
+        { "email": "mraksoll@gmail.com" },
+        { "discord": "mraksoll#0596" },
+        { "github": "https://github.com/bitweb-project/electrumx/issues" }
     ],
     "ws_url": "electrumx7.scalaris.info:20003"
   }

--- a/electrums/CCL
+++ b/electrums/CCL
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30029"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20029",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30029"
     },
     {
         "url": "electrum2.cipig.net:20029",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30029"
     },
     {
         "url": "electrum1.cipig.net:10029",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30029"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20029",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30029"
     },
     {
         "url": "electrum2.cipig.net:10029",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30029"
+        ]
     }
 ]

--- a/electrums/CHIPS
+++ b/electrums/CHIPS
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30053"
     },
     {
         "url": "electrum1.cipig.net:20053",
@@ -21,7 +22,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30053"
     },
     {
         "url": "electrum3.cipig.net:20053",
@@ -33,7 +35,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30053"
     },
     {
         "url": "electrum1.cipig.net:10053",
@@ -44,8 +47,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30053"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10053",
@@ -56,8 +58,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30053"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10053",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30053"
+        ]
     }
 ]

--- a/electrums/CY
+++ b/electrums/CY
@@ -4,12 +4,8 @@
 	"protocol": "SSL",
 	"ws_url": "electrum01.cyberyen.work:50004",
 	"contact": [
-	    {
-		"email": "ruaxxx@ruaxxx.com"
-	    },
-	    {
-		"discord": "ruaxxx#3151"
-	    }
+	    {"email": "ruaxxx@ruaxxx.com"},
+	    {"discord": "ruaxxx#3151"}
 	]
     },
     {
@@ -17,12 +13,8 @@
 	"protocol": "SSL",
 	"ws_url": "electrum02.cyberyen.work:50004",
 	"contact": [
-	    {
-		"email": "ruaxxx@ruaxxx.com"
-	    },
-	    {
-		"discord": "ruaxxx#3151"
-	    }
+	    {"email": "ruaxxx@ruaxxx.com"},
+	    {"discord": "ruaxxx#3151"}
 	]
     },
     {
@@ -30,12 +22,8 @@
 	"protocol": "SSL",
 	"ws_url": "electrum03.cyberyen.work:50004",
 	"contact": [
-	    {
-		"email": "ruaxxx@ruaxxx.com"
-	    },
-	    {
-		"discord": "ruaxxx#3151"
-	    }
+	    {"email": "ruaxxx@ruaxxx.com"},
+	    {"discord": "ruaxxx#3151"}
 	]
     }
 ]

--- a/electrums/DASH
+++ b/electrums/DASH
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30061"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10061",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30061"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10061",
@@ -32,8 +30,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30061"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20061",
@@ -45,7 +42,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30061"
     },
     {
         "url": "electrum1.cipig.net:20061",
@@ -57,7 +55,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30061"
     },
     {
         "url": "electrum2.cipig.net:20061",
@@ -69,7 +68,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30061"
     }
 ]
 

--- a/electrums/DGB
+++ b/electrums/DGB
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30059"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20059",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30059"
     },
     {
         "url": "electrum3.cipig.net:20059",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30059"
     },
     {
         "url": "electrum3.cipig.net:10059",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30059"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20059",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30059"
     },
     {
         "url": "electrum1.cipig.net:10059",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30059"
+        ]
     }
 ]

--- a/electrums/DOGE
+++ b/electrums/DOGE
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30060"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10060",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30060"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10060",
@@ -32,8 +30,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30060"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20060",
@@ -45,7 +42,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30060"
     },
     {
         "url": "electrum3.cipig.net:20060",
@@ -57,7 +55,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30060"
     },
     {
         "url": "electrum1.cipig.net:20060",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30060"
     }
 ]

--- a/electrums/ECA
+++ b/electrums/ECA
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30052"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10052",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30052"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20052",
@@ -33,7 +31,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30052"
     },
     {
         "url": "electrum2.cipig.net:20052",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30052"
     },
     {
         "url": "electrum3.cipig.net:10052",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30052"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20052",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30052"
     }
 ]

--- a/electrums/EMC2
+++ b/electrums/EMC2
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30062"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10062",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30062"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20062",
@@ -33,7 +31,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30062"
     },
     {
         "url": "electrum1.cipig.net:20062",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30062"
     },
     {
         "url": "electrum1.cipig.net:10062",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30062"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20062",
@@ -69,7 +68,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30062"
     }
 ]
 

--- a/electrums/FTC
+++ b/electrums/FTC
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30054"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10054",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30054"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20054",
@@ -33,7 +31,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30054"
     },
     {
         "url": "electrum2.cipig.net:20054",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30054"
     },
     {
         "url": "electrum2.cipig.net:10054",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30054"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20054",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30054"
     }
 ]

--- a/electrums/GLEEC
+++ b/electrums/GLEEC
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30022"
     },
     {
         "url": "electrum1.cipig.net:10022",
@@ -21,8 +22,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30022"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10022",
@@ -34,8 +34,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30022"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10022",
@@ -47,8 +46,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30022"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20022",
@@ -60,7 +58,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30022"
     },
     {
         "url": "electrum2.cipig.net:20022",
@@ -72,7 +71,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30022"
     }
 ]
 

--- a/electrums/GRMS
+++ b/electrums/GRMS
@@ -12,7 +12,8 @@
 					{
                         "github": "Miner113"
                     }
-                ]
+                ],
+                "ws_url": "electrum.grms.pw:50004"
             },
 			{
                 "url": "electrum.grms.pw:17485",
@@ -26,8 +27,7 @@
 					{
                         "github": "Miner113"
                     }
-                ],
-                "ws_url": "electrum.grms.pw:50004"
+                ]
             },
 			{
                 "url": "electrum1.grms.pw:50002",
@@ -42,7 +42,8 @@
 					{
                         "github": "Miner113"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.grms.pw:50004"
             },
 			{
                 "url": "electrum1.grms.pw:17485",
@@ -56,8 +57,7 @@
 					{
                         "github": "Miner113"
                     }
-                ],
-                "ws_url": "electrum1.grms.pw:50004"
+                ]
             },
 			{
                 "url": "electrum2.grms.pw:50002",
@@ -72,7 +72,8 @@
 					{
                         "github": "Miner113"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.grms.pw:50004"
             },
 			{
                 "url": "electrum2.grms.pw:17485",
@@ -86,8 +87,7 @@
 					{
                         "github": "Miner113"
                     }
-                ],
-                "ws_url": "electrum2.grms.pw:50004"
+                ]
             },
 			{
                 "url": "electrum3.grms.pw:50002",
@@ -102,7 +102,8 @@
 					{
                         "github": "Miner113"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.grms.pw:50004"
             },
 			{
                 "url": "electrum3.grms.pw:17485",
@@ -116,7 +117,6 @@
 					{
                         "github": "Miner113"
                     }
-                ],
-                "ws_url": "electrum3.grms.pw:50004"
+                ]
             }
 ]

--- a/electrums/KMD
+++ b/electrums/KMD
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30001"
     },
     {
         "url": "electrum3.cipig.net:10001",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30001"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20001",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30001"
     },
     {
         "url": "electrum1.cipig.net:10001",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30001"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10001",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30001"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20001",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30001"
     }
 ]

--- a/electrums/KOIN
+++ b/electrums/KOIN
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30024"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20024",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30024"
     },
     {
         "url": "electrum2.cipig.net:10024",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30024"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20024",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30024"
     },
     {
         "url": "electrum3.cipig.net:20024",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30024"
     },
     {
         "url": "electrum1.cipig.net:10024",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30024"
+        ]
     }
 ]

--- a/electrums/LABS
+++ b/electrums/LABS
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30019"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20019",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30019"
     },
     {
         "url": "electrum2.cipig.net:20019",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30019"
     },
     {
         "url": "electrum1.cipig.net:10019",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30019"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10019",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30019"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20019",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30019"
     }
 ]

--- a/electrums/LBC
+++ b/electrums/LBC
@@ -1,29 +1,29 @@
 [
     {
-        "url": "electrum1.cipig.net:10067",
-        "ws_url": "electrum1.cipig.net:30067"
+        "url": "electrum1.cipig.net:10067"
     },
     {
-        "url": "electrum2.cipig.net:10067",
-        "ws_url": "electrum2.cipig.net:30067"
+        "url": "electrum2.cipig.net:10067"
     },
     {
-        "url": "electrum3.cipig.net:10067",
-        "ws_url": "electrum3.cipig.net:30067"
+        "url": "electrum3.cipig.net:10067"
     },
     {
         "url": "electrum1.cipig.net:20067",
         "disable_cert_verification": false,
-        "protocol": "SSL"
+        "protocol": "SSL",
+        "ws_url": "electrum1.cipig.net:30067"
     },
     {
         "url": "electrum2.cipig.net:20067",
         "disable_cert_verification": false,
-        "protocol": "SSL"
+        "protocol": "SSL",
+        "ws_url": "electrum2.cipig.net:30067"
     },
     {
         "url": "electrum3.cipig.net:20067",
         "disable_cert_verification": false,
-        "protocol": "SSL"
+        "protocol": "SSL",
+        "ws_url": "electrum3.cipig.net:30067"
   }
 ]

--- a/electrums/LTC
+++ b/electrums/LTC
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30063"
     },
     {
         "url": "electrum3.cipig.net:20063",
@@ -21,7 +22,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30063"
     },
     {
         "url": "electrum2.cipig.net:10063",
@@ -32,8 +34,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30063"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10063",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30063"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20063",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30063"
     },
     {
         "url": "electrum1.cipig.net:10063",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30063"
+        ]
     }
 ]

--- a/electrums/MCL
+++ b/electrums/MCL
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30023"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20023",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30023"
     },
     {
         "url": "electrum3.cipig.net:10023",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30023"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20023",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30023"
     },
     {
         "url": "electrum2.cipig.net:20023",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30023"
     },
     {
         "url": "electrum1.cipig.net:10023",
@@ -68,8 +69,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30023"
+        ]
     }
 ]
 

--- a/electrums/NFTX
+++ b/electrums/NFTX
@@ -9,10 +9,11 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ]
+                ],
+                "ws_url": "electrum.nftx.pw:50004"
             },
 			{
                 "url": "electrum.nftx.pw:17485",
@@ -23,11 +24,10 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ],
-                "ws_url": "electrum.nftx.pw:50004"
+                ]
             },
 			{
                 "url": "electrum1.nftx.pw:50002",
@@ -39,10 +39,11 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.nftx.pw:50004"
             },
 			{
                 "url": "electrum1.nftx.pw:17485",
@@ -53,11 +54,10 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ],
-                "ws_url": "electrum1.nftx.pw:50004"
+                ]
             },
 			{
                 "url": "electrum2.nftx.pw:50002",
@@ -69,10 +69,11 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.nftx.pw:50004"
             },
 			{
                 "url": "electrum2.nftx.pw:17485",
@@ -83,11 +84,10 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ],
-                "ws_url": "electrum2.nftx.pw:50004"
+                ]
             },
 			{
                 "url": "electrum3.nftx.pw:50002",
@@ -99,10 +99,11 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.nftx.pw:50004"
             },
 			{
                 "url": "electrum3.nftx.pw:17485",
@@ -113,10 +114,9 @@
                     {
                         "discord": "nftx-sergei#1197"
                     },
-		    {
+		            {
                         "github": "nftx-sergei"
                     }
-                ],
-                "ws_url": "electrum3.nftx.pw:50004"
+                ]
             }
 ]

--- a/electrums/QTUM
+++ b/electrums/QTUM
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30050"
     },
     {
         "url": "electrum3.cipig.net:10050",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30050"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10050",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30050"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20050",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30050"
     },
     {
         "url": "electrum2.cipig.net:10050",
@@ -56,8 +56,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30050"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20050",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30050"
     }
 ]

--- a/electrums/RVN
+++ b/electrums/RVN
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30051"
     },
     {
         "url": "electrum1.cipig.net:10051",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30051"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10051",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30051"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10051",
@@ -44,8 +43,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30051"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20051",
@@ -57,7 +55,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30051"
     },
     {
         "url": "electrum2.cipig.net:20051",
@@ -69,6 +68,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30051"
     }
 ]

--- a/electrums/SPACE
+++ b/electrums/SPACE
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30011"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20011",
@@ -21,7 +20,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30011"
     },
     {
         "url": "electrum3.cipig.net:20011",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30011"
     },
     {
         "url": "electrum2.cipig.net:20011",
@@ -45,7 +46,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30011"
     },
     {
         "url": "electrum3.cipig.net:10011",
@@ -56,8 +58,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30011"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10011",
@@ -68,8 +69,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30011"
+        ]
     }
 ]
 

--- a/electrums/SUPERNET
+++ b/electrums/SUPERNET
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30005"
     },
     {
         "url": "electrum3.cipig.net:20005",
@@ -21,7 +22,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30005"
     },
     {
         "url": "electrum1.cipig.net:10005",
@@ -32,8 +34,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30005"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20005",
@@ -45,7 +46,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30005"
     },
     {
         "url": "electrum2.cipig.net:10005",
@@ -56,8 +58,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30005"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10005",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30005"
+        ]
     }
 ]

--- a/electrums/SYS
+++ b/electrums/SYS
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30064"
     },
     {
         "url": "electrum1.cipig.net:10064",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30064"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20064",
@@ -33,7 +33,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30064"
     },
     {
         "url": "electrum2.cipig.net:10064",
@@ -44,8 +45,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30064"
+        ]
     },
     {
         "url": "electrum3.cipig.net:20064",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30064"
     },
     {
         "url": "electrum3.cipig.net:10064",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30064"
+        ]
     }
 ]

--- a/electrums/TKL
+++ b/electrums/TKL
@@ -9,7 +9,8 @@
             {
                 "discord": "chmex#0686"
             }
-        ]
+        ],
+        "ws_url": "2.eu.tokel.electrum.dexstats.info:9077"
     },
     {
         "url": "1.eu.tokel.electrum.dexstats.info:10077",
@@ -20,8 +21,7 @@
             {
                 "discord": "chmex#0686"
             }
-        ],
-        "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
+        ]
     },
     {
         "url": "2.eu.tokel.electrum.dexstats.info:10077",
@@ -32,8 +32,7 @@
             {
                 "discord": "chmex#0686"
             }
-        ],
-        "ws_url": "2.eu.tokel.electrum.dexstats.info:9077"
+        ]
     },
     {
         "url": "1.eu.tokel.electrum.dexstats.info:11077",
@@ -45,7 +44,8 @@
             {
                 "discord": "chmex#0686"
             }
-        ]
+        ],
+        "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
     }
 ]
 

--- a/electrums/VOTE2023
+++ b/electrums/VOTE2023
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30002"
     },
     {
         "url": "electrum2.cipig.net:20002",
@@ -21,7 +22,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30002"
     },
     {
         "url": "electrum2.cipig.net:10002",
@@ -32,8 +34,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30002"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20002",
@@ -45,7 +46,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30002"
     },
     {
         "url": "electrum3.cipig.net:10002",
@@ -56,8 +58,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30002"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10002",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30002"
+        ]
     }
 ]

--- a/electrums/XMY
+++ b/electrums/XMY
@@ -1,11 +1,11 @@
 [
     {
         "url": "lenoir.ecoincore.com:10891",
-        "protocol": "TCP",
-        "ws_url": "lenoir.ecoincore.com:10894"
+        "protocol": "TCP"
     },
     {
         "url": "lenoir.ecoincore.com:10892",
-        "protocol": "SSL"
+        "protocol": "SSL",
+        "ws_url": "lenoir.ecoincore.com:10894"
     }
 ]

--- a/electrums/ZEC
+++ b/electrums/ZEC
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30058"
     },
     {
         "url": "electrum2.cipig.net:10058",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30058"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10058",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30058"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20058",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30058"
     },
     {
         "url": "electrum1.cipig.net:20058",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30058"
     },
     {
         "url": "electrum1.cipig.net:10058",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30058"
+        ]
     }
 ]

--- a/electrums/ZER
+++ b/electrums/ZER
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30065"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10065",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30065"
+        ]
     },
     {
         "url": "electrum1.cipig.net:20065",
@@ -33,7 +31,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30065"
     },
     {
         "url": "electrum2.cipig.net:20065",
@@ -45,7 +44,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30065"
     },
     {
         "url": "electrum3.cipig.net:20065",
@@ -57,7 +57,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30065"
     },
     {
         "url": "electrum1.cipig.net:10065",
@@ -68,7 +69,6 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30065"
+        ]
     }
 ]

--- a/electrums/ZET
+++ b/electrums/ZET
@@ -2,11 +2,11 @@
     {
         "url": "zeta-seed-c.zetacoin.tech:50012",
         "protocol": "SSL",
-        "disable_cert_verification": false
+        "disable_cert_verification": false,
+        "ws_url": "207.180.252.200:50013"
     },
     {
         "url": "207.180.252.200:50011",
-        "protocol": "TCP",
-        "ws_url": "207.180.252.200:50013"
+        "protocol": "TCP"
     }
 ]

--- a/electrums/ZOMBIE
+++ b/electrums/ZOMBIE
@@ -8,8 +8,7 @@
          {
             "discord":"smk#7640"
          }
-      ],
-      "ws_url":"zombie.dragonhound.info:30058"
+      ]
    },
    {
       "url":"zombie.dragonhound.info:20033",
@@ -33,8 +32,7 @@
          {
             "discord":"smk#7640"
          }
-      ],
-      "ws_url":"zombie.dragonhound.info:30059"
+      ]
    },
    {
       "url":"zombie.dragonhound.info:20133",

--- a/electrums/tBTC
+++ b/electrums/tBTC
@@ -8,8 +8,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30068"
+        ]
     },
     {
         "url": "electrum3.cipig.net:10068",
@@ -20,8 +19,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30068"
+        ]
     },
     {
         "url": "testnet.aranguren.org:51001",
@@ -36,8 +34,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30068"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20068",
@@ -49,7 +46,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30068"
     },
     {
         "url": "electrum1.cipig.net:20068",
@@ -61,7 +59,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30068"
     },
     {
         "url": "electrum3.cipig.net:20068",
@@ -73,7 +72,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30068"
     }
 ]
 

--- a/electrums/tQTUM
+++ b/electrums/tQTUM
@@ -9,7 +9,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum3.cipig.net:30071"
     },
     {
         "url": "electrum3.cipig.net:10071",
@@ -20,8 +21,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum3.cipig.net:30071"
+        ]
     },
     {
         "url": "electrum1.cipig.net:10071",
@@ -32,8 +32,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum1.cipig.net:30071"
+        ]
     },
     {
         "url": "electrum2.cipig.net:10071",
@@ -44,8 +43,7 @@
             {
                 "discord": "cipi#4502"
             }
-        ],
-        "ws_url": "electrum2.cipig.net:30071"
+        ]
     },
     {
         "url": "electrum2.cipig.net:20071",
@@ -57,7 +55,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum2.cipig.net:30071"
     },
     {
         "url": "electrum1.cipig.net:20071",
@@ -69,7 +68,8 @@
             {
                 "discord": "cipi#4502"
             }
-        ]
+        ],
+        "ws_url": "electrum1.cipig.net:30071"
     }
 ]
 

--- a/utils/coins_config.json
+++ b/utils/coins_config.json
@@ -8538,6 +8538,51 @@
         ],
         "explorer_block_url": "block/"
     },
+    "CLC": {
+        "coin": "CLC",
+        "type": "Smart Chain",
+        "name": "Collider Coin",
+        "coinpaprika_id": "clc-collider-coin",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://clc.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "CLC",
+        "fname": "Collider Coin",
+        "rpcport": 31034,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "requires_notarization": false,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrumx.cryptocollider.com:10001",
+                "contact": [
+                    {
+                        "email": "electrumx@cryptocollider.com"
+                    },
+                    {
+                        "discord": "collider#6160"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "COMP-AVX20": {
         "coin": "COMP-AVX20",
         "type": "AVX-20",
@@ -9425,7 +9470,7 @@
             {
                 "url": "electrum02.cyberyen.work:50002",
                 "protocol": "SSL",
-                "ws_url": "electrum03.cyberyen.work:50004",
+                "ws_url": "electrum02.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9436,9 +9481,9 @@
                 ]
             },
             {
-                "url": "electrum01.cyberyen.work:50002",
+                "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
-                "ws_url": "electrum01.cyberyen.work:50004",
+                "ws_url": "electrum03.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9494,7 +9539,7 @@
             {
                 "url": "electrum02.cyberyen.work:50002",
                 "protocol": "SSL",
-                "ws_url": "electrum03.cyberyen.work:50004",
+                "ws_url": "electrum02.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9505,9 +9550,9 @@
                 ]
             },
             {
-                "url": "electrum01.cyberyen.work:50002",
+                "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
-                "ws_url": "electrum01.cyberyen.work:50004",
+                "ws_url": "electrum03.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -16569,18 +16614,6 @@
                 ]
             },
             {
-                "url": "electrum32.groestlcoin.org:50001",
-                "ws_url": "electrum32.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -17025,18 +17058,6 @@
             {
                 "url": "electrum9.groestlcoin.org:50001",
                 "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum32.groestlcoin.org:50001",
-                "ws_url": "electrum32.groestlcoin.org:50004",
                 "contact": [
                     {
                         "email": "jackielove4u@hotmail.com"
@@ -44029,7 +44050,7 @@
     },
     "MAZA": {
         "coin": "MAZA",
-        "type": "UTXO",
+ 74       "type": "UTXO",
         "name": "MazaCoin",
         "coinpaprika_id": "maza-maza",
         "coingecko_id": "maza",
@@ -44069,10 +44090,7 @@
                 "url": "electrumx.mazanode.com:50001",
                 "contact": [
                     {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
+                        "email": "brian@mazacoin.org"
                     }
                 ]
             },
@@ -44092,13 +44110,10 @@
                 "protocol": "SSL",
                 "contact": [
                     {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
+                        "email": "brian@mazacoin.org"
                     }
                 ],
-                "ws_url": "electrumx2.mazacha.in:50005"
+                "ws_url": "electrumx.mazanode.com:50005"
             },
             {
                 "url": "electrumx2.mazacha.in:50002",
@@ -44111,7 +44126,7 @@
                         "discord": "sherm77#5923"
                     }
                 ],
-                "ws_url": "electrumx1.mazacha.in:50005"
+                "ws_url": "electrumx2.mazacha.in:50005"
             }
         ],
         "explorer_block_url": "block/"

--- a/utils/coins_config.json
+++ b/utils/coins_config.json
@@ -1963,7 +1963,8 @@
         },
         "required_confirmations": 2,
         "requires_notarization": true,
-        "check_point_block": 1900000,
+        "checkpoint_height": 1900000,
+        "checkpoint_blocktime": 1652512363,
         "electrum": [
             {
                 "url": "electrum1.cipig.net:10008",
@@ -6319,6 +6320,22 @@
         },
         "electrum": [
             {
+                "url": "electrumx.bitwebcore.net:20002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "mraksoll@gmail.com"
+                    },
+                    {
+                        "discord": "mraksoll#0596"
+                    },
+                    {
+                        "github": "https://github.com/bitweb-project/electrumx/issues"
+                    }
+                ],
+                "ws_url": "electrumx.bitwebcore.net:20003"
+            },
+            {
                 "url": "electrumx6.scalaris.info:20002",
                 "protocol": "SSL",
                 "contact": [
@@ -6387,6 +6404,22 @@
             "type": "UTXO"
         },
         "electrum": [
+            {
+                "url": "electrumx.bitwebcore.net:20002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "mraksoll@gmail.com"
+                    },
+                    {
+                        "discord": "mraksoll#0596"
+                    },
+                    {
+                        "github": "https://github.com/bitweb-project/electrumx/issues"
+                    }
+                ],
+                "ws_url": "electrumx.bitwebcore.net:20003"
+            },
             {
                 "url": "electrumx6.scalaris.info:20002",
                 "protocol": "SSL",
@@ -9435,19 +9468,6 @@
         },
         "electrum": [
             {
-                "url": "electrum01.cyberyen.work:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum01.cyberyen.work:50004",
-                "contact": [
-                    {
-                        "email": "ruaxxx@ruaxxx.com"
-                    },
-                    {
-                        "discord": "ruaxxx#3151"
-                    }
-                ]
-            },
-            {
                 "url": "electrum02.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum02.cyberyen.work:50004",
@@ -9464,6 +9484,19 @@
                 "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum03.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9517,19 +9550,6 @@
         },
         "electrum": [
             {
-                "url": "electrum01.cyberyen.work:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum01.cyberyen.work:50004",
-                "contact": [
-                    {
-                        "email": "ruaxxx@ruaxxx.com"
-                    },
-                    {
-                        "discord": "ruaxxx#3151"
-                    }
-                ]
-            },
-            {
                 "url": "electrum02.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum02.cyberyen.work:50004",
@@ -9546,6 +9566,19 @@
                 "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum03.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -11828,16 +11861,16 @@
                 "ws_url": "electrum2.egulden.org:50004"
             },
             {
+                "url": "electrum3.egulden.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "ws_url": "electrum3.egulden.org:50004"
+            },
+            {
                 "url": "holland.ecoincore.com:11017",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
                 "ws_url": "holland.ecoincore.com:11019"
-            },
-            {
-                "url": "lenoir.ecoincore.com:11017",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:11019"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -16002,6 +16035,26 @@
                 "ws_url": "electrum.maxpuig.com:50004"
             },
             {
+                "url": "fr.garlium.crapules.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "orpheas#1503"
+                    }
+                ]
+            },
+            {
+                "url": "pl.garlium.crapules.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "orpheas#1503"
+                    }
+                ]
+            },
+            {
                 "url": "uk.garlium.crapules.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -16587,6 +16640,18 @@
                 ]
             },
             {
+                "url": "electrum32.groestlcoin.org:50001",
+                "ws_url": "electrum32.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -17031,6 +17096,18 @@
             {
                 "url": "electrum9.groestlcoin.org:50001",
                 "ws_url": "electrum9.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
+                "url": "electrum32.groestlcoin.org:50001",
+                "ws_url": "electrum32.groestlcoin.org:50004",
                 "contact": [
                     {
                         "email": "jackielove4u@hotmail.com"
@@ -36892,14 +36969,6 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrumx1.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx2.vaporumcoin.us:50001",
                 "contact": [
                     {
@@ -36949,6 +37018,9 @@
         "electrum": [
             {
                 "url": "88.99.26.209:5028"
+            },
+            {
+                "url": "electrumx-brn.webhop.me:55001"
             },
             {
                 "url": "electrumx.javerity.com:5885",
@@ -37005,6 +37077,9 @@
         "electrum": [
             {
                 "url": "88.99.26.209:5028"
+            },
+            {
+                "url": "electrumx-brn.webhop.me:55001"
             },
             {
                 "url": "electrumx.javerity.com:5885",
@@ -38647,10 +38722,6 @@
             {
                 "url": "electrumx1.vanillacash.info:50011",
                 "ws_url": "electrumx1.vanillacash.info:50013"
-            },
-            {
-                "url": "electrumx2.vanillacash.info:50011",
-                "ws_url": "electrumx2.vanillacash.info:50013"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -44090,7 +44161,7 @@
         },
         "electrum": [
             {
-                "url": "electrum.seed.mazanode.com:50001",
+                "url": "electrumx.mazanode.com:50001",
                 "contact": [
                     {
                         "email": "brian@mazacoin.org"
@@ -44098,7 +44169,18 @@
                 ]
             },
             {
-                "url": "electrumx.mazanode.com:50001",
+                "url": "electrumx2.mazacha.in:50001",
+                "contact": [
+                    {
+                        "email": "contact@mazacoin.org"
+                    },
+                    {
+                        "discord": "sherm77#5923"
+                    }
+                ]
+            },
+            {
+                "url": "electrum.seed.mazanode.com:50001",
                 "contact": [
                     {
                         "email": "brian@mazacoin.org"
@@ -44117,27 +44199,6 @@
                 ]
             },
             {
-                "url": "electrumx2.mazacha.in:50001",
-                "contact": [
-                    {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
-                    }
-                ]
-            },
-            {
-                "url": "electrum.seed.mazanode.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "brian@mazacoin.org"
-                    }
-                ],
-                "ws_url": "electrum.seed.mazanode.com:50005"
-            },
-            {
                 "url": "electrumx.mazanode.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -44146,19 +44207,6 @@
                     }
                 ],
                 "ws_url": "electrumx.mazanode.com:50005"
-            },
-            {
-                "url": "electrumx1.mazacha.in:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
-                    }
-                ],
-                "ws_url": "electrumx1.mazacha.in:50005"
             },
             {
                 "url": "electrumx2.mazacha.in:50002",
@@ -44172,6 +44220,29 @@
                     }
                 ],
                 "ws_url": "electrumx2.mazacha.in:50005"
+            },
+            {
+                "url": "electrum.seed.mazanode.com:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ],
+                "ws_url": "electrum.seed.mazanode.com:50005"
+            },
+            {
+                "url": "electrumx1.mazacha.in:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "contact@mazacoin.org"
+                    },
+                    {
+                        "discord": "sherm77#5923"
+                    }
+                ],
+                "ws_url": "electrumx1.mazacha.in:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -44347,54 +44418,6 @@
                     }
                 ],
                 "ws_url": "electrum2-mainnet.evrmorecoin.org:50004"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "BKC": {
-        "coin": "BKC",
-        "type": "UTXO",
-        "name": "Bunkercoin",
-        "coinpaprika_id": "bkc-bunkercoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://bkcexplorer.bunker.mt/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Bunkercoin Signed Message:\n",
-        "fname": "Bunkercoin",
-        "rpcport": 22555,
-        "pubtype": 25,
-        "p2shtype": 22,
-        "wiftype": 158,
-        "txfee": 1000000,
-        "force_min_relay_fee": true,
-        "dust": 1000000,
-        "mm2": 1,
-        "required_confirmations": 10,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/3'",
-        "links": {
-            "github": "https://github.com/bunkercoin/bunkercoin",
-            "homepage": "https://bunkercoin.org"
-        },
-        "electrum": [
-            {
-                "url": "bunkerelectrum.bunker.mt:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "bunkermatty#5308"
-                    }
-                ]
             }
         ],
         "explorer_block_url": "block/"

--- a/utils/coins_config.json
+++ b/utils/coins_config.json
@@ -1975,8 +1975,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30008"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10008",
@@ -1987,8 +1986,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30008"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10008",
@@ -1999,8 +1997,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30008"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20008",
@@ -2012,7 +2009,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30008"
             },
             {
                 "url": "electrum2.cipig.net:20008",
@@ -2024,7 +2022,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30008"
             },
             {
                 "url": "electrum3.cipig.net:20008",
@@ -2036,7 +2035,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30008"
             }
         ],
         "explorer_block_url": "block/"
@@ -2716,8 +2716,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30057"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10057",
@@ -2728,8 +2727,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30057"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10057",
@@ -2740,8 +2738,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30057"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20057",
@@ -2753,7 +2750,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30057"
             },
             {
                 "url": "electrum2.cipig.net:20057",
@@ -2765,7 +2763,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30057"
             },
             {
                 "url": "electrum3.cipig.net:20057",
@@ -2777,7 +2776,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30057"
             }
         ],
         "explorer_block_url": "block/"
@@ -3887,8 +3887,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30055"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10055",
@@ -3899,8 +3898,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30055"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10055",
@@ -3911,8 +3909,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30055"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20055",
@@ -3924,7 +3921,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30055"
             },
             {
                 "url": "electrum2.cipig.net:20055",
@@ -3936,7 +3934,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30055"
             },
             {
                 "url": "electrum3.cipig.net:20055",
@@ -3948,7 +3947,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30055"
             }
         ],
         "explorer_block_url": "block/"
@@ -4349,6 +4349,46 @@
         "token_id": "bb553ac2ac7af0fcd4f24f9dfacc7f925bfb1446c6e18c7966db95a8d50fb378",
         "parent_coin": "SLP",
         "token_address_url": "token/",
+        "explorer_block_url": "block/"
+    },
+    "BBK": {
+        "coin": "BBK",
+        "type": "UTXO",
+        "name": "BitBlocks",
+        "coinpaprika_id": "bbk-bitblocks",
+        "coingecko_id": "",
+        "livecoinwatch_id": "BBK",
+        "explorer_url": "https://bbk.ccore.online/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": true,
+        "sign_message_prefix": "DarkNet Signed Message:\n",
+        "fname": "BitBlocks",
+        "rpcport": 59768,
+        "pubtype": 25,
+        "p2shtype": 85,
+        "wiftype": 107,
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "links": {
+            "github": "https://github.com/BitBlocksProject/BitBlocks",
+            "homepage": "https://bitblocksproject.com"
+        },
+        "electrum": [
+            {
+                "url": "bbk-one.ewm-cx.net:50001",
+                "protocol": "TCP"
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "BBK-BEP20": {
@@ -5940,8 +5980,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30000"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10000",
@@ -5952,8 +5991,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30000"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10000",
@@ -5964,8 +6002,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20000",
@@ -5977,7 +6014,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30000"
             },
             {
                 "url": "electrum2.cipig.net:20000",
@@ -5989,7 +6027,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30000"
             },
             {
                 "url": "electrum3.cipig.net:20000",
@@ -6001,7 +6040,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30000"
             }
         ],
         "explorer_block_url": "block/"
@@ -6057,8 +6097,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30000"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10000",
@@ -6069,8 +6108,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30000"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10000",
@@ -6081,8 +6119,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20000",
@@ -6094,7 +6131,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30000"
             },
             {
                 "url": "electrum2.cipig.net:20000",
@@ -6106,7 +6144,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30000"
             },
             {
                 "url": "electrum3.cipig.net:20000",
@@ -6118,7 +6157,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30000"
             }
         ],
         "explorer_block_url": "block/"
@@ -7485,8 +7525,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30029"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10029",
@@ -7497,8 +7536,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30029"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10029",
@@ -7509,8 +7547,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30029"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20029",
@@ -7522,7 +7559,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30029"
             },
             {
                 "url": "electrum2.cipig.net:20029",
@@ -7534,7 +7572,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30029"
             },
             {
                 "url": "electrum3.cipig.net:20029",
@@ -7546,7 +7585,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30029"
             }
         ],
         "explorer_block_url": "block/"
@@ -7590,12 +7630,6 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "lenoir.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
-            },
-            {
                 "url": "miami.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -7616,6 +7650,12 @@
                 "protocol": "SSL",
                 "disable_cert_verification": true,
                 "ws_url": "woolloomooloo.ecoincore.com:34335"
+            },
+            {
+                "url": "lenoir.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "ws_url": "lenoir.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7663,12 +7703,6 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "lenoir.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
-            },
-            {
                 "url": "miami.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -7689,6 +7723,12 @@
                 "protocol": "SSL",
                 "disable_cert_verification": true,
                 "ws_url": "woolloomooloo.ecoincore.com:34335"
+            },
+            {
+                "url": "lenoir.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "ws_url": "lenoir.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -8172,8 +8212,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30053"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10053",
@@ -8184,8 +8223,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30053"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10053",
@@ -8196,8 +8234,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30053"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20053",
@@ -8209,7 +8246,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30053"
             },
             {
                 "url": "electrum2.cipig.net:20053",
@@ -8221,7 +8259,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30053"
             },
             {
                 "url": "electrum3.cipig.net:20053",
@@ -8233,7 +8272,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30053"
             }
         ],
         "explorer_block_url": "block/"
@@ -9492,6 +9532,19 @@
                         "discord": "ruaxxx#3151"
                     }
                 ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -9553,6 +9606,19 @@
                 "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum03.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9978,8 +10044,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30061"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10061",
@@ -9990,8 +10055,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30061"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10061",
@@ -10002,8 +10066,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30061"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20061",
@@ -10015,7 +10078,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30061"
             },
             {
                 "url": "electrum2.cipig.net:20061",
@@ -10027,7 +10091,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30061"
             },
             {
                 "url": "electrum3.cipig.net:20061",
@@ -10039,7 +10104,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30061"
             }
         ],
         "explorer_block_url": "block/"
@@ -10374,8 +10440,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30059"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10059",
@@ -10386,8 +10451,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10059",
@@ -10398,8 +10462,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20059",
@@ -10411,7 +10474,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum2.cipig.net:20059",
@@ -10423,7 +10487,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum3.cipig.net:20059",
@@ -10435,7 +10500,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30059"
             }
         ],
         "explorer_block_url": "block/"
@@ -10490,8 +10556,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30059"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10059",
@@ -10502,8 +10567,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10059",
@@ -10514,8 +10578,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20059",
@@ -10527,7 +10590,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum2.cipig.net:20059",
@@ -10539,7 +10603,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum3.cipig.net:20059",
@@ -10551,7 +10616,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30059"
             }
         ],
         "explorer_block_url": "block/"
@@ -10916,8 +10982,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -10928,8 +10993,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -10940,8 +11004,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -10953,7 +11016,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -10965,7 +11029,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -10977,7 +11042,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -11210,8 +11276,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30060"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10060",
@@ -11222,8 +11287,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30060"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10060",
@@ -11234,8 +11298,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30060"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20060",
@@ -11247,7 +11310,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30060"
             },
             {
                 "url": "electrum2.cipig.net:20060",
@@ -11259,7 +11323,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30060"
             },
             {
                 "url": "electrum3.cipig.net:20060",
@@ -11271,7 +11336,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30060"
             }
         ],
         "explorer_block_url": "block/"
@@ -11731,8 +11797,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30052"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10052",
@@ -11743,8 +11808,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30052"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10052",
@@ -11755,8 +11819,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30052"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20052",
@@ -11768,7 +11831,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30052"
             },
             {
                 "url": "electrum2.cipig.net:20052",
@@ -11780,7 +11844,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30052"
             },
             {
                 "url": "electrum3.cipig.net:20052",
@@ -11792,7 +11857,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30052"
             }
         ],
         "explorer_block_url": "block/"
@@ -12171,8 +12237,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30062"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10062",
@@ -12183,8 +12248,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30062"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10062",
@@ -12195,8 +12259,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30062"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20062",
@@ -12208,7 +12271,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30062"
             },
             {
                 "url": "electrum2.cipig.net:20062",
@@ -12220,7 +12284,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30062"
             },
             {
                 "url": "electrum3.cipig.net:20062",
@@ -12232,7 +12297,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30062"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -14447,8 +14513,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30054"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10054",
@@ -14459,8 +14524,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30054"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10054",
@@ -14471,8 +14535,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20054",
@@ -14484,7 +14547,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30054"
             },
             {
                 "url": "electrum2.cipig.net:20054",
@@ -14496,7 +14560,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30054"
             },
             {
                 "url": "electrum3.cipig.net:20054",
@@ -14508,7 +14573,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30054"
             }
         ],
         "explorer_block_url": "block/"
@@ -14563,8 +14629,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30054"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10054",
@@ -14575,8 +14640,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30054"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10054",
@@ -14587,8 +14651,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20054",
@@ -14600,7 +14663,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30054"
             },
             {
                 "url": "electrum2.cipig.net:20054",
@@ -14612,7 +14676,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30054"
             },
             {
                 "url": "electrum3.cipig.net:20054",
@@ -14624,7 +14689,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30054"
             }
         ],
         "explorer_block_url": "block/"
@@ -15408,8 +15474,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30022"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10022",
@@ -15421,8 +15486,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30022"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10022",
@@ -15434,8 +15498,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30022"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20022",
@@ -15447,7 +15510,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30022"
             },
             {
                 "url": "electrum2.cipig.net:20022",
@@ -15459,7 +15523,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30022"
             },
             {
                 "url": "electrum3.cipig.net:20022",
@@ -15471,7 +15536,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30022"
             }
         ],
         "explorer_block_url": "block/"
@@ -16614,6 +16680,18 @@
                 ]
             },
             {
+                "url": "electrum32.groestlcoin.org:50001",
+                "ws_url": "electrum32.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -17058,6 +17136,18 @@
             {
                 "url": "electrum9.groestlcoin.org:50001",
                 "ws_url": "electrum9.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
+                "url": "electrum32.groestlcoin.org:50001",
+                "ws_url": "electrum32.groestlcoin.org:50004",
                 "contact": [
                     {
                         "email": "jackielove4u@hotmail.com"
@@ -20817,8 +20907,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30001"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10001",
@@ -20829,8 +20918,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30001"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10001",
@@ -20841,8 +20929,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30001"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20001",
@@ -20854,7 +20941,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30001"
             },
             {
                 "url": "electrum2.cipig.net:20001",
@@ -20866,7 +20954,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30001"
             },
             {
                 "url": "electrum3.cipig.net:20001",
@@ -20878,7 +20967,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30001"
             }
         ],
         "explorer_block_url": "block/",
@@ -21220,8 +21310,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30024"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10024",
@@ -21232,8 +21321,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30024"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10024",
@@ -21244,8 +21332,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30024"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20024",
@@ -21257,7 +21344,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30024"
             },
             {
                 "url": "electrum2.cipig.net:20024",
@@ -21269,7 +21357,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30024"
             },
             {
                 "url": "electrum3.cipig.net:20024",
@@ -21281,7 +21370,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30024"
             }
         ],
         "explorer_block_url": "block/"
@@ -21386,8 +21476,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30019"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10019",
@@ -21398,8 +21487,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30019"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10019",
@@ -21410,8 +21498,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30019"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20019",
@@ -21423,7 +21510,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30019"
             },
             {
                 "url": "electrum2.cipig.net:20019",
@@ -21435,7 +21523,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30019"
             },
             {
                 "url": "electrum3.cipig.net:20019",
@@ -21447,7 +21536,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30019"
             }
         ],
         "explorer_block_url": "block/"
@@ -21485,31 +21575,31 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
+                "url": "electrum1.cipig.net:10067"
             },
             {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
+                "url": "electrum2.cipig.net:10067"
             },
             {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
+                "url": "electrum3.cipig.net:10067"
             },
             {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum1.cipig.net:30067"
             },
             {
                 "url": "electrum2.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum2.cipig.net:30067"
             },
             {
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum3.cipig.net:30067"
             }
         ],
         "explorer_block_url": "block/"
@@ -21551,31 +21641,31 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
+                "url": "electrum1.cipig.net:10067"
             },
             {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
+                "url": "electrum2.cipig.net:10067"
             },
             {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
+                "url": "electrum3.cipig.net:10067"
             },
             {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum1.cipig.net:30067"
             },
             {
                 "url": "electrum2.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum2.cipig.net:30067"
             },
             {
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum3.cipig.net:30067"
             }
         ],
         "explorer_block_url": "block/"
@@ -22965,8 +23055,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30063"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10063",
@@ -22977,8 +23066,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30063"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10063",
@@ -22989,8 +23077,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20063",
@@ -23002,7 +23089,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30063"
             },
             {
                 "url": "electrum2.cipig.net:20063",
@@ -23014,7 +23102,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30063"
             },
             {
                 "url": "electrum3.cipig.net:20063",
@@ -23026,7 +23115,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30063"
             }
         ],
         "explorer_block_url": "block/"
@@ -23082,8 +23172,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30063"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10063",
@@ -23094,8 +23183,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30063"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10063",
@@ -23106,8 +23194,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20063",
@@ -23119,7 +23206,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30063"
             },
             {
                 "url": "electrum2.cipig.net:20063",
@@ -23131,7 +23219,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30063"
             },
             {
                 "url": "electrum3.cipig.net:20063",
@@ -23143,7 +23232,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30063"
             }
         ],
         "explorer_block_url": "block/"
@@ -24123,8 +24213,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30023"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10023",
@@ -24135,8 +24224,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30023"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10023",
@@ -24147,8 +24235,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30023"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20023",
@@ -24160,7 +24247,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30023"
             },
             {
                 "url": "electrum2.cipig.net:20023",
@@ -24172,7 +24260,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30023"
             },
             {
                 "url": "electrum3.cipig.net:20023",
@@ -24184,7 +24273,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30023"
             }
         ],
         "explorer_block_url": "block/"
@@ -26007,8 +26097,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -26019,8 +26108,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -26031,8 +26119,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -26044,7 +26131,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -26056,7 +26144,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -26068,7 +26157,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28155,8 +28245,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -28167,8 +28256,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -28179,8 +28267,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -28192,7 +28279,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -28204,7 +28292,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -28216,7 +28305,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28270,8 +28360,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -28282,8 +28371,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -28294,8 +28382,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -28307,7 +28394,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -28319,7 +28407,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -28331,7 +28420,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28385,8 +28475,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -28397,8 +28486,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -28409,8 +28497,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -28422,7 +28509,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -28434,7 +28522,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -28446,7 +28535,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28765,8 +28855,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10071",
@@ -28777,8 +28866,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10071",
@@ -28789,8 +28877,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20071",
@@ -28802,7 +28889,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30071"
             },
             {
                 "url": "electrum2.cipig.net:20071",
@@ -28814,7 +28902,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30071"
             },
             {
                 "url": "electrum3.cipig.net:20071",
@@ -28826,7 +28915,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -28882,8 +28972,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -28894,8 +28983,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -28906,8 +28994,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -28919,7 +29006,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -28931,7 +29019,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -28943,7 +29032,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -29001,8 +29091,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -29013,8 +29102,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -29025,8 +29113,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -29038,7 +29125,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -29050,7 +29138,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -29062,7 +29151,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -29191,8 +29281,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10071",
@@ -29203,8 +29292,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10071",
@@ -29215,8 +29303,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20071",
@@ -29228,7 +29315,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30071"
             },
             {
                 "url": "electrum2.cipig.net:20071",
@@ -29240,7 +29328,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30071"
             },
             {
                 "url": "electrum3.cipig.net:20071",
@@ -29252,7 +29341,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -29301,8 +29391,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10071",
@@ -29313,8 +29402,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10071",
@@ -29325,8 +29413,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20071",
@@ -29338,7 +29425,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30071"
             },
             {
                 "url": "electrum2.cipig.net:20071",
@@ -29350,7 +29438,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30071"
             },
             {
                 "url": "electrum3.cipig.net:20071",
@@ -29362,7 +29451,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -30529,8 +30619,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30051"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10051",
@@ -30541,8 +30630,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30051"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10051",
@@ -30553,8 +30641,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30051"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20051",
@@ -30566,7 +30653,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30051"
             },
             {
                 "url": "electrum2.cipig.net:20051",
@@ -30578,7 +30666,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30051"
             },
             {
                 "url": "electrum3.cipig.net:20051",
@@ -30590,7 +30679,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30051"
             }
         ],
         "explorer_block_url": "block/"
@@ -31455,8 +31545,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30011"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10011",
@@ -31467,8 +31556,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30011"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10011",
@@ -31479,8 +31567,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30011"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20011",
@@ -31492,7 +31579,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30011"
             },
             {
                 "url": "electrum2.cipig.net:20011",
@@ -31504,7 +31592,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30011"
             },
             {
                 "url": "electrum3.cipig.net:20011",
@@ -31516,7 +31605,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30011"
             }
         ],
         "explorer_block_url": "block/"
@@ -31687,8 +31777,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30005"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10005",
@@ -31699,8 +31788,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30005"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10005",
@@ -31711,8 +31799,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30005"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20005",
@@ -31724,7 +31811,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30005"
             },
             {
                 "url": "electrum2.cipig.net:20005",
@@ -31736,7 +31824,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30005"
             },
             {
                 "url": "electrum3.cipig.net:20005",
@@ -31748,7 +31837,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30005"
             }
         ],
         "explorer_block_url": "block/"
@@ -32410,8 +32500,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30064"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10064",
@@ -32422,8 +32511,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30064"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10064",
@@ -32434,8 +32522,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20064",
@@ -32447,7 +32534,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30064"
             },
             {
                 "url": "electrum2.cipig.net:20064",
@@ -32459,7 +32547,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30064"
             },
             {
                 "url": "electrum3.cipig.net:20064",
@@ -32471,7 +32560,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30064"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32527,8 +32617,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30064"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10064",
@@ -32539,8 +32628,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30064"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10064",
@@ -32551,8 +32639,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20064",
@@ -32564,7 +32651,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30064"
             },
             {
                 "url": "electrum2.cipig.net:20064",
@@ -32576,7 +32664,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30064"
             },
             {
                 "url": "electrum3.cipig.net:20064",
@@ -32588,7 +32677,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30064"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32710,8 +32800,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30068"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10068",
@@ -32722,8 +32811,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10068",
@@ -32734,8 +32822,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
+                ]
             },
             {
                 "url": "testnet.aranguren.org:51001",
@@ -32751,7 +32838,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30068"
             },
             {
                 "url": "electrum2.cipig.net:20068",
@@ -32763,7 +32851,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30068"
             },
             {
                 "url": "electrum3.cipig.net:20068",
@@ -32775,7 +32864,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -32823,8 +32913,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30068"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10068",
@@ -32835,8 +32924,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10068",
@@ -32847,8 +32935,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
+                ]
             },
             {
                 "url": "testnet.aranguren.org:51001",
@@ -32864,7 +32951,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30068"
             },
             {
                 "url": "electrum2.cipig.net:20068",
@@ -32876,7 +32964,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30068"
             },
             {
                 "url": "electrum3.cipig.net:20068",
@@ -32888,7 +32977,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -33275,8 +33365,18 @@
                     {
                         "discord": "chmex#0686"
                     }
-                ],
-                "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
+                ]
+            },
+            {
+                "url": "2.eu.tokel.electrum.dexstats.info:10077",
+                "contact": [
+                    {
+                        "email": "chmex@dexstats.info"
+                    },
+                    {
+                        "discord": "chmex#0686"
+                    }
+                ]
             },
             {
                 "url": "1.eu.tokel.electrum.dexstats.info:11077",
@@ -33288,7 +33388,21 @@
                     {
                         "discord": "chmex#0686"
                     }
-                ]
+                ],
+                "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
+            },
+            {
+                "url": "2.eu.tokel.electrum.dexstats.info:11077",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "chmex@dexstats.info"
+                    },
+                    {
+                        "discord": "chmex#0686"
+                    }
+                ],
+                "ws_url": "2.eu.tokel.electrum.dexstats.info:9077"
             }
         ],
         "explorer_block_url": "block/"
@@ -38053,12 +38167,12 @@
         "electrum": [
             {
                 "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
+                "protocol": "TCP"
             },
             {
                 "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "lenoir.ecoincore.com:10894"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38100,12 +38214,12 @@
         "electrum": [
             {
                 "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
+                "protocol": "TCP"
             },
             {
                 "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "lenoir.ecoincore.com:10894"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38761,8 +38875,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -38773,8 +38886,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -38785,8 +38897,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -38798,7 +38909,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -38810,7 +38922,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -38822,7 +38935,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -39447,8 +39561,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30058"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10058",
@@ -39459,8 +39572,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30058"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10058",
@@ -39471,8 +39583,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30058"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20058",
@@ -39484,7 +39595,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30058"
             },
             {
                 "url": "electrum2.cipig.net:20058",
@@ -39496,7 +39608,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30058"
             },
             {
                 "url": "electrum3.cipig.net:20058",
@@ -39508,7 +39621,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30058"
             }
         ],
         "explorer_block_url": "block/"
@@ -39556,8 +39670,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30065"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10065",
@@ -39568,8 +39681,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30065"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10065",
@@ -39580,8 +39692,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30065"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20065",
@@ -39593,7 +39704,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30065"
             },
             {
                 "url": "electrum2.cipig.net:20065",
@@ -39605,7 +39717,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30065"
             },
             {
                 "url": "electrum3.cipig.net:20065",
@@ -39617,7 +39730,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30065"
             }
         ],
         "explorer_block_url": "block/"
@@ -39717,8 +39831,7 @@
         "electrum": [
             {
                 "url": "207.180.252.200:50011",
-                "protocol": "TCP",
-                "ws_url": "207.180.252.200:50013"
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -40009,8 +40122,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40021,8 +40133,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40033,8 +40144,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40046,7 +40156,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40058,7 +40169,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40070,7 +40182,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40311,8 +40424,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40323,8 +40435,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40335,8 +40446,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40348,7 +40458,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40360,7 +40471,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40372,7 +40484,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40427,8 +40540,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40439,8 +40551,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40451,8 +40562,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40464,7 +40574,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40476,7 +40587,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40488,7 +40600,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40543,8 +40656,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40555,8 +40667,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40567,8 +40678,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40580,7 +40690,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40592,7 +40703,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40604,7 +40716,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40659,8 +40772,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40671,8 +40783,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40683,8 +40794,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40696,7 +40806,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40708,7 +40819,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40720,7 +40832,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40775,8 +40888,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40787,8 +40899,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40799,8 +40910,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40812,7 +40922,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40824,7 +40935,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40836,7 +40948,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40891,8 +41004,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -40903,8 +41015,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -40915,8 +41026,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -40928,7 +41038,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -40940,7 +41051,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -40952,7 +41064,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -41007,8 +41120,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -41019,8 +41131,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -41031,8 +41142,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -41044,7 +41154,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -41056,7 +41167,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -41068,7 +41180,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -41123,8 +41236,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10050",
@@ -41135,8 +41247,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10050",
@@ -41147,8 +41258,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20050",
@@ -41160,7 +41270,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30050"
             },
             {
                 "url": "electrum2.cipig.net:20050",
@@ -41172,7 +41283,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30050"
             },
             {
                 "url": "electrum3.cipig.net:20050",
@@ -41184,7 +41296,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -43465,8 +43578,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30002"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10002",
@@ -43477,8 +43589,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30002"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10002",
@@ -43489,8 +43600,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum3.cipig.net:30002"
+                ]
             },
             {
                 "url": "electrum1.cipig.net:20002",
@@ -43502,7 +43612,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30002"
             },
             {
                 "url": "electrum2.cipig.net:20002",
@@ -43514,7 +43625,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30002"
             },
             {
                 "url": "electrum3.cipig.net:20002",
@@ -43526,7 +43638,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30002"
             }
         ],
         "explorer_block_url": "block/"
@@ -43590,8 +43703,7 @@
                     {
                         "discord": "smk#7640"
                     }
-                ],
-                "ws_url": "zombie.dragonhound.info:30058"
+                ]
             },
             {
                 "url": "zombie.dragonhound.info:10133",
@@ -43602,8 +43714,7 @@
                     {
                         "discord": "smk#7640"
                     }
-                ],
-                "ws_url": "zombie.dragonhound.info:30059"
+                ]
             },
             {
                 "url": "zombie.dragonhound.info:20033",
@@ -44106,6 +44217,25 @@
                 ]
             },
             {
+                "url": "electrum.seed.mazanode.com:50001",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.mazacha.in:50001",
+                "contact": [
+                    {
+                        "email": "contact@mazacoin.org"
+                    },
+                    {
+                        "discord": "sherm77#5923"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx.mazanode.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -44127,6 +44257,29 @@
                     }
                 ],
                 "ws_url": "electrumx2.mazacha.in:50005"
+            },
+            {
+                "url": "electrum.seed.mazanode.com:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ],
+                "ws_url": "electrum.seed.mazanode.com:50005"
+            },
+            {
+                "url": "electrumx1.mazacha.in:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "contact@mazacoin.org"
+                    },
+                    {
+                        "discord": "sherm77#5923"
+                    }
+                ],
+                "ws_url": "electrumx1.mazacha.in:50005"
             }
         ],
         "explorer_block_url": "block/"

--- a/utils/coins_config.json
+++ b/utils/coins_config.json
@@ -7630,10 +7630,10 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "miami.ecoincore.com:34333",
+                "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
+                "ws_url": "lenoir.ecoincore.com:34335"
             },
             {
                 "url": "oakland.ecoincore.com:34333",
@@ -7652,10 +7652,10 @@
                 "ws_url": "woolloomooloo.ecoincore.com:34335"
             },
             {
-                "url": "lenoir.ecoincore.com:34333",
+                "url": "miami.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
+                "ws_url": "miami.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7703,10 +7703,10 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "miami.ecoincore.com:34333",
+                "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
+                "ws_url": "lenoir.ecoincore.com:34335"
             },
             {
                 "url": "oakland.ecoincore.com:34333",
@@ -7725,10 +7725,10 @@
                 "ws_url": "woolloomooloo.ecoincore.com:34335"
             },
             {
-                "url": "lenoir.ecoincore.com:34333",
+                "url": "miami.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
+                "ws_url": "miami.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"

--- a/utils/coins_config_ssl.json
+++ b/utils/coins_config_ssl.json
@@ -6457,10 +6457,10 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "miami.ecoincore.com:34333",
+                "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
+                "ws_url": "lenoir.ecoincore.com:34335"
             },
             {
                 "url": "oakland.ecoincore.com:34333",
@@ -6513,10 +6513,10 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "miami.ecoincore.com:34333",
+                "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
+                "ws_url": "lenoir.ecoincore.com:34335"
             },
             {
                 "url": "oakland.ecoincore.com:34333",

--- a/utils/coins_config_ssl.json
+++ b/utils/coins_config_ssl.json
@@ -132,15 +132,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -190,15 +181,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -251,24 +233,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -515,15 +479,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -579,24 +534,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -885,15 +822,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -943,15 +871,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -1008,24 +927,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1131,24 +1032,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1259,24 +1142,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1384,15 +1249,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1442,24 +1298,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1570,24 +1408,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1646,15 +1466,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -1801,15 +1612,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1859,24 +1661,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1967,7 +1751,8 @@
         "checkpoint_blocktime": 1652512363,
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10008",
+                "url": "electrum1.cipig.net:20008",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -1979,7 +1764,8 @@
                 "ws_url": "electrum1.cipig.net:30008"
             },
             {
-                "url": "electrum2.cipig.net:10008",
+                "url": "electrum2.cipig.net:20008",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -1991,42 +1777,6 @@
                 "ws_url": "electrum2.cipig.net:30008"
             },
             {
-                "url": "electrum3.cipig.net:10008",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30008"
-            },
-            {
-                "url": "electrum1.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20008",
                 "protocol": "SSL",
                 "contact": [
@@ -2036,7 +1786,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30008"
             }
         ],
         "explorer_block_url": "block/"
@@ -2079,15 +1830,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2139,15 +1881,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2301,15 +2034,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2436,15 +2160,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2489,30 +2204,6 @@
         },
         "derivation_path": "m/44'/921'",
         "electrum": [
-            {
-                "url": "electrum-ca.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
-            {
-                "url": "electrum-eu.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
-            {
-                "url": "electrum-us.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
             {
                 "url": "electrum-ca.avn.network:50002",
                 "protocol": "SSL",
@@ -2633,24 +2324,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2708,7 +2381,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10057",
+                "url": "electrum1.cipig.net:20057",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -2720,19 +2394,8 @@
                 "ws_url": "electrum1.cipig.net:30057"
             },
             {
-                "url": "electrum2.cipig.net:10057",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30057"
-            },
-            {
-                "url": "electrum3.cipig.net:10057",
+                "url": "electrum2.cipig.net:20057",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -2744,30 +2407,6 @@
                 "ws_url": "electrum3.cipig.net:30057"
             },
             {
-                "url": "electrum1.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20057",
                 "protocol": "SSL",
                 "contact": [
@@ -2777,7 +2416,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30057"
             }
         ],
         "explorer_block_url": "block/"
@@ -2819,15 +2459,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2886,24 +2517,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2920,44 +2533,6 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "AYA": {
-        "coin": "AYA",
-        "type": "UTXO",
-        "name": "Aryacoin",
-        "coinpaprika_id": "aya-aryacoin",
-        "coingecko_id": "aryacoin",
-        "livecoinwatch_id": "AYA",
-        "explorer_url": "https://explorer.aryacoin.io/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Aryacoin Signed Message:\n",
-        "fname": "Aryacoin",
-        "rpcport": 9332,
-        "pubtype": 23,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 54600,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/357'",
-        "electrum": [
-            {
-                "url": "88.99.26.209:5151"
             }
         ],
         "explorer_block_url": "block/"
@@ -2999,15 +2574,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3059,15 +2625,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3125,24 +2682,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -3296,15 +2835,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -3354,15 +2884,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3415,24 +2936,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -3636,24 +3139,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3711,15 +3196,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3879,7 +3355,8 @@
         "slp_prefix": "simpleledger",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10055",
+                "url": "electrum1.cipig.net:20055",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -3891,7 +3368,8 @@
                 "ws_url": "electrum1.cipig.net:30055"
             },
             {
-                "url": "electrum2.cipig.net:10055",
+                "url": "electrum2.cipig.net:20055",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -3903,42 +3381,6 @@
                 "ws_url": "electrum2.cipig.net:30055"
             },
             {
-                "url": "electrum3.cipig.net:10055",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30055"
-            },
-            {
-                "url": "electrum1.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20055",
                 "protocol": "SSL",
                 "contact": [
@@ -3948,7 +3390,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30055"
             }
         ],
         "explorer_block_url": "block/"
@@ -4127,24 +3570,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -4391,15 +3816,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4500,24 +3916,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -4576,15 +3974,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -4681,15 +4070,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4702,50 +4082,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/",
         "forex_id": "IDR"
-    },
-    "BITN": {
-        "coin": "BITN",
-        "type": "UTXO",
-        "name": "Bitnet",
-        "coinpaprika_id": "bit-bitnet",
-        "coingecko_id": "",
-        "livecoinwatch_id": "________BIT",
-        "explorer_url": "https://bitexplorer.io/",
-        "explorer_tx_url": "tx/",
-        "explorer_address_url": "address/",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Bitnet Signed Message:\n",
-        "fname": "Bitnet",
-        "rpcport": 9332,
-        "pubtype": 25,
-        "p2shtype": 22,
-        "wiftype": 158,
-        "txfee": 700000,
-        "segwit": true,
-        "bech32_hrp": "bit",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "bitexplorer.io:50001",
-                "protocol": "TCP",
-                "ws_url": "bitexplorer.io:50004",
-                "contact": [
-                    {
-                        "discord": "c4pt#7855"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
     },
     "BLK": {
         "coin": "BLK",
@@ -4781,30 +4117,6 @@
         },
         "derivation_path": "m/44'/10'",
         "electrum": [
-            {
-                "url": "electrum1.blackcoin.nl:10001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.blackcoin.nl:20001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.blackcoin.nl:30001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.blackcoin.nl:10002",
                 "protocol": "SSL",
@@ -4881,15 +4193,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4933,30 +4236,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrum1.blackcoin.nl:10011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.blackcoin.nl:20011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.blackcoin.nl:30011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.blackcoin.nl:10012",
                 "protocol": "SSL",
@@ -5030,15 +4309,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5050,49 +4320,6 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
-    },
-    "BOLI": {
-        "coin": "BOLI",
-        "type": "UTXO",
-        "name": "Bolivarcoin",
-        "coinpaprika_id": "boli-bolivarcoin",
-        "coingecko_id": "bolivarcoin",
-        "livecoinwatch_id": "BOLI",
-        "explorer_url": "https://chainz.cryptoid.info/boli/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "DarkCoin Signed Message:\n",
-        "fname": "Bolivarcoin",
-        "confpath": "USERHOME/.bolivarcoincore/bolivarcoin.conf",
-        "rpcport": 3563,
-        "pubtype": 85,
-        "p2shtype": 5,
-        "wiftype": 213,
-        "segwit": false,
-        "txfee": 10000,
-        "mm2": 1,
-        "required_confirmations": 3,
-        "avg_blocktime": 180,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/278'",
-        "links": {
-            "github": "https://github.com/BOLI-Project/BolivarCoin",
-            "homepage": "https://bolis.info"
-        },
-        "electrum": [
-            {
-                "url": "electrum2.bolivarcoin.tech:23001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "BONE-ERC20": {
         "coin": "BONE-ERC20",
@@ -5131,24 +4358,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5285,15 +4494,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5349,24 +4549,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5477,15 +4659,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5537,24 +4710,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5615,24 +4770,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5932,7 +5069,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10000",
+                "url": "electrum1.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -5944,7 +5082,8 @@
                 "ws_url": "electrum1.cipig.net:30000"
             },
             {
-                "url": "electrum2.cipig.net:10000",
+                "url": "electrum2.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -5956,42 +5095,6 @@
                 "ws_url": "electrum2.cipig.net:30000"
             },
             {
-                "url": "electrum3.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
-            },
-            {
-                "url": "electrum1.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20000",
                 "protocol": "SSL",
                 "contact": [
@@ -6001,7 +5104,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30000"
             }
         ],
         "explorer_block_url": "block/"
@@ -6049,7 +5153,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10000",
+                "url": "electrum1.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -6061,7 +5166,8 @@
                 "ws_url": "electrum1.cipig.net:30000"
             },
             {
-                "url": "electrum2.cipig.net:10000",
+                "url": "electrum2.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -6073,42 +5179,6 @@
                 "ws_url": "electrum2.cipig.net:30000"
             },
             {
-                "url": "electrum3.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
-            },
-            {
-                "url": "electrum1.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20000",
                 "protocol": "SSL",
                 "contact": [
@@ -6118,7 +5188,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30000"
             }
         ],
         "explorer_block_url": "block/"
@@ -6162,15 +5233,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -6181,51 +5243,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "BTCZ": {
-        "coin": "BTCZ",
-        "type": "UTXO",
-        "name": "BitcoinZ",
-        "coinpaprika_id": "btcz-bitcoinz",
-        "coingecko_id": "bitcoinz",
-        "livecoinwatch_id": "BTCZ",
-        "explorer_url": "https://explorer.btcz.rocks/",
-        "explorer_tx_url": "tx/",
-        "explorer_address_url": "address/",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "BitcoinZ Signed Message:\n",
-        "fname": "BitcoinZ",
-        "rpcport": 1979,
-        "taddr": 28,
-        "pubtype": 184,
-        "p2shtype": 189,
-        "wiftype": 128,
-        "txfee": 10000,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/177'",
-        "electrum": [
-            {
-                "url": "electrum2.btcz.rocks:50001",
-                "contact": [
-                    {
-                        "discord": "VandarGR#6065"
-                    }
-                ],
-                "ws_url": "electrum2.btcz.rocks:50004"
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "BTCZ-BEP20": {
@@ -6266,15 +5283,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6494,15 +5502,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -6553,15 +5552,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6619,24 +5609,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -6851,15 +5823,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -7050,24 +6013,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7125,15 +6070,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -7234,24 +6170,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7363,15 +6281,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -7424,15 +6333,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -7477,7 +6377,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10029",
+                "url": "electrum1.cipig.net:20029",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -7489,7 +6390,8 @@
                 "ws_url": "electrum1.cipig.net:30029"
             },
             {
-                "url": "electrum2.cipig.net:10029",
+                "url": "electrum2.cipig.net:20029",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -7501,42 +6403,6 @@
                 "ws_url": "electrum2.cipig.net:30029"
             },
             {
-                "url": "electrum3.cipig.net:10029",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30029"
-            },
-            {
-                "url": "electrum1.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20029",
                 "protocol": "SSL",
                 "contact": [
@@ -7546,7 +6412,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30029"
             }
         ],
         "explorer_block_url": "block/"
@@ -7585,11 +6452,6 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "chicago.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
                 "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -7605,17 +6467,6 @@
                 "url": "oakland.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true
-            },
-            {
-                "url": "seattle.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "woolloomooloo.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "woolloomooloo.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7658,11 +6509,6 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "chicago.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
                 "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -7678,17 +6524,6 @@
                 "url": "oakland.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true
-            },
-            {
-                "url": "seattle.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "woolloomooloo.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "woolloomooloo.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7731,24 +6566,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7864,24 +6681,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7940,15 +6739,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -8047,15 +6837,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -8066,71 +6847,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "CHTA": {
-        "coin": "CHTA",
-        "type": "UTXO",
-        "name": "Cheetahcoin",
-        "coinpaprika_id": "chta-cheetahcoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "CHTA",
-        "explorer_url": "http://chtaexplorer.mooo.com:3002/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Cheetahcoin",
-        "rpcport": 8536,
-        "pubtype": 28,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 40000,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 120,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/682'",
-        "electrum": [
-            {
-                "url": "electrum.shorelinecrypto.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.mooo.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.mooo.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "CHIPS": {
@@ -8164,7 +6880,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10053",
+                "url": "electrum1.cipig.net:20053",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -8176,7 +6893,8 @@
                 "ws_url": "electrum1.cipig.net:30053"
             },
             {
-                "url": "electrum2.cipig.net:10053",
+                "url": "electrum2.cipig.net:20053",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -8188,42 +6906,6 @@
                 "ws_url": "electrum2.cipig.net:30053"
             },
             {
-                "url": "electrum3.cipig.net:10053",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30053"
-            },
-            {
-                "url": "electrum1.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20053",
                 "protocol": "SSL",
                 "contact": [
@@ -8233,7 +6915,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30053"
             }
         ],
         "explorer_block_url": "block/"
@@ -8280,24 +6963,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8406,24 +7071,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8538,51 +7185,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "CLC": {
-        "coin": "CLC",
-        "type": "Smart Chain",
-        "name": "Collider Coin",
-        "coinpaprika_id": "clc-collider-coin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://clc.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "CLC",
-        "fname": "Collider Coin",
-        "rpcport": 31034,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "requires_notarization": false,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx.cryptocollider.com:10001",
-                "contact": [
-                    {
-                        "email": "electrumx@cryptocollider.com"
-                    },
-                    {
-                        "discord": "collider#6160"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "COMP-AVX20": {
         "coin": "COMP-AVX20",
         "type": "AVX-20",
@@ -8667,15 +7269,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -8731,24 +7324,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8903,24 +7478,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9071,24 +7628,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9332,15 +7871,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9391,24 +7921,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9492,6 +8004,19 @@
                         "discord": "ruaxxx#3151"
                     }
                 ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -9553,6 +8078,19 @@
                 "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum03.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9654,24 +8192,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9729,15 +8249,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -9970,7 +8481,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10061",
+                "url": "electrum1.cipig.net:20061",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9982,7 +8494,8 @@
                 "ws_url": "electrum1.cipig.net:30061"
             },
             {
-                "url": "electrum2.cipig.net:10061",
+                "url": "electrum2.cipig.net:20061",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9994,42 +8507,6 @@
                 "ws_url": "electrum2.cipig.net:30061"
             },
             {
-                "url": "electrum3.cipig.net:10061",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30061"
-            },
-            {
-                "url": "electrum1.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20061",
                 "protocol": "SSL",
                 "contact": [
@@ -10039,7 +8516,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30061"
             }
         ],
         "explorer_block_url": "block/"
@@ -10081,24 +8559,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10164,24 +8624,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -10240,24 +8682,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10366,7 +8790,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10059",
+                "url": "electrum1.cipig.net:20059",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10378,42 +8803,6 @@
                 "ws_url": "electrum1.cipig.net:30059"
             },
             {
-                "url": "electrum2.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
-            },
-            {
-                "url": "electrum3.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
-            },
-            {
-                "url": "electrum1.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20059",
                 "protocol": "SSL",
                 "contact": [
@@ -10423,7 +8812,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum3.cipig.net:20059",
@@ -10435,7 +8825,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30059"
             }
         ],
         "explorer_block_url": "block/"
@@ -10482,7 +8873,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10059",
+                "url": "electrum1.cipig.net:20059",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10494,42 +8886,6 @@
                 "ws_url": "electrum1.cipig.net:30059"
             },
             {
-                "url": "electrum2.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
-            },
-            {
-                "url": "electrum3.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
-            },
-            {
-                "url": "electrum1.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20059",
                 "protocol": "SSL",
                 "contact": [
@@ -10539,7 +8895,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum3.cipig.net:20059",
@@ -10551,7 +8908,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30059"
             }
         ],
         "explorer_block_url": "block/"
@@ -10586,11 +8944,6 @@
         },
         "derivation_path": "m/44'/18'",
         "electrum": [
-            {
-                "url": "electrumx.dgc.ewmcx.org:50001",
-                "protocol": "TCP",
-                "ws_url": "electrumx.dgc.ewmcx.org:50003"
-            },
             {
                 "url": "failover.dgc.ewmcx.biz:50002",
                 "protocol": "SSL",
@@ -10638,24 +8991,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10716,15 +9051,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -10846,15 +9172,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -10908,7 +9225,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10920,7 +9238,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10932,42 +9251,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -10977,7 +9260,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -11019,15 +9303,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11080,24 +9355,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -11202,7 +9459,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10060",
+                "url": "electrum1.cipig.net:20060",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11214,7 +9472,8 @@
                 "ws_url": "electrum1.cipig.net:30060"
             },
             {
-                "url": "electrum2.cipig.net:10060",
+                "url": "electrum2.cipig.net:20060",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11226,42 +9485,6 @@
                 "ws_url": "electrum2.cipig.net:30060"
             },
             {
-                "url": "electrum3.cipig.net:10060",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30060"
-            },
-            {
-                "url": "electrum1.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20060",
                 "protocol": "SSL",
                 "contact": [
@@ -11271,7 +9494,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30060"
             }
         ],
         "explorer_block_url": "block/"
@@ -11313,15 +9537,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11375,15 +9590,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11435,15 +9641,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11493,15 +9690,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11560,48 +9748,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "DP": {
-        "coin": "DP",
-        "type": "Smart Chain",
-        "name": "DigitalPrice",
-        "coinpaprika_id": "dp-digitalprice",
-        "coingecko_id": "digitalprice",
-        "livecoinwatch_id": "DP",
-        "explorer_url": "https://dp.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "DP",
-        "fname": "DigitalPrice",
-        "rpcport": 28388,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "requires_notarization": false,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "1.eu.dp.electrum.dexstats.info:10021",
-                "contact": [
-                    {
-                        "discord": "Zanzarismo#6500"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "DOI": {
         "coin": "DOI",
         "type": "UTXO",
@@ -11634,16 +9780,6 @@
         },
         "electrum": [
             {
-                "url": "pink-deer-69.doi.works:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/namecoin/electrum-nmc/issues",
-                        "twitter": "example_username"
-                    }
-                ]
-            },
-            {
                 "url": "big-parrot-60.doi.works:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -11664,28 +9800,6 @@
                     }
                 ],
                 "ws-url": "itchy-jellyfish-89.doi.works:50004"
-            },
-            {
-                "url": "pink-deer-69.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/namecoin/electrum-nmc/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "pink-deer-69.doi.works:50004"
-            },
-            {
-                "url": "ugly-bird-70.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/doichain/electrum-doi/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "ugly-bird-70.doi.works:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -11723,7 +9837,8 @@
         "derivation_path": "m/44'/249'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10052",
+                "url": "electrum1.cipig.net:20052",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11735,7 +9850,8 @@
                 "ws_url": "electrum1.cipig.net:30052"
             },
             {
-                "url": "electrum2.cipig.net:10052",
+                "url": "electrum2.cipig.net:20052",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11747,42 +9863,6 @@
                 "ws_url": "electrum2.cipig.net:30052"
             },
             {
-                "url": "electrum3.cipig.net:10052",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30052"
-            },
-            {
-                "url": "electrum1.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20052",
                 "protocol": "SSL",
                 "contact": [
@@ -11792,7 +9872,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30052"
             }
         ],
         "explorer_block_url": "block/"
@@ -11888,15 +9969,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11947,24 +10019,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12026,15 +10080,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12092,24 +10137,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12163,7 +10190,8 @@
         "derivation_path": "m/44'/41'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10062",
+                "url": "electrum1.cipig.net:20062",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -12175,7 +10203,8 @@
                 "ws_url": "electrum1.cipig.net:30062"
             },
             {
-                "url": "electrum2.cipig.net:10062",
+                "url": "electrum2.cipig.net:20062",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -12187,42 +10216,6 @@
                 "ws_url": "electrum2.cipig.net:30062"
             },
             {
-                "url": "electrum3.cipig.net:10062",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30062"
-            },
-            {
-                "url": "electrum1.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20062",
                 "protocol": "SSL",
                 "contact": [
@@ -12232,7 +10225,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30062"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -12280,24 +10274,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12451,15 +10427,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12558,15 +10525,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12611,24 +10569,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12770,15 +10710,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13014,24 +10945,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13144,24 +11057,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13312,15 +11207,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -13371,24 +11257,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13451,24 +11319,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13527,15 +11377,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13637,15 +11478,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -13696,24 +11528,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13780,88 +11594,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "FIRO": {
-        "coin": "FIRO",
-        "type": "UTXO",
-        "name": "Firo",
-        "coinpaprika_id": "firo-firo",
-        "coingecko_id": "zcoin",
-        "livecoinwatch_id": "FIRO",
-        "explorer_url": "https://explorer.firo.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Firo Signed Message:\n",
-        "fname": "Firo",
-        "rpcport": 8888,
-        "pubtype": 82,
-        "p2shtype": 7,
-        "wiftype": 210,
-        "txfee": 1000,
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 300,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "trezor_coin": "Firo",
-        "links": {
-            "github": "https://github.com/firoorg/firo",
-            "homepage": "https://firo.org"
-        },
-        "electrum": [
-            {
-                "url": "electrumx.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx01.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx02.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx03.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx05.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "FIRO-BEP20": {
         "coin": "FIRO-BEP20",
         "type": "BEP-20",
@@ -13899,15 +11631,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13960,24 +11683,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx1.fujicoin.org:50003",
                 "protocol": "SSL",
                 "contact": [
@@ -13986,16 +11691,6 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx2.fujicoin.org:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -14042,24 +11737,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx1.fujicoin.org:50003",
                 "protocol": "SSL",
                 "contact": [
@@ -14068,16 +11745,6 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx2.fujicoin.org:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -14119,15 +11786,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -14181,15 +11839,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14239,15 +11888,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -14300,24 +11940,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14380,15 +12002,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14439,7 +12052,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10054",
+                "url": "electrum1.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14451,7 +12065,8 @@
                 "ws_url": "electrum1.cipig.net:30054"
             },
             {
-                "url": "electrum2.cipig.net:10054",
+                "url": "electrum2.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14463,42 +12078,6 @@
                 "ws_url": "electrum2.cipig.net:30054"
             },
             {
-                "url": "electrum3.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
-            },
-            {
-                "url": "electrum1.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20054",
                 "protocol": "SSL",
                 "contact": [
@@ -14508,7 +12087,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30054"
             }
         ],
         "explorer_block_url": "block/"
@@ -14555,7 +12135,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10054",
+                "url": "electrum1.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14567,7 +12148,8 @@
                 "ws_url": "electrum1.cipig.net:30054"
             },
             {
-                "url": "electrum2.cipig.net:10054",
+                "url": "electrum2.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14579,42 +12161,6 @@
                 "ws_url": "electrum2.cipig.net:30054"
             },
             {
-                "url": "electrum3.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
-            },
-            {
-                "url": "electrum1.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20054",
                 "protocol": "SSL",
                 "contact": [
@@ -14624,7 +12170,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30054"
             }
         ],
         "explorer_block_url": "block/"
@@ -14743,15 +12290,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14806,24 +12344,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14886,15 +12406,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14945,24 +12456,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15207,24 +12700,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15285,15 +12760,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15346,15 +12812,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15365,115 +12822,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "GLEEC": {
-        "coin": "GLEEC",
-        "type": "Smart Chain",
-        "name": "Gleec",
-        "coinpaprika_id": "gleec-gleec-coin",
-        "coingecko_id": "gleec-coin",
-        "livecoinwatch_id": "GLEEC",
-        "explorer_url": "https://gleec.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "GLEEC",
-        "fname": "Gleec",
-        "rpcport": 23226,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrum1.cipig.net:10022",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30022"
-            },
-            {
-                "url": "electrum2.cipig.net:10022",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30022"
-            },
-            {
-                "url": "electrum3.cipig.net:10022",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30022"
-            },
-            {
-                "url": "electrum1.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "GLM-ERC20": {
@@ -15514,24 +12862,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15641,15 +12971,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15700,15 +13021,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -15810,24 +13122,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15980,15 +13274,6 @@
         "derivation_path": "m/44'/69420'",
         "electrum": [
             {
-                "url": "electrum.maxpuig.com:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "mecs#4770"
-                    }
-                ]
-            },
-            {
                 "url": "au.garlium.crapules.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -16007,36 +13292,6 @@
                     }
                 ],
                 "ws_url": "electrum.maxpuig.com:50004"
-            },
-            {
-                "url": "fr.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "pl.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "uk.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -16079,24 +13334,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -16159,15 +13396,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -16217,402 +13445,6 @@
             "homepage": "https://www.groestlcoin.org"
         },
         "electrum": [
-            {
-                "url": "electrum1.groestlcoin.org:50001",
-                "ws_url": "electrum1.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum12.groestlcoin.org:50001",
-                "ws_url": "electrum12.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum13.groestlcoin.org:50001",
-                "ws_url": "electrum13.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum14.groestlcoin.org:50001",
-                "ws_url": "electrum14.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum15.groestlcoin.org:50001",
-                "ws_url": "electrum15.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum16.groestlcoin.org:50001",
-                "ws_url": "electrum16.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum17.groestlcoin.org:50001",
-                "ws_url": "electrum17.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum19.groestlcoin.org:50001",
-                "ws_url": "electrum19.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.groestlcoin.org:50001",
-                "ws_url": "electrum2.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum20.groestlcoin.org:50001",
-                "ws_url": "electrum20.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum21.groestlcoin.org:50001",
-                "ws_url": "electrum21.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum22.groestlcoin.org:50001",
-                "ws_url": "electrum22.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum23.groestlcoin.org:50001",
-                "ws_url": "electrum23.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum24.groestlcoin.org:50001",
-                "ws_url": "electrum24.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum25.groestlcoin.org:50001",
-                "ws_url": "electrum25.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum26.groestlcoin.org:50001",
-                "ws_url": "electrum26.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum27.groestlcoin.org:50001",
-                "ws_url": "electrum27.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum28.groestlcoin.org:50001",
-                "ws_url": "electrum28.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum29.groestlcoin.org:50001",
-                "ws_url": "electrum29.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.groestlcoin.org:50001",
-                "ws_url": "electrum3.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum30.groestlcoin.org:50001",
-                "ws_url": "electrum30.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum33.groestlcoin.org:50001",
-                "ws_url": "electrum33.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum34.groestlcoin.org:50001",
-                "ws_url": "electrum34.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum35.groestlcoin.org:50001",
-                "ws_url": "electrum35.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum36.groestlcoin.org:50001",
-                "ws_url": "electrum36.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum37.groestlcoin.org:50001",
-                "ws_url": "electrum37.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum38.groestlcoin.org:50001",
-                "ws_url": "electrum38.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum39.groestlcoin.org:50001",
-                "ws_url": "electrum39.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum40.groestlcoin.org:50001",
-                "ws_url": "electrum40.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum5.groestlcoin.org:50001",
-                "ws_url": "electrum5.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum7.groestlcoin.org:50001",
-                "ws_url": "electrum7.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum8.groestlcoin.org:50001",
-                "ws_url": "electrum8.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum9.groestlcoin.org:50001",
-                "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
             {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
@@ -16671,402 +13503,6 @@
             "homepage": "https://www.groestlcoin.org"
         },
         "electrum": [
-            {
-                "url": "electrum1.groestlcoin.org:50001",
-                "ws_url": "electrum1.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum12.groestlcoin.org:50001",
-                "ws_url": "electrum12.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum13.groestlcoin.org:50001",
-                "ws_url": "electrum13.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum14.groestlcoin.org:50001",
-                "ws_url": "electrum14.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum15.groestlcoin.org:50001",
-                "ws_url": "electrum15.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum16.groestlcoin.org:50001",
-                "ws_url": "electrum16.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum17.groestlcoin.org:50001",
-                "ws_url": "electrum17.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum19.groestlcoin.org:50001",
-                "ws_url": "electrum19.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.groestlcoin.org:50001",
-                "ws_url": "electrum2.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum20.groestlcoin.org:50001",
-                "ws_url": "electrum20.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum21.groestlcoin.org:50001",
-                "ws_url": "electrum21.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum22.groestlcoin.org:50001",
-                "ws_url": "electrum22.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum23.groestlcoin.org:50001",
-                "ws_url": "electrum23.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum24.groestlcoin.org:50001",
-                "ws_url": "electrum24.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum25.groestlcoin.org:50001",
-                "ws_url": "electrum25.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum26.groestlcoin.org:50001",
-                "ws_url": "electrum26.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum27.groestlcoin.org:50001",
-                "ws_url": "electrum27.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum28.groestlcoin.org:50001",
-                "ws_url": "electrum28.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum29.groestlcoin.org:50001",
-                "ws_url": "electrum29.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.groestlcoin.org:50001",
-                "ws_url": "electrum3.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum30.groestlcoin.org:50001",
-                "ws_url": "electrum30.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum33.groestlcoin.org:50001",
-                "ws_url": "electrum33.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum34.groestlcoin.org:50001",
-                "ws_url": "electrum34.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum35.groestlcoin.org:50001",
-                "ws_url": "electrum35.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum36.groestlcoin.org:50001",
-                "ws_url": "electrum36.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum37.groestlcoin.org:50001",
-                "ws_url": "electrum37.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum38.groestlcoin.org:50001",
-                "ws_url": "electrum38.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum39.groestlcoin.org:50001",
-                "ws_url": "electrum39.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum40.groestlcoin.org:50001",
-                "ws_url": "electrum40.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum5.groestlcoin.org:50001",
-                "ws_url": "electrum5.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum7.groestlcoin.org:50001",
-                "ws_url": "electrum7.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum8.groestlcoin.org:50001",
-                "ws_url": "electrum8.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum9.groestlcoin.org:50001",
-                "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
             {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
@@ -17172,24 +13608,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17344,15 +13762,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -17403,24 +13812,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17481,24 +13872,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17564,24 +13937,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17690,24 +14045,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17862,24 +14199,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17938,24 +14257,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18194,67 +14495,6 @@
         ],
         "explorer_block_url": "block.dws?"
     },
-    "ILN": {
-        "coin": "ILN",
-        "type": "Smart Chain",
-        "name": "Ilien",
-        "coinpaprika_id": "iln-ilien9195",
-        "coingecko_id": "",
-        "livecoinwatch_id": "ILN",
-        "explorer_url": "https://explorer.ilien.io/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "ILN",
-        "fname": "Ilien",
-        "rpcport": 12986,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "p2p": 12985,
-        "magic": "feb4cb23",
-        "nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrum1.ilien.io:65011",
-                "contact": [
-                    {
-                        "email": "admin@ilien.io"
-                    },
-                    {
-                        "discord": "siu - Chainmakers#3920"
-                    }
-                ],
-                "ws_url": "electrum1.ilien.io:30069"
-            },
-            {
-                "url": "electrum2.ilien.io:65011",
-                "contact": [
-                    {
-                        "email": "admin@ilien.io"
-                    },
-                    {
-                        "discord": "siu - Chainmakers#3920"
-                    }
-                ],
-                "ws_url": "electrum2.ilien.io:30069"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "ILN-BEP20": {
         "coin": "ILN-BEP20",
         "type": "BEP-20",
@@ -18293,15 +14533,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -18452,24 +14683,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18530,15 +14743,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18589,24 +14793,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18668,15 +14854,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18726,24 +14903,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18805,15 +14964,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18863,15 +15013,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -18973,15 +15114,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19081,15 +15213,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -19288,15 +15411,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19347,24 +15461,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19571,15 +15667,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19630,24 +15717,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19760,15 +15829,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19819,24 +15879,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20386,24 +16428,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20708,15 +16732,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -20809,7 +16824,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10001",
+                "url": "electrum1.cipig.net:20001",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -20821,7 +16837,8 @@
                 "ws_url": "electrum1.cipig.net:30001"
             },
             {
-                "url": "electrum2.cipig.net:10001",
+                "url": "electrum2.cipig.net:20001",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -20833,42 +16850,6 @@
                 "ws_url": "electrum2.cipig.net:30001"
             },
             {
-                "url": "electrum3.cipig.net:10001",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30001"
-            },
-            {
-                "url": "electrum1.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20001",
                 "protocol": "SSL",
                 "contact": [
@@ -20878,7 +16859,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30001"
             }
         ],
         "explorer_block_url": "block/",
@@ -20922,15 +16904,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -20982,15 +16955,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -21047,24 +17011,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21212,7 +17158,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10024",
+                "url": "electrum1.cipig.net:20024",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21224,7 +17171,8 @@
                 "ws_url": "electrum1.cipig.net:30024"
             },
             {
-                "url": "electrum2.cipig.net:10024",
+                "url": "electrum2.cipig.net:20024",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21236,42 +17184,6 @@
                 "ws_url": "electrum2.cipig.net:30024"
             },
             {
-                "url": "electrum3.cipig.net:10024",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30024"
-            },
-            {
-                "url": "electrum1.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20024",
                 "protocol": "SSL",
                 "contact": [
@@ -21281,7 +17193,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30024"
             }
         ],
         "explorer_block_url": "block/"
@@ -21324,15 +17237,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -21378,31 +17282,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30019"
-            },
-            {
-                "url": "electrum2.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30019"
-            },
-            {
-                "url": "electrum3.cipig.net:10019",
+                "url": "electrum1.cipig.net:20019",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21414,18 +17295,6 @@
                 "ws_url": "electrum3.cipig.net:30019"
             },
             {
-                "url": "electrum1.cipig.net:20019",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20019",
                 "protocol": "SSL",
                 "contact": [
@@ -21435,7 +17304,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30019"
             },
             {
                 "url": "electrum3.cipig.net:20019",
@@ -21447,7 +17317,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30019"
             }
         ],
         "explorer_block_url": "block/"
@@ -21485,31 +17356,22 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
-            },
-            {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
-            },
-            {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
-            },
-            {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum1.cipig.net:30067"
             },
             {
                 "url": "electrum2.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum2.cipig.net:30067"
             },
             {
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum3.cipig.net:30067"
             }
         ],
         "explorer_block_url": "block/"
@@ -21551,130 +17413,25 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
-            },
-            {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
-            },
-            {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
-            },
-            {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum1.cipig.net:30067"
             },
             {
                 "url": "electrum2.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum2.cipig.net:30067"
             },
             {
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum3.cipig.net:30067"
             }
         ],
         "explorer_block_url": "block/"
-    },
-    "LCC": {
-        "coin": "LCC",
-        "type": "UTXO",
-        "name": "Litecoin Cash",
-        "coinpaprika_id": "lcc-litecoin-cash",
-        "coingecko_id": "litecoin-cash",
-        "livecoinwatch_id": "LCC",
-        "explorer_url": "https://chainz.cryptoid.info/lcc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Litecoin Signed Message:\n",
-        "fname": "Litecoin Cash",
-        "rpcport": 62457,
-        "pubtype": 28,
-        "p2shtype": 50,
-        "wiftype": 176,
-        "decimals": 7,
-        "fork_id": "0x40",
-        "signature_version": "base",
-        "txfee": 20000,
-        "segwit": true,
-        "bech32_hrp": "lcc",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "electrum": [
-            {
-                "url": "188.166.117.139:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "88.99.26.209:5140",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "LCC-segwit": {
-        "coin": "LCC-segwit",
-        "type": "UTXO",
-        "name": "Litecoin Cash",
-        "coinpaprika_id": "lcc-litecoin-cash",
-        "coingecko_id": "litecoin-cash",
-        "livecoinwatch_id": "LCC",
-        "explorer_url": "https://chainz.cryptoid.info/lcc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Litecoin Signed Message:\n",
-        "fname": "Litecoin Cash",
-        "rpcport": 62457,
-        "pubtype": 28,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "decimals": 7,
-        "fork_id": "0x40",
-        "signature_version": "base",
-        "txfee": 20000,
-        "segwit": true,
-        "bech32_hrp": "lcc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "LCC",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "electrum": [
-            {
-                "url": "188.166.117.139:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "88.99.26.209:5140",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "LDO-ERC20": {
         "coin": "LDO-ERC20",
@@ -21714,24 +17471,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21846,24 +17585,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -21971,24 +17692,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22091,15 +17794,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -22335,15 +18029,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -22399,24 +18084,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -22479,15 +18146,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -22548,94 +18206,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "WCN": {
-        "coin": "WCN",
-        "type": "UTXO",
-        "name": "Widecoin",
-        "coinpaprika_id": "wcn-widecoin",
-        "coingecko_id": "widecoin",
-        "livecoinwatch_id": "WCN",
-        "explorer_url": "https://explorer.widecoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Widecoin",
-        "rpcport": 8552,
-        "pubtype": 73,
-        "p2shtype": 33,
-        "wiftype": 153,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "wc",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/613'",
-        "electrum": [
-            {
-                "url": "electrumx.widecoin.org:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx2.widecoin.org:50001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "WCN-segwit": {
-        "coin": "WCN-segwit",
-        "type": "UTXO",
-        "name": "Widecoin",
-        "coinpaprika_id": "wcn-widecoin",
-        "coingecko_id": "widecoin",
-        "livecoinwatch_id": "WCN",
-        "explorer_url": "https://explorer.widecoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Widecoin",
-        "rpcport": 8552,
-        "pubtype": 73,
-        "p2shtype": 33,
-        "wiftype": 153,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "wc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "WCN",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/613'",
-        "electrum": [
-            {
-                "url": "electrumx.widecoin.org:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx2.widecoin.org:50001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "LEASH-ERC20": {
         "coin": "LEASH-ERC20",
         "type": "ERC-20",
@@ -22673,24 +18243,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -22758,24 +18310,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22836,15 +18370,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -22895,15 +18420,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -22957,7 +18473,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10063",
+                "url": "electrum1.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -22969,7 +18486,8 @@
                 "ws_url": "electrum1.cipig.net:30063"
             },
             {
-                "url": "electrum2.cipig.net:10063",
+                "url": "electrum2.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -22981,42 +18499,6 @@
                 "ws_url": "electrum2.cipig.net:30063"
             },
             {
-                "url": "electrum3.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
-            },
-            {
-                "url": "electrum1.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20063",
                 "protocol": "SSL",
                 "contact": [
@@ -23026,7 +18508,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30063"
             }
         ],
         "explorer_block_url": "block/"
@@ -23074,7 +18557,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10063",
+                "url": "electrum1.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -23086,7 +18570,8 @@
                 "ws_url": "electrum1.cipig.net:30063"
             },
             {
-                "url": "electrum2.cipig.net:10063",
+                "url": "electrum2.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -23098,42 +18583,6 @@
                 "ws_url": "electrum2.cipig.net:30063"
             },
             {
-                "url": "electrum3.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
-            },
-            {
-                "url": "electrum1.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20063",
                 "protocol": "SSL",
                 "contact": [
@@ -23143,7 +18592,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30063"
             }
         ],
         "explorer_block_url": "block/"
@@ -23194,16 +18644,6 @@
                 "url": "electrum7.getlynx.io:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum7.getlynx.io:50004"
-            },
-            {
-                "url": "electrum8.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum8.getlynx.io:50004"
-            },
-            {
-                "url": "electrum9.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum9.getlynx.io:50004"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -23251,24 +18691,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23329,15 +18751,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -23484,15 +18897,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23543,24 +18947,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23753,15 +19139,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23816,24 +19193,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23984,24 +19343,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24062,15 +19403,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -24115,7 +19447,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10023",
+                "url": "electrum1.cipig.net:20023",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24127,7 +19460,8 @@
                 "ws_url": "electrum1.cipig.net:30023"
             },
             {
-                "url": "electrum2.cipig.net:10023",
+                "url": "electrum2.cipig.net:20023",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24139,42 +19473,6 @@
                 "ws_url": "electrum2.cipig.net:30023"
             },
             {
-                "url": "electrum3.cipig.net:10023",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30023"
-            },
-            {
-                "url": "electrum1.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20023",
                 "protocol": "SSL",
                 "contact": [
@@ -24184,7 +19482,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30023"
             }
         ],
         "explorer_block_url": "block/"
@@ -24231,24 +19530,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24302,39 +19583,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrum1.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.cipig.net:20069",
                 "ws_url": "electrum1.cipig.net:30069",
@@ -24417,24 +19665,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24493,15 +19723,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -24600,15 +19821,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -24664,24 +19876,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24791,24 +19985,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24914,15 +20090,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25023,110 +20190,6 @@
             },
             {
                 "url": "https://poly-rpc.gateway.pokt.network"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "MONA": {
-        "coin": "MONA",
-        "type": "UTXO",
-        "name": "MonaCoin",
-        "coinpaprika_id": "mona-monacoin",
-        "coingecko_id": "monacoin",
-        "livecoinwatch_id": "MONA",
-        "explorer_url": "https://blockbook.electrum-mona.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Monacoin Signed Message:\n",
-        "fname": "MonaCoin",
-        "rpcport": 9402,
-        "pubtype": 50,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 100000,
-        "segwit": true,
-        "bech32_hrp": "mona",
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 90,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/22'",
-        "trezor_coin": "Monacoin",
-        "links": {
-            "github": "https://github.com/monacoinproject/monacoin",
-            "homepage": "https://monacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "133.167.67.203:50001"
-            },
-            {
-                "url": "electrumx.tamami-foundation.org:50001"
-            },
-            {
-                "url": "electrumx1.monacoin.ninja:50001"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "MONA-segwit": {
-        "coin": "MONA-segwit",
-        "type": "UTXO",
-        "name": "MonaCoin",
-        "coinpaprika_id": "mona-monacoin",
-        "coingecko_id": "monacoin",
-        "livecoinwatch_id": "MONA",
-        "explorer_url": "https://blockbook.electrum-mona.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Monacoin Signed Message:\n",
-        "fname": "MonaCoin",
-        "rpcport": 9402,
-        "pubtype": 50,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 100000,
-        "segwit": true,
-        "bech32_hrp": "mona",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "MONA",
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 90,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/22'",
-        "trezor_coin": "Monacoin",
-        "links": {
-            "github": "https://github.com/monacoinproject/monacoin",
-            "homepage": "https://monacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "133.167.67.203:50001"
-            },
-            {
-                "url": "electrumx.tamami-foundation.org:50001"
-            },
-            {
-                "url": "electrumx1.monacoin.ninja:50001"
             }
         ],
         "explorer_block_url": "block/"
@@ -25296,15 +20359,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25356,15 +20410,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25375,71 +20420,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "NENG": {
-        "coin": "NENG",
-        "type": "UTXO",
-        "name": "Nengcoin",
-        "coinpaprika_id": "neng-nengcoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "NENG",
-        "explorer_url": "http://nengexplorer.mooo.com:3001/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Nengcoin",
-        "rpcport": 6376,
-        "pubtype": 53,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 200000,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/681'",
-        "electrum": [
-            {
-                "url": "electrum.shorelinecrypto.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.mooo.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.mooo.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "NEXO-ERC20": {
@@ -25484,24 +20464,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -25648,39 +20610,6 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum1.cipig.net:20036",
                 "protocol": "SSL",
                 "contact": [
@@ -25756,9 +20685,6 @@
         },
         "electrum": [
             {
-                "url": "46.229.238.187:57001"
-            },
-            {
                 "url": "nmc2.bitcoins.sk:57002",
                 "protocol": "SSL",
                 "disable_cert_verification": true
@@ -25806,9 +20732,6 @@
             "homepage": "https://namecoin.org"
         },
         "electrum": [
-            {
-                "url": "46.229.238.187:57001"
-            },
             {
                 "url": "nmc2.bitcoins.sk:57002",
                 "protocol": "SSL",
@@ -25937,15 +20860,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25999,7 +20913,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -26011,7 +20926,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -26023,42 +20939,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -26068,7 +20948,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -26111,24 +20992,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26240,15 +21103,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26303,24 +21157,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26434,24 +21270,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26602,15 +21420,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26665,24 +21474,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26742,15 +21533,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -26896,15 +21678,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26960,24 +21733,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27048,139 +21803,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "PINK": {
-        "coin": "PINK",
-        "type": "UTXO",
-        "name": "Pinkcoin",
-        "coinpaprika_id": "pink-pinkcoin",
-        "coingecko_id": "pinkcoin",
-        "livecoinwatch_id": "PINK",
-        "explorer_url": "https://chainz.cryptoid.info/pink/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": true,
-        "sign_message_prefix": "Pinkcoin Signed Message:\n",
-        "fname": "Pinkcoin",
-        "rpcport": 9135,
-        "isPoS": 1,
-        "pubtype": 3,
-        "p2shtype": 28,
-        "wiftype": 131,
-        "txfee": 10000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/117'",
-        "links": {
-            "github": "https://github.com/Pink2Dev/Pink2",
-            "homepage": "https://getstarted.with.pink"
-        },
-        "electrum": [
-            {
-                "url": "pink-one.ewm-cx.net:50001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "PIVX": {
-        "coin": "PIVX",
-        "type": "UTXO",
-        "name": "PIVX",
-        "coinpaprika_id": "pivx-pivx",
-        "coingecko_id": "pivx",
-        "livecoinwatch_id": "PIVX",
-        "explorer_url": "https://chainz.cryptoid.info/pivx/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "PIVX",
-        "rpcport": 51473,
-        "pubtype": 30,
-        "p2shtype": 13,
-        "wiftype": 212,
-        "txfee": 100000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/119'",
-        "electrum": [
-            {
-                "url": "electrum01.chainster.org:50001",
-                "ws_url": "electrum01.chainster.org:50003",
-                "contact": [
-                    {
-                        "discord": "312541186793406465"
-                    }
-                ]
-            },
-            {
-                "url": "electrum02.chainster.org:50001",
-                "ws_url": "electrum02.chainster.org:50003",
-                "contact": [
-                    {
-                        "discord": "312541186793406465"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "PND": {
-        "coin": "PND",
-        "type": "UTXO",
-        "name": "Pandacoin",
-        "coinpaprika_id": "pnd-pandacoin",
-        "coingecko_id": "pandacoin",
-        "livecoinwatch_id": "PND",
-        "explorer_url": "https://chainz.cryptoid.info/pnd/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Pandacoin",
-        "isPoS": 1,
-        "rpcport": 22444,
-        "pubtype": 55,
-        "p2shtype": 22,
-        "wiftype": 183,
-        "decimals": 6,
-        "txfee": 10000000,
-        "dust": 1000000,
-        "segwit": true,
-        "bech32_hrp": "pn",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/37'",
-        "electrum": [
-            {
-                "url": "electrum.thepandacoin.net:50001",
-                "ws_url": "electrum.thepandacoin.net:443"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
     "POT": {
         "coin": "POT",
         "type": "UTXO",
@@ -27215,10 +21837,6 @@
         },
         "derivation_path": "m/44'/81'",
         "electrum": [
-            {
-                "url": "62.171.189.243:50001",
-                "protocol": "TCP"
-            },
             {
                 "url": "pot-duo.ewmcx.net:50012",
                 "protocol": "SSL",
@@ -27266,24 +21884,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27396,24 +21996,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27578,24 +22160,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27703,15 +22267,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -27762,24 +22317,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27881,37 +22418,9 @@
         },
         "electrum": [
             {
-                "url": "electrumx.live:50010",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
-                "url": "txserver.live:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx.live:50012",
                 "protocol": "SSL",
                 "ws_url": "electrumx.live:30010",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
-                "url": "txserver.live:50002",
-                "protocol": "SSL",
-                "ws_url": "txserver.live:30001",
                 "contact": [
                     {
                         "discord": "PRUX-Coin#1668"
@@ -27958,15 +22467,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28022,24 +22522,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28147,7 +22629,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28159,7 +22642,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28171,42 +22655,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28216,7 +22664,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28262,7 +22711,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28274,7 +22724,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28286,42 +22737,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28331,7 +22746,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28377,7 +22793,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28389,7 +22806,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28401,42 +22819,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28446,7 +22828,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28488,15 +22871,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28552,24 +22926,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28635,24 +22991,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28757,7 +23095,8 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
+                "url": "electrum1.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28769,7 +23108,8 @@
                 "ws_url": "electrum1.cipig.net:30071"
             },
             {
-                "url": "electrum2.cipig.net:10071",
+                "url": "electrum2.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28781,42 +23121,6 @@
                 "ws_url": "electrum2.cipig.net:30071"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
                 "contact": [
@@ -28826,7 +23130,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -28874,7 +23179,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28886,7 +23192,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28898,42 +23205,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28943,7 +23214,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28993,7 +23265,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29005,7 +23278,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29017,42 +23291,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -29062,7 +23300,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -29109,24 +23348,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29183,7 +23404,8 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
+                "url": "electrum1.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29195,7 +23417,8 @@
                 "ws_url": "electrum1.cipig.net:30071"
             },
             {
-                "url": "electrum2.cipig.net:10071",
+                "url": "electrum2.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29207,42 +23430,6 @@
                 "ws_url": "electrum2.cipig.net:30071"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
                 "contact": [
@@ -29252,7 +23439,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -29293,7 +23481,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
+                "url": "electrum1.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29305,7 +23494,8 @@
                 "ws_url": "electrum1.cipig.net:30071"
             },
             {
-                "url": "electrum2.cipig.net:10071",
+                "url": "electrum2.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29317,42 +23507,6 @@
                 "ws_url": "electrum2.cipig.net:30071"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
                 "contact": [
@@ -29362,7 +23516,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -29462,24 +23617,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29589,24 +23726,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -29665,24 +23784,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29785,39 +23886,6 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum1.cipig.net:20020",
                 "ws_url": "electrum1.cipig.net:30020",
                 "protocol": "SSL",
@@ -29890,39 +23958,6 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
-            {
-                "url": "electrum1.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.cipig.net:20021",
                 "ws_url": "electrum1.cipig.net:30021",
@@ -30007,24 +24042,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30135,24 +24152,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30261,24 +24260,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30344,24 +24325,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30378,47 +24341,6 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "RTM": {
-        "coin": "RTM",
-        "type": "UTXO",
-        "name": "Raptoreum",
-        "coinpaprika_id": "rtm-raptoreum",
-        "coingecko_id": "raptoreum",
-        "livecoinwatch_id": "RTM",
-        "explorer_url": "https://explorer.raptoreum.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Raptoreum",
-        "rpcport": 9998,
-        "pubtype": 60,
-        "p2shtype": 16,
-        "wiftype": 128,
-        "txfee": 1000,
-        "mm2": 1,
-        "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
-        "required_confirmations": 3,
-        "avg_blocktime": 120,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/10226'",
-        "electrum": [
-            {
-                "url": "x1.raptoreum.com:50001",
-                "ws_url": "x1.raptoreum.com:50004"
-            },
-            {
-                "url": "x2.raptoreum.com:50001",
-                "ws_url": "x2.raptoreum.com:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -30461,15 +24383,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30521,7 +24434,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10051",
+                "url": "electrum1.cipig.net:20051",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -30533,7 +24447,8 @@
                 "ws_url": "electrum1.cipig.net:30051"
             },
             {
-                "url": "electrum2.cipig.net:10051",
+                "url": "electrum2.cipig.net:20051",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -30545,42 +24460,6 @@
                 "ws_url": "electrum2.cipig.net:30051"
             },
             {
-                "url": "electrum3.cipig.net:10051",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30051"
-            },
-            {
-                "url": "electrum1.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20051",
                 "protocol": "SSL",
                 "contact": [
@@ -30590,7 +24469,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30051"
             }
         ],
         "explorer_block_url": "block/"
@@ -30633,24 +24513,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30711,15 +24573,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30822,15 +24675,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -30881,15 +24725,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30988,15 +24823,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31052,24 +24878,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31269,15 +25077,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31377,24 +25176,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31447,7 +25228,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10011",
+                "url": "electrum1.cipig.net:20011",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31459,7 +25241,8 @@
                 "ws_url": "electrum1.cipig.net:30011"
             },
             {
-                "url": "electrum2.cipig.net:10011",
+                "url": "electrum2.cipig.net:20011",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31471,42 +25254,6 @@
                 "ws_url": "electrum2.cipig.net:30011"
             },
             {
-                "url": "electrum3.cipig.net:10011",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30011"
-            },
-            {
-                "url": "electrum1.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20011",
                 "protocol": "SSL",
                 "contact": [
@@ -31516,7 +25263,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30011"
             }
         ],
         "explorer_block_url": "block/"
@@ -31559,24 +25307,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31679,7 +25409,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10005",
+                "url": "electrum1.cipig.net:20005",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31691,7 +25422,8 @@
                 "ws_url": "electrum1.cipig.net:30005"
             },
             {
-                "url": "electrum2.cipig.net:10005",
+                "url": "electrum2.cipig.net:20005",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31703,42 +25435,6 @@
                 "ws_url": "electrum2.cipig.net:30005"
             },
             {
-                "url": "electrum3.cipig.net:10005",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30005"
-            },
-            {
-                "url": "electrum1.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20005",
                 "protocol": "SSL",
                 "contact": [
@@ -31748,7 +25444,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30005"
             }
         ],
         "explorer_block_url": "block/"
@@ -31837,15 +25534,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31901,24 +25589,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32161,15 +25831,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -32219,15 +25880,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -32280,24 +25932,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32402,7 +26036,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10064",
+                "url": "electrum1.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32414,7 +26049,8 @@
                 "ws_url": "electrum1.cipig.net:30064"
             },
             {
-                "url": "electrum2.cipig.net:10064",
+                "url": "electrum2.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32426,42 +26062,6 @@
                 "ws_url": "electrum2.cipig.net:30064"
             },
             {
-                "url": "electrum3.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
-            },
-            {
-                "url": "electrum1.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20064",
                 "protocol": "SSL",
                 "contact": [
@@ -32471,7 +26071,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30064"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32519,7 +26120,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10064",
+                "url": "electrum1.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32531,7 +26133,8 @@
                 "ws_url": "electrum1.cipig.net:30064"
             },
             {
-                "url": "electrum2.cipig.net:10064",
+                "url": "electrum2.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32543,42 +26146,6 @@
                 "ws_url": "electrum2.cipig.net:30064"
             },
             {
-                "url": "electrum3.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
-            },
-            {
-                "url": "electrum1.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20064",
                 "protocol": "SSL",
                 "contact": [
@@ -32588,7 +26155,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30064"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32631,24 +26199,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32702,7 +26252,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10068",
+                "url": "electrum1.cipig.net:20068",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32714,46 +26265,6 @@
                 "ws_url": "electrum1.cipig.net:30068"
             },
             {
-                "url": "electrum2.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
-            },
-            {
-                "url": "electrum3.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
-            },
-            {
-                "url": "testnet.aranguren.org:51001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrum1.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20068",
                 "protocol": "SSL",
                 "contact": [
@@ -32763,19 +26274,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -32815,7 +26315,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10068",
+                "url": "electrum1.cipig.net:20068",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32827,46 +26328,6 @@
                 "ws_url": "electrum1.cipig.net:30068"
             },
             {
-                "url": "electrum2.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
-            },
-            {
-                "url": "electrum3.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
-            },
-            {
-                "url": "testnet.aranguren.org:51001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrum1.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20068",
                 "protocol": "SSL",
                 "contact": [
@@ -32876,19 +26337,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -32931,24 +26381,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -33103,15 +26535,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -33122,56 +26545,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "THC": {
-        "coin": "THC",
-        "type": "Smart Chain",
-        "name": "HempCoin",
-        "coinpaprika_id": "thc-hempcoin",
-        "coingecko_id": "hempcoin-thc",
-        "livecoinwatch_id": "THC",
-        "explorer_url": "https://thc.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "THC",
-        "fname": "HempCoin",
-        "rpcport": 36790,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "1.eu.thc.electrum.dexstats.info:10020",
-                "contact": [
-                    {
-                        "discord": "CHMEX#0686"
-                    }
-                ]
-            },
-            {
-                "url": "2.eu.thc.electrum.dexstats.info:10020",
-                "contact": [
-                    {
-                        "discord": "CHMEX#0686"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "THC-BEP20": {
@@ -33212,15 +26585,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33267,7 +26631,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "1.eu.tokel.electrum.dexstats.info:10077",
+                "url": "1.eu.tokel.electrum.dexstats.info:11077",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "chmex@dexstats.info"
@@ -33279,7 +26644,7 @@
                 "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
             },
             {
-                "url": "1.eu.tokel.electrum.dexstats.info:11077",
+                "url": "2.eu.tokel.electrum.dexstats.info:11077",
                 "protocol": "SSL",
                 "contact": [
                     {
@@ -33288,7 +26653,8 @@
                     {
                         "discord": "chmex#0686"
                     }
-                ]
+                ],
+                "ws_url": "2.eu.tokel.electrum.dexstats.info:9077"
             }
         ],
         "explorer_block_url": "block/"
@@ -33331,24 +26697,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -33409,15 +26757,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33511,15 +26850,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -33570,15 +26900,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33676,15 +26997,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33788,24 +27100,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -33866,15 +27160,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -33925,15 +27210,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33990,24 +27266,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -34296,15 +27554,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -34359,24 +27608,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -34570,24 +27801,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34745,24 +27958,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34820,15 +28015,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -35163,24 +28349,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -35238,15 +28406,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -35525,15 +28684,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -35584,24 +28734,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36022,15 +29154,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -36084,24 +29207,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36163,24 +29268,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -36233,22 +29320,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "e2.validitytech.com:11001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "e3.validitytech.com:11001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
             {
                 "url": "e2.validitytech.com:11002",
                 "protocol": "SSL",
@@ -36314,15 +29385,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -36371,24 +29433,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36449,24 +29493,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36537,100 +29563,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "VIA": {
-        "coin": "VIA",
-        "type": "UTXO",
-        "name": "Viacoin",
-        "coinpaprika_id": "via-viacoin",
-        "coingecko_id": "viacoin",
-        "livecoinwatch_id": "VIA",
-        "explorer_url": "https://explorer.viacoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Viacoin Signed Message:\n",
-        "fname": "Viacoin",
-        "rpcport": 5222,
-        "pubtype": 71,
-        "p2shtype": 33,
-        "wiftype": 199,
-        "txfee": 100000,
-        "dust": 54600,
-        "required_confirmations": 7,
-        "mature_confirmations": 3600,
-        "avg_blocktime": 24,
-        "segwit": true,
-        "bech32_hrp": "via",
-        "mm2": 1,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/14'",
-        "trezor_coin": "Viacoin",
-        "links": {
-            "github": "https://github.com/viacoin",
-            "homepage": "https://viacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5102"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "VIA-segwit": {
-        "coin": "VIA-segwit",
-        "type": "UTXO",
-        "name": "Viacoin",
-        "coinpaprika_id": "via-viacoin",
-        "coingecko_id": "viacoin",
-        "livecoinwatch_id": "VIA",
-        "explorer_url": "https://explorer.viacoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Viacoin Signed Message:\n",
-        "fname": "Viacoin",
-        "rpcport": 5222,
-        "pubtype": 71,
-        "p2shtype": 33,
-        "wiftype": 199,
-        "txfee": 100000,
-        "dust": 54600,
-        "required_confirmations": 7,
-        "mature_confirmations": 3600,
-        "avg_blocktime": 24,
-        "segwit": true,
-        "bech32_hrp": "via",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "VIA",
-        "mm2": 1,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/14'",
-        "trezor_coin": "Viacoin",
-        "links": {
-            "github": "https://github.com/viacoin",
-            "homepage": "https://viacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5102"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "VITE-BEP20": {
         "coin": "VITE-BEP20",
         "type": "BEP-20",
@@ -36670,15 +29602,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -36689,53 +29612,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "VRM": {
-        "coin": "VRM",
-        "type": "UTXO",
-        "name": "Verium Reserve",
-        "coinpaprika_id": "vrm-veriumreserve",
-        "coingecko_id": "",
-        "livecoinwatch_id": "VRM",
-        "explorer_url": "https://explorer-vrm.vericonomy.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Verium Reserve",
-        "rpcport": 33987,
-        "pubtype": 70,
-        "p2shtype": 132,
-        "wiftype": 198,
-        "txfee": 100000,
-        "force_min_relay_fee": true,
-        "isPoS": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 240,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrum01-vrm.vericonomy.com:50001",
-                "contact": [
-                    {
-                        "email": "dev@vericoin.info"
-                    },
-                    {
-                        "twitter": "vericonomy"
-                    },
-                    {
-                        "github": "VeriConomy"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "VRSC": {
@@ -36768,48 +29644,6 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
-            {
-                "url": "el0.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
-            {
-                "url": "el1.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
-            {
-                "url": "el2.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
             {
                 "url": "el0.verus.io:17486",
                 "protocol": "SSL",
@@ -36864,161 +29698,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "VPRM": {
-        "coin": "VPRM",
-        "type": "Smart Chain",
-        "name": "Vaporum",
-        "coinpaprika_id": "vprm-vaporum-coin",
-        "coingecko_id": "vaporum-coin",
-        "livecoinwatch_id": "VPRM",
-        "explorer_url": "http://explorer.vaporumcoin.us/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "VPRM",
-        "fname": "Vaporum",
-        "rpcport": 51609,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx2.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "VTC": {
-        "coin": "VTC",
-        "type": "UTXO",
-        "name": "Vertcoin",
-        "coinpaprika_id": "vtc-vertcoin",
-        "coingecko_id": "vertcoin",
-        "livecoinwatch_id": "VTC",
-        "explorer_url": "https://chainz.cryptoid.info/vtc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Vertcoin Signed Message:\n",
-        "fname": "Vertcoin",
-        "rpcport": 5888,
-        "pubtype": 71,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "vtc",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/28'",
-        "trezor_coin": "Vertcoin",
-        "links": {
-            "github": "https://github.com/vertcoin-project/vertcoin-core",
-            "homepage": "https://vertcoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5028"
-            },
-            {
-                "url": "electrumx-brn.webhop.me:55001"
-            },
-            {
-                "url": "electrumx.javerity.com:5885",
-                "ws_url": "electrumx.javerity.com:5887",
-                "contact": [
-                    {
-                        "discord": "cruelnovo#4936"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "VTC-segwit": {
-        "coin": "VTC-segwit",
-        "type": "UTXO",
-        "name": "Vertcoin",
-        "coinpaprika_id": "vtc-vertcoin",
-        "coingecko_id": "vertcoin",
-        "livecoinwatch_id": "VTC",
-        "explorer_url": "https://chainz.cryptoid.info/vtc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Vertcoin Signed Message:\n",
-        "fname": "Vertcoin",
-        "rpcport": 5888,
-        "pubtype": 71,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "vtc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "VTC",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/28'",
-        "trezor_coin": "Vertcoin",
-        "links": {
-            "github": "https://github.com/vertcoin-project/vertcoin-core",
-            "homepage": "https://vertcoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5028"
-            },
-            {
-                "url": "electrumx-brn.webhop.me:55001"
-            },
-            {
-                "url": "electrumx.javerity.com:5885",
-                "ws_url": "electrumx.javerity.com:5887",
-                "contact": [
-                    {
-                        "discord": "cruelnovo#4936"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
     "WAVES-BEP20": {
         "coin": "WAVES-BEP20",
         "type": "BEP-20",
@@ -37057,15 +29736,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -37123,24 +29793,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -37251,24 +29903,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -37327,24 +29961,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -37450,15 +30066,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -37606,24 +30213,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -37684,15 +30273,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -37703,73 +30283,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "XEP-segwit": {
-        "coin": "XEP-segwit",
-        "type": "UTXO",
-        "name": "Electra Protocol",
-        "coinpaprika_id": "",
-        "coingecko_id": "",
-        "livecoinwatch_id": "XEP",
-        "explorer_url": "https://electraprotocol.network/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Electra Protocol",
-        "rpcport": 16816,
-        "pubtype": 55,
-        "p2shtype": 137,
-        "wiftype": 162,
-        "txversion": 2,
-        "txfee": 100000,
-        "mm2": 1,
-        "segwit": true,
-        "signature_version": "witness_v0",
-        "bech32_hrp": "ep",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "XEP",
-        "required_confirmations": 4,
-        "avg_blocktime": 80,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/597'",
-        "electrum": [
-            {
-                "url": "electrumx1.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx1.electraprotocol.eu:50003"
-            },
-            {
-                "url": "electrumx2.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx2.electraprotocol.eu:50003"
-            },
-            {
-                "url": "electrumx3.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx3.electraprotocol.eu:50003"
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "XEP-BEP20": {
@@ -37810,15 +30323,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -37871,24 +30375,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -37999,15 +30485,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -38052,13 +30529,9 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
-            },
-            {
                 "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "lenoir.ecoincore.com:10894"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38099,13 +30572,9 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
-            },
-            {
                 "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "lenoir.ecoincore.com:10894"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38183,50 +30652,6 @@
                     }
                 ],
                 "ws_url": "electrumx3.neurai.top:50002"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XPM": {
-        "coin": "XPM",
-        "type": "UTXO",
-        "name": "Primecoin",
-        "coinpaprika_id": "xpm-primecoin",
-        "coingecko_id": "primecoin",
-        "livecoinwatch_id": "XPM",
-        "explorer_url": "https://www.blockseek.io/xpm/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": true,
-        "fname": "Primecoin",
-        "rpcport": 8332,
-        "pubtype": 23,
-        "p2shtype": 83,
-        "wiftype": 151,
-        "txfee": 0,
-        "dust": 1000000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/24'",
-        "trezor_coin": "Primecoin",
-        "links": {
-            "github": "https://github.com/primecoin/primecoin",
-            "homepage": "https://primecoin.io"
-        },
-        "electrum": [
-            {
-                "url": "electrumx.mainnet.primecoin.org:50011"
-            },
-            {
-                "url": "electrumx.primecoin.org:50001"
             }
         ],
         "explorer_block_url": "block/"
@@ -38323,15 +30748,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -38382,24 +30798,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -38465,24 +30863,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -38594,15 +30974,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -38614,43 +30985,6 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
-    },
-    "XVC": {
-        "coin": "XVC",
-        "type": "UTXO",
-        "name": "VanillaCash",
-        "coinpaprika_id": "xvc-vcash",
-        "coingecko_id": "vcash",
-        "livecoinwatch_id": "XVC",
-        "explorer_url": "https://chainz.cryptoid.info/xvc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "VanillaCash",
-        "isPoS": 1,
-        "rpcport": 48888,
-        "pubtype": 18,
-        "p2shtype": 30,
-        "wiftype": 181,
-        "txfee": 1000,
-        "dust": 10000,
-        "mm2": 1,
-        "required_confirmations": 7,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrumx1.vanillacash.info:50011",
-                "ws_url": "electrumx1.vanillacash.info:50013"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "XVC-BEP20": {
         "coin": "XVC-BEP20",
@@ -38689,15 +31023,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -38753,7 +31078,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -38765,7 +31091,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -38777,42 +31104,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -38822,49 +31113,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XVG": {
-        "coin": "XVG",
-        "type": "UTXO",
-        "name": "Verge",
-        "coinpaprika_id": "xvg-verge",
-        "coingecko_id": "verge",
-        "livecoinwatch_id": "XVG",
-        "explorer_url": "https://xvgblockexplorer.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "VERGE Signed Message:\n",
-        "fname": "Verge",
-        "isPoS": 1,
-        "rpcport": 20102,
-        "pubtype": 30,
-        "p2shtype": 33,
-        "wiftype": 158,
-        "decimals": 6,
-        "segwit": true,
-        "bech32_hrp": "vg",
-        "txfee": 400000,
-        "dust": 400000,
-        "force_min_relay_fee": true,
-        "mm2": 1,
-        "required_confirmations": 10,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/77'",
-        "electrum": [
-            {
-                "url": "88.99.26.209:5036"
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -38906,15 +31156,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -39013,15 +31254,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -39077,24 +31309,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -39293,15 +31507,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -39357,24 +31562,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -39439,7 +31626,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10058",
+                "url": "electrum1.cipig.net:20058",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39451,7 +31639,8 @@
                 "ws_url": "electrum1.cipig.net:30058"
             },
             {
-                "url": "electrum2.cipig.net:10058",
+                "url": "electrum2.cipig.net:20058",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39463,42 +31652,6 @@
                 "ws_url": "electrum2.cipig.net:30058"
             },
             {
-                "url": "electrum3.cipig.net:10058",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30058"
-            },
-            {
-                "url": "electrum1.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20058",
                 "protocol": "SSL",
                 "contact": [
@@ -39508,7 +31661,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30058"
             }
         ],
         "explorer_block_url": "block/"
@@ -39548,7 +31702,8 @@
         "derivation_path": "m/44'/323'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10065",
+                "url": "electrum1.cipig.net:20065",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39560,7 +31715,8 @@
                 "ws_url": "electrum1.cipig.net:30065"
             },
             {
-                "url": "electrum2.cipig.net:10065",
+                "url": "electrum2.cipig.net:20065",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39572,42 +31728,6 @@
                 "ws_url": "electrum2.cipig.net:30065"
             },
             {
-                "url": "electrum3.cipig.net:10065",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30065"
-            },
-            {
-                "url": "electrum1.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20065",
                 "protocol": "SSL",
                 "contact": [
@@ -39617,7 +31737,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30065"
             }
         ],
         "explorer_block_url": "block/"
@@ -39662,15 +31783,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -39682,46 +31794,6 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
-    },
-    "ZET": {
-        "coin": "ZET",
-        "type": "UTXO",
-        "name": "Zetacoin",
-        "coinpaprika_id": "zet-zetacoin",
-        "coingecko_id": "zetacoin",
-        "livecoinwatch_id": "ZET",
-        "explorer_url": "https://chainz.cryptoid.info/zet/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Zetacoin Signed Message:\n",
-        "fname": "Zetacoin",
-        "isPoS": 1,
-        "rpcport": 22014,
-        "pubtype": 20,
-        "p2shtype": 85,
-        "wiftype": 153,
-        "txfee": 100000,
-        "dust": 100000,
-        "mm2": 1,
-        "mature_confirmations": 500,
-        "required_confirmations": 7,
-        "avg_blocktime": 45,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "207.180.252.200:50011",
-                "protocol": "TCP",
-                "ws_url": "207.180.252.200:50013"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "ZIL-BEP20": {
         "coin": "ZIL-BEP20",
@@ -39760,15 +31832,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -39871,24 +31934,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -40001,7 +32046,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40013,7 +32059,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40025,42 +32072,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40070,7 +32081,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40109,11 +32121,6 @@
         },
         "derivation_path": "m/44'/19167'",
         "electrum": [
-            {
-                "url": "electrumx2.runonflux.io:50001",
-                "protocol": "TCP",
-                "ws_url": "electrumx2.runonflux.io:50004"
-            },
             {
                 "url": "electrumx.runonflux.io:50002",
                 "protocol": "SSL",
@@ -40161,24 +32168,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -40240,15 +32229,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -40303,7 +32283,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40315,7 +32296,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40327,42 +32309,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40372,7 +32318,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40419,7 +32366,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40431,7 +32379,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40443,42 +32392,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40488,7 +32401,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40535,7 +32449,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40547,7 +32462,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40559,42 +32475,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40604,7 +32484,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40651,7 +32532,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40663,7 +32545,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40675,42 +32558,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40720,7 +32567,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40767,7 +32615,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40779,7 +32628,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40791,42 +32641,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40836,7 +32650,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40883,7 +32698,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40895,7 +32711,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40907,42 +32724,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40952,7 +32733,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40999,7 +32781,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41011,7 +32794,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41023,42 +32807,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -41068,7 +32816,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -41115,7 +32864,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41127,7 +32877,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41139,42 +32890,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -41184,7 +32899,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -41232,24 +32948,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41314,24 +33012,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41399,24 +33079,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41482,24 +33144,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41560,24 +33204,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41636,24 +33262,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41720,24 +33328,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41796,24 +33386,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41881,24 +33453,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41961,24 +33515,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42084,24 +33620,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42160,24 +33678,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42242,24 +33742,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42327,24 +33809,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42405,24 +33869,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42481,24 +33927,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42565,24 +33993,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42641,24 +34051,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42721,24 +34113,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42799,15 +34173,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -42858,24 +34223,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42936,15 +34283,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -43046,17 +34384,6 @@
         },
         "electrum": [
             {
-                "url": "swap.softbalanced.com:50001",
-                "contact": [
-                    {
-                        "email": "dev@softbalanced.com"
-                    },
-                    {
-                        "discord": "softbalanced#4045"
-                    }
-                ]
-            },
-            {
                 "url": "swap.softbalanced.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -43137,34 +34464,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx1.cointest.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -43233,34 +34532,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrumx1.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
             {
                 "url": "electrumx1.cointest.com:50002",
                 "protocol": "SSL",
@@ -43404,15 +34675,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -43457,7 +34719,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10002",
+                "url": "electrum1.cipig.net:20002",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -43469,7 +34732,8 @@
                 "ws_url": "electrum1.cipig.net:30002"
             },
             {
-                "url": "electrum2.cipig.net:10002",
+                "url": "electrum2.cipig.net:20002",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -43481,42 +34745,6 @@
                 "ws_url": "electrum2.cipig.net:30002"
             },
             {
-                "url": "electrum3.cipig.net:10002",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30002"
-            },
-            {
-                "url": "electrum1.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20002",
                 "protocol": "SSL",
                 "contact": [
@@ -43526,7 +34754,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30002"
             }
         ],
         "explorer_block_url": "block/"
@@ -43581,30 +34810,6 @@
         },
         "required_confirmations": 3,
         "electrum": [
-            {
-                "url": "zombie.dragonhound.info:10033",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30058"
-            },
-            {
-                "url": "zombie.dragonhound.info:10133",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30059"
-            },
             {
                 "url": "zombie.dragonhound.info:20033",
                 "protocol": "SSL",
@@ -43673,15 +34878,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -43726,30 +34922,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrum1.runebase.io:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.runebase.io:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ]
-            },
             {
                 "url": "electrum3.runebase.io:50002",
                 "protocol": "SSL",
@@ -43798,22 +34970,6 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
-            {
-                "url": "electrumx1.actioncoin.com:10001",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.actioncoin.com:10001",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
-            },
             {
                 "url": "electrumx1.actioncoin.com:30001",
                 "ws_url": "electrumx1.actioncoin.com:20001",
@@ -43874,15 +35030,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -44087,25 +35234,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx.mazanode.com:50001",
-                "contact": [
-                    {
-                        "email": "brian@mazacoin.org"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.mazacha.in:50001",
-                "contact": [
-                    {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx.mazanode.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -44127,6 +35255,16 @@
                     }
                 ],
                 "ws_url": "electrumx2.mazacha.in:50005"
+            },
+            {
+                "url": "electrum.seed.mazanode.com:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ],
+                "ws_url": "electrum.seed.mazanode.com:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -44169,28 +35307,6 @@
             "homepage": "https://coin.crionic.org"
         },
         "electrum": [
-            {
-                "url": "coin.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "explorer.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
             {
                 "url": "coin.crionic.org:50002",
                 "protocol": "SSL",
@@ -44255,28 +35371,6 @@
             "homepage": "https://evrmorecoin.org"
         },
         "electrum": [
-            {
-                "url": "electrum1-mainnet.evrmorecoin.org:50001",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2-mainnet.evrmorecoin.org:50001",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ]
-            },
             {
                 "url": "electrum1-mainnet.evrmorecoin.org:50002",
                 "protocol": "SSL",

--- a/utils/coins_config_ssl.json
+++ b/utils/coins_config_ssl.json
@@ -6452,10 +6452,9 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:34333",
+                "url": "chicago.ecoincore.com:34333",
                 "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
+                "disable_cert_verification": true
             },
             {
                 "url": "miami.ecoincore.com:34333",
@@ -6509,10 +6508,9 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:34333",
+                "url": "chicago.ecoincore.com:34333",
                 "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
+                "disable_cert_verification": true
             },
             {
                 "url": "miami.ecoincore.com:34333",
@@ -9800,6 +9798,17 @@
                     }
                 ],
                 "ws-url": "itchy-jellyfish-89.doi.works:50004"
+            },
+            {
+                "url": "pink-deer-69.doi.works:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues",
+                        "twitter": "example_username"
+                    }
+                ],
+                "ws-url": "pink-deer-69.doi.works:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -11691,6 +11700,16 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50003",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ],
+                "ws_url": "electrumx2.fujicoin.org:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -11745,6 +11764,16 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50003",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ],
+                "ws_url": "electrumx2.fujicoin.org:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -12824,6 +12853,79 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "GLEEC": {
+        "coin": "GLEEC",
+        "type": "Smart Chain",
+        "name": "Gleec",
+        "coinpaprika_id": "gleec-gleec-coin",
+        "coingecko_id": "gleec-coin",
+        "livecoinwatch_id": "GLEEC",
+        "explorer_url": "https://gleec.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "GLEEC",
+        "fname": "Gleec",
+        "rpcport": 23226,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrum1.cipig.net:20022",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum1.cipig.net:30022"
+            },
+            {
+                "url": "electrum2.cipig.net:20022",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum2.cipig.net:30022"
+            },
+            {
+                "url": "electrum3.cipig.net:20022",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum3.cipig.net:30022"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "GLM-ERC20": {
         "coin": "GLM-ERC20",
         "type": "ERC-20",
@@ -13292,6 +13394,16 @@
                     }
                 ],
                 "ws_url": "electrum.maxpuig.com:50004"
+            },
+            {
+                "url": "fr.garlium.crapules.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "orpheas#1503"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -22426,6 +22538,16 @@
                         "discord": "PRUX-Coin#1668"
                     }
                 ]
+            },
+            {
+                "url": "txserver.live:50002",
+                "protocol": "SSL",
+                "ws_url": "txserver.live:30001",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -26276,6 +26398,19 @@
                     }
                 ],
                 "ws_url": "electrum2.cipig.net:30068"
+            },
+            {
+                "url": "electrum3.cipig.net:20068",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum3.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -26339,6 +26474,19 @@
                     }
                 ],
                 "ws_url": "electrum2.cipig.net:30068"
+            },
+            {
+                "url": "electrum3.cipig.net:20068",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum3.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"

--- a/utils/coins_config_tcp.json
+++ b/utils/coins_config_tcp.json
@@ -35,10 +35,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -79,10 +75,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -128,10 +120,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -139,15 +127,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -188,10 +167,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -199,15 +174,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -249,10 +215,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -266,24 +228,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -371,10 +315,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -418,10 +358,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -467,10 +403,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -511,10 +443,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -522,15 +450,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -577,10 +496,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -594,24 +509,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -654,10 +551,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -788,10 +681,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -881,10 +770,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -892,15 +777,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -941,10 +817,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -952,15 +824,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -1006,10 +869,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1023,24 +882,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -1084,10 +925,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -1129,10 +966,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1146,24 +979,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -1206,10 +1021,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -1255,10 +1066,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1272,24 +1079,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -1332,10 +1121,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -1380,10 +1165,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -1391,15 +1172,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -1440,10 +1212,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1457,24 +1225,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -1517,10 +1267,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -1566,10 +1312,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1583,24 +1325,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -1644,10 +1368,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -1655,15 +1375,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -1705,10 +1416,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
-            {
                 "url": "https://rpc.fantom.network"
             }
         ],
@@ -1749,10 +1456,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -1797,10 +1500,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -1808,15 +1507,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -1857,10 +1547,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1874,24 +1560,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -2044,10 +1712,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2055,15 +1719,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -2104,10 +1759,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2115,15 +1766,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -2164,10 +1806,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -2264,10 +1902,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2275,15 +1909,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -2355,10 +1980,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -2399,10 +2020,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2410,15 +2027,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -2525,10 +2133,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -2572,10 +2176,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2589,24 +2189,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -2727,10 +2309,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2738,15 +2316,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -2792,10 +2361,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2809,24 +2374,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -2907,10 +2454,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2918,15 +2461,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -2967,10 +2501,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -2978,15 +2508,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -3033,10 +2554,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3050,24 +2567,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -3155,10 +2654,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -3202,10 +2697,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -3213,15 +2704,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -3262,10 +2744,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -3273,15 +2751,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -3323,10 +2792,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3340,24 +2805,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -3401,10 +2848,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
-            {
                 "url": "https://rpc.fantom.network"
             }
         ],
@@ -3445,10 +2888,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -3494,10 +2933,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -3542,10 +2977,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3559,24 +2990,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -3619,10 +3032,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -3630,15 +3039,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -3723,10 +3123,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -4002,10 +3398,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -4019,24 +3411,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -4182,10 +3556,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -4304,10 +3674,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -4315,15 +3681,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -4364,10 +3721,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -4413,10 +3766,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -4430,24 +3779,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -4491,10 +3822,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -4502,15 +3829,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -4594,10 +3912,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -4605,15 +3919,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -4770,10 +4075,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -4781,15 +4082,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -4895,10 +4187,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -4906,15 +4194,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -4998,10 +4277,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -5015,24 +4290,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -5150,10 +4407,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -5161,15 +4414,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -5216,10 +4460,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -5233,24 +4473,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -5293,10 +4515,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -5342,10 +4560,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -5353,15 +4567,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -5404,10 +4609,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -5421,24 +4622,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -5482,10 +4665,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -5499,24 +4678,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -5560,10 +4721,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -5609,10 +4766,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -5657,10 +4810,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -5961,10 +5110,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -5972,15 +5117,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -6067,10 +5203,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -6078,15 +5210,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -6293,10 +5416,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -6304,15 +5423,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -6354,10 +5464,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -6365,15 +5471,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -6420,10 +5517,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -6437,24 +5530,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -6497,10 +5572,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -6650,10 +5721,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -6661,15 +5728,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -6711,10 +5769,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -6755,10 +5809,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -6849,10 +5899,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -6866,24 +5912,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -6926,10 +5954,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -6937,15 +5961,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -6986,10 +6001,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -7035,10 +6046,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7052,24 +6059,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -7113,10 +6102,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -7162,10 +6147,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -7173,15 +6154,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -7223,10 +6195,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -7234,15 +6202,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -7360,10 +6319,10 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "miami.ecoincore.com:34333",
+                "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
+                "ws_url": "lenoir.ecoincore.com:34335"
             },
             {
                 "url": "oakland.ecoincore.com:34333",
@@ -7416,10 +6375,10 @@
                 "disable_cert_verification": true
             },
             {
-                "url": "miami.ecoincore.com:34333",
+                "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
+                "ws_url": "lenoir.ecoincore.com:34335"
             },
             {
                 "url": "oakland.ecoincore.com:34333",
@@ -7465,10 +6424,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7482,24 +6437,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -7542,10 +6479,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -7596,10 +6529,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7613,24 +6542,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -7674,10 +6585,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -7685,15 +6592,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -7733,10 +6631,6 @@
         "swap_contract_address": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "fallback_swap_contract": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/arbitrum",
-                "gui_auth": true
-            },
             {
                 "url": "https://arb1.arbitrum.io/rpc"
             }
@@ -7779,10 +6673,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -7790,15 +6680,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -7981,10 +6862,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7998,24 +6875,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -8058,10 +6917,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -8107,10 +6962,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -8124,24 +6975,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -8228,10 +7061,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -8322,10 +7151,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -8366,10 +7191,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -8377,15 +7198,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -8432,10 +7244,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -8449,24 +7257,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -8554,10 +7344,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -8602,10 +7388,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -8619,24 +7401,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -8724,10 +7488,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -8772,10 +7532,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -8789,24 +7545,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -8850,10 +7588,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -8894,10 +7628,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -8984,10 +7714,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -9031,10 +7757,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -9042,15 +7764,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -9092,10 +7805,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9109,24 +7818,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -9330,10 +8021,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -9379,10 +8066,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9396,24 +8079,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -9456,10 +8121,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -9467,15 +8128,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -9516,10 +8168,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -9650,10 +8298,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -9775,10 +8419,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9792,24 +8432,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -9856,10 +8478,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9873,24 +8491,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -9934,10 +8534,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9951,24 +8547,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -10011,10 +8589,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -10266,10 +8840,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -10283,24 +8853,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -10344,10 +8896,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -10355,15 +8903,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -10472,10 +9011,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -10483,15 +9018,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -10614,10 +9140,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -10625,15 +9147,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -10675,10 +9188,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -10692,24 +9201,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -10875,10 +9366,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -10886,15 +9373,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -10935,10 +9413,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -10946,15 +9420,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -10995,10 +9460,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -11006,15 +9467,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -11055,10 +9507,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -11066,15 +9514,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -11394,10 +9833,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -11405,15 +9840,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -11455,10 +9881,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -11472,24 +9894,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -11532,10 +9936,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -11543,15 +9943,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -11598,10 +9989,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -11615,24 +10002,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -11755,10 +10124,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -11772,24 +10137,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -11877,10 +10224,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -11924,10 +10267,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -11935,15 +10274,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -11989,9 +10319,6 @@
             },
             {
                 "url": "https://besu-de.etc-network.info"
-            },
-            {
-                "url": "https://besu-at.etc-network.info"
             }
         ],
         "explorer_block_url": "block/"
@@ -12031,10 +10358,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -12042,15 +10365,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -12086,10 +10400,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12103,24 +10413,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -12164,10 +10456,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -12200,10 +10488,6 @@
         "swap_contract_address": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "fallback_swap_contract": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/arbitrum",
-                "gui_auth": true
-            },
             {
                 "url": "https://arb1.arbitrum.io/rpc"
             }
@@ -12245,10 +10529,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -12256,15 +10536,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -12305,10 +10576,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -12439,10 +10706,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -12487,10 +10750,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12504,24 +10763,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -12565,10 +10806,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -12619,10 +10856,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12636,24 +10869,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -12697,10 +10912,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -12785,10 +10996,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -12796,15 +11003,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -12846,10 +11044,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12863,24 +11057,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -12924,10 +11100,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12941,24 +11113,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -13002,10 +11156,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13013,15 +11163,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -13062,10 +11203,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -13110,10 +11247,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13121,15 +11254,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -13171,10 +11295,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13188,24 +11308,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -13356,10 +11458,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13367,15 +11465,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -13558,10 +11647,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13569,15 +11654,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -13618,10 +11694,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13629,15 +11701,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -13678,10 +11741,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13689,15 +11748,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -13739,10 +11789,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13756,24 +11802,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -13817,10 +11845,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -13828,15 +11852,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -14070,10 +12085,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
-            {
                 "url": "https://rpc.fantom.network"
             }
         ],
@@ -14114,10 +12125,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -14125,15 +12132,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -14179,10 +12177,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -14196,24 +12190,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -14257,10 +12233,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -14268,15 +12240,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -14318,10 +12281,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -14335,24 +12294,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -14395,10 +12336,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -14443,10 +12380,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -14533,10 +12466,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
-            {
                 "url": "https://rpc.fantom.network"
             }
         ],
@@ -14578,10 +12507,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -14595,24 +12520,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -14656,10 +12563,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -14667,15 +12570,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -14717,10 +12611,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -14728,15 +12618,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -14851,10 +12732,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -14868,24 +12745,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -14928,10 +12787,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -14976,10 +12831,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -14987,15 +12838,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -15037,10 +12879,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -15048,15 +12886,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -15097,10 +12926,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -15147,10 +12972,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15164,24 +12985,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -15224,10 +13027,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -15272,10 +13071,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -15387,10 +13182,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15404,24 +13195,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -15465,10 +13238,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -15476,15 +13245,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -15686,10 +13446,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -15736,10 +13492,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15753,24 +13505,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -15858,10 +13592,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -15906,10 +13636,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -15917,15 +13643,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -15967,10 +13684,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15984,24 +13697,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -16045,10 +13740,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16062,24 +13753,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -16128,10 +13801,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16145,24 +13814,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -16205,10 +13856,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -16254,10 +13901,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16271,24 +13914,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -16331,10 +13956,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -16424,10 +14045,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16441,24 +14058,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -16502,10 +14101,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16519,24 +14114,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -16667,10 +14244,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -16857,10 +14430,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -16868,15 +14437,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -16917,10 +14477,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -16966,10 +14522,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -17014,10 +14566,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17031,24 +14579,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -17092,10 +14622,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17103,15 +14629,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17153,10 +14670,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17170,24 +14683,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -17230,10 +14725,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17241,15 +14732,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17290,10 +14772,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17307,24 +14785,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -17367,10 +14827,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17378,15 +14834,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17427,10 +14874,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17438,15 +14881,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17487,10 +14921,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -17535,10 +14965,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17546,15 +14972,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17595,10 +15012,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -17645,10 +15058,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17656,15 +15065,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17706,10 +15106,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -17756,10 +15152,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -17805,10 +15197,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -17850,10 +15238,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -17861,15 +15245,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -17911,10 +15286,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17928,24 +15299,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -17989,10 +15342,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18039,10 +15388,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -18088,10 +15433,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -18133,10 +15474,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -18144,15 +15481,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -18194,10 +15522,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18211,24 +15535,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -18272,10 +15578,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18322,10 +15624,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -18333,15 +15631,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -18383,10 +15672,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18400,24 +15685,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -18461,10 +15728,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18511,10 +15774,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -18559,10 +15818,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18609,10 +15864,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -18657,10 +15908,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18707,10 +15954,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -18755,10 +15998,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18805,10 +16044,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -18854,10 +16089,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -18899,10 +16130,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -18948,10 +16175,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18965,24 +16188,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -19025,10 +16230,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -19073,10 +16274,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -19123,10 +16320,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -19171,10 +16364,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -19221,10 +16410,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -19270,10 +16455,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -19281,15 +16462,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -19453,10 +16625,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -19464,15 +16632,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -19513,10 +16672,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -19524,15 +16679,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -19578,10 +16724,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -19595,24 +16737,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -19655,10 +16779,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -19703,10 +16823,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -19822,10 +16938,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -19833,15 +16945,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -20161,10 +17264,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20178,24 +17277,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -20238,10 +17319,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -20291,10 +17368,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20308,24 +17381,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -20368,10 +17423,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -20416,10 +17467,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20433,24 +17480,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -20494,10 +17523,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -20538,10 +17563,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -20549,15 +17570,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -20598,10 +17610,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -20732,10 +17740,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -20780,10 +17784,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -20791,15 +17791,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -20846,10 +17837,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20863,24 +17850,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -20924,10 +17893,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -20935,15 +17900,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -20984,10 +17940,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -21120,10 +18072,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -21137,24 +18085,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -21203,10 +18133,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -21220,24 +18146,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -21281,10 +18189,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -21292,15 +18196,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -21342,10 +18237,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -21353,15 +18244,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -21622,10 +18504,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -21639,24 +18517,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -21700,10 +18560,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -21711,15 +18567,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -21805,10 +18652,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -21853,10 +18696,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -21864,15 +18703,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -21914,10 +18744,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -21931,24 +18757,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -21991,10 +18799,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -22075,10 +18879,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -22122,10 +18922,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -22133,15 +18929,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -22187,10 +18974,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22204,24 +18987,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -22353,10 +19118,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22370,24 +19131,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -22431,10 +19174,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -22442,15 +19181,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -22569,10 +19299,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22586,24 +19312,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -22720,10 +19428,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22737,24 +19441,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -22798,10 +19484,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -22809,15 +19491,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -22859,10 +19532,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -22903,10 +19572,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -22914,15 +19579,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -22969,10 +19625,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22986,24 +19638,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -23094,10 +19728,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -23111,24 +19741,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -23172,10 +19784,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -23217,10 +19825,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -23228,15 +19832,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -23321,10 +19916,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -23599,10 +20190,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -23610,15 +20197,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -23659,10 +20237,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -23670,15 +20244,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -23789,10 +20354,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -23806,24 +20367,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -23910,10 +20453,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -24207,10 +20746,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -24218,15 +20753,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -24350,10 +20876,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24367,24 +20889,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -24428,10 +20932,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -24477,10 +20977,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -24488,15 +20984,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -24542,10 +21029,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24559,24 +21042,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -24619,10 +21084,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -24673,10 +21134,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24690,24 +21147,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -24751,10 +21190,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -24791,10 +21226,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/harmony",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.harmony.one"
             },
@@ -24839,10 +21270,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -24850,15 +21277,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -24904,10 +21322,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24921,24 +21335,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -24981,10 +21377,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -24992,15 +21384,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -25086,10 +21469,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -25133,10 +21512,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -25144,15 +21519,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -25199,10 +21565,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -25216,24 +21578,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -25276,10 +21620,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -25505,10 +21845,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -25522,24 +21858,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -25582,10 +21900,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -25635,10 +21949,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -25652,24 +21962,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -25712,10 +22004,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -25815,10 +22103,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -25832,24 +22116,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -25892,10 +22158,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -25940,10 +22202,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -25951,15 +22209,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -26001,10 +22250,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26018,24 +22263,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -26078,10 +22305,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -26188,10 +22411,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -26199,15 +22418,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -26252,10 +22462,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26269,24 +22475,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -26619,10 +22807,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -26630,15 +22814,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -26683,10 +22858,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26700,24 +22871,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -26766,10 +22919,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26783,24 +22932,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -27141,10 +23272,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27158,24 +23285,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -27428,10 +23537,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27445,24 +23550,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -27553,10 +23640,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27570,24 +23653,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -27631,10 +23696,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27648,24 +23709,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -27708,10 +23751,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -27907,10 +23946,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27924,24 +23959,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -27984,10 +24001,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -28033,10 +24046,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28050,24 +24059,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -28110,10 +24101,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -28159,10 +24146,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28176,24 +24159,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -28242,10 +24207,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28259,24 +24220,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -28361,10 +24304,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -28372,15 +24311,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -28500,10 +24430,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28517,24 +24443,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -28578,10 +24486,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -28589,15 +24493,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -28638,10 +24533,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -28687,10 +24578,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -28698,15 +24585,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -28748,10 +24626,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -28759,15 +24633,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -28809,10 +24674,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -28853,10 +24714,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -28864,15 +24721,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -28919,10 +24767,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28936,24 +24780,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -28996,10 +24822,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -29086,10 +24908,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -29134,10 +24952,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -29145,15 +24959,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -29194,10 +24999,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -29242,10 +25043,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -29259,24 +25056,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -29393,10 +25172,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -29410,24 +25185,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -29470,10 +25227,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -29592,10 +25345,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -29636,10 +25385,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -29647,15 +25392,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -29702,10 +25438,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -29719,24 +25451,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -29779,10 +25493,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -29913,10 +25623,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -29960,10 +25666,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -29971,15 +25673,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -30020,10 +25713,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -30031,15 +25720,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -30081,10 +25761,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30098,24 +25774,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -30366,10 +26024,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30383,24 +26037,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -30592,10 +26228,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30609,24 +26241,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -30714,10 +26328,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -30762,10 +26372,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -30773,15 +26379,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -30873,10 +26470,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -30884,15 +26477,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31005,10 +26589,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31022,24 +26602,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -31083,10 +26645,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31094,15 +26652,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31183,10 +26732,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31194,15 +26739,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31244,10 +26780,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31255,15 +26787,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31304,10 +26827,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -31350,10 +26869,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31361,15 +26876,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31411,10 +26917,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -31460,10 +26962,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31477,24 +26975,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -31538,10 +27018,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31549,15 +27025,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31599,10 +27066,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31610,15 +27073,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -31664,10 +27118,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31681,24 +27131,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -31742,10 +27174,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -31786,10 +27214,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -31920,10 +27344,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -31968,10 +27388,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -31979,15 +27395,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -32033,10 +27440,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -32050,24 +27453,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -32110,10 +27495,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -32197,10 +27578,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -32242,10 +27619,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -32259,24 +27632,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -32319,10 +27674,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -32367,10 +27718,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -32417,10 +27764,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -32434,24 +27777,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -32494,10 +27819,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -32505,15 +27826,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -32643,10 +27955,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -32741,10 +28049,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -32785,10 +28089,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -32835,10 +28135,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -32852,24 +28148,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -32912,10 +28190,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -32923,15 +28197,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -32971,10 +28236,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -33149,10 +28410,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -33197,10 +28454,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -33208,15 +28461,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -33258,10 +28502,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -33275,24 +28515,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -33379,10 +28601,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -33513,10 +28731,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -33560,10 +28774,6 @@
         "fallback_swap_contract": "0x9130b257d37a52e52f21054c4da3450c72f595ce",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/arbitrum",
-                "gui_auth": true
-            },
-            {
                 "url": "https://arb1.arbitrum.io/rpc"
             }
         ],
@@ -33604,10 +28814,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -33650,10 +28856,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -33694,10 +28896,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -33705,15 +28903,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -33758,10 +28947,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -33775,24 +28960,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -33835,10 +29002,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -33852,24 +29015,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -33978,10 +29123,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -33989,15 +29130,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -34037,10 +29169,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34054,24 +29182,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -34115,10 +29225,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34132,24 +29238,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -34192,10 +29280,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -34334,10 +29418,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -34345,15 +29425,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -34681,10 +29752,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -34692,15 +29759,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -34747,10 +29805,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34764,24 +29818,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -34824,10 +29860,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -34873,10 +29905,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34890,24 +29918,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -34951,10 +29961,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34968,24 +29974,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -35029,10 +30017,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -35074,10 +30058,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -35085,15 +30065,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -35135,10 +30106,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
-            {
                 "url": "https://rpc.fantom.network"
             }
         ],
@@ -35179,10 +30146,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -35228,10 +30191,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -35245,24 +30204,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -35306,10 +30247,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -35317,15 +30254,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -35434,10 +30362,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -35445,15 +30369,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -35495,10 +30410,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -35512,24 +30423,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -35574,10 +30467,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -35621,10 +30510,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -35632,15 +30517,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -35945,10 +30821,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -35956,15 +30828,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -36006,10 +30869,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -36023,24 +30882,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -36089,10 +30930,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -36106,24 +30943,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -36167,10 +30986,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -36216,10 +31031,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -36227,15 +31038,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -36313,10 +31115,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -36324,15 +31122,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -36497,10 +31286,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -36508,15 +31293,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -36558,10 +31334,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
-            {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
         ],
@@ -36602,10 +31374,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -36613,15 +31381,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -36668,10 +31427,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -36685,24 +31440,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -36745,10 +31482,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/fantom",
-                "gui_auth": true
-            },
             {
                 "url": "https://rpc.fantom.network"
             }
@@ -36835,10 +31568,6 @@
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
-            {
                 "url": "https://polygon-rpc.com"
             },
             {
@@ -36882,10 +31611,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -36893,15 +31618,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -36948,10 +31664,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -36965,24 +31677,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -37185,10 +31879,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -37196,15 +31886,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -37284,10 +31965,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -37295,15 +31972,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -37344,10 +32012,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/avalanche",
-                "gui_auth": true
-            },
             {
                 "url": "https://api.avax.network/ext/bc/C/rpc"
             }
@@ -37395,10 +32059,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -37412,24 +32072,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -37472,10 +32114,6 @@
         "swap_contract_address": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
         "nodes": [
-            {
-                "url": "https://node.komodo.earth:8080/polygon",
-                "gui_auth": true
-            },
             {
                 "url": "https://polygon-rpc.com"
             },
@@ -37652,10 +32290,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -37669,24 +32303,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -37729,10 +32345,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -37740,15 +32352,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -38459,10 +33062,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38476,24 +33075,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -38541,10 +33122,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38558,24 +33135,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -38624,10 +33183,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38641,24 +33196,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -38707,10 +33244,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38724,24 +33257,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -38785,10 +33300,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38802,24 +33313,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -38863,10 +33356,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38880,24 +33369,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -38945,10 +33416,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -38962,24 +33429,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39023,10 +33472,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39040,24 +33485,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39106,10 +33533,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39123,24 +33546,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39188,10 +33593,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39205,24 +33606,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39309,10 +33692,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39326,24 +33705,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39387,10 +33748,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39404,24 +33761,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39469,10 +33808,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39486,24 +33821,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39552,10 +33869,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39569,24 +33882,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39630,10 +33925,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39647,24 +33938,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39708,10 +33981,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39725,24 +33994,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39790,10 +34041,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39807,24 +34054,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39868,10 +34097,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39885,24 +34110,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -39946,10 +34153,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -39963,24 +34166,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -40024,10 +34209,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -40035,15 +34216,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -40085,10 +34257,6 @@
         "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/ethereum",
-                "gui_auth": true
-            },
-            {
                 "url": "http://eth1.cipig.net:8555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -40102,24 +34270,6 @@
             },
             {
                 "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth1.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth2.cipig.net:18555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "https://eth3.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
@@ -40163,10 +34313,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -40174,15 +34320,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -40601,10 +34738,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -40612,15 +34745,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -40824,10 +34948,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -40835,15 +34955,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",
@@ -41019,10 +35130,6 @@
         "fallback_swap_contract": "0xeDc5b89Fe1f0382F9E4316069971D90a0951DB31",
         "nodes": [
             {
-                "url": "https://node.komodo.earth:8080/binance",
-                "gui_auth": true
-            },
-            {
                 "url": "http://bsc1.cipig.net:8655"
             },
             {
@@ -41030,15 +35137,6 @@
             },
             {
                 "url": "http://bsc3.cipig.net:8655"
-            },
-            {
-                "url": "https://bsc1.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc2.cipig.net:18655"
-            },
-            {
-                "url": "https://bsc3.cipig.net:18655"
             }
         ],
         "token_address_url": "tokentxns?a=",

--- a/utils/coins_config_tcp.json
+++ b/utils/coins_config_tcp.json
@@ -2834,6 +2834,44 @@
         ],
         "explorer_block_url": "block/"
     },
+    "AYA": {
+        "coin": "AYA",
+        "type": "UTXO",
+        "name": "Aryacoin",
+        "coinpaprika_id": "aya-aryacoin",
+        "coingecko_id": "aryacoin",
+        "livecoinwatch_id": "AYA",
+        "explorer_url": "https://explorer.aryacoin.io/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Aryacoin Signed Message:\n",
+        "fname": "Aryacoin",
+        "rpcport": 9332,
+        "pubtype": 23,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 100000,
+        "dust": 54600,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/357'",
+        "electrum": [
+            {
+                "url": "88.99.26.209:5151"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "BABYDOGE-BEP20": {
         "coin": "BABYDOGE-BEP20",
         "type": "BEP-20",
@@ -4188,6 +4226,46 @@
         "token_id": "bb553ac2ac7af0fcd4f24f9dfacc7f925bfb1446c6e18c7966db95a8d50fb378",
         "parent_coin": "SLP",
         "token_address_url": "token/",
+        "explorer_block_url": "block/"
+    },
+    "BBK": {
+        "coin": "BBK",
+        "type": "UTXO",
+        "name": "BitBlocks",
+        "coinpaprika_id": "bbk-bitblocks",
+        "coingecko_id": "",
+        "livecoinwatch_id": "BBK",
+        "explorer_url": "https://bbk.ccore.online/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": true,
+        "sign_message_prefix": "DarkNet Signed Message:\n",
+        "fname": "BitBlocks",
+        "rpcport": 59768,
+        "pubtype": 25,
+        "p2shtype": 85,
+        "wiftype": 107,
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "links": {
+            "github": "https://github.com/BitBlocksProject/BitBlocks",
+            "homepage": "https://bitblocksproject.com"
+        },
+        "electrum": [
+            {
+                "url": "bbk-one.ewm-cx.net:50001",
+                "protocol": "TCP"
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "BBK-BEP20": {
@@ -5908,6 +5986,51 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "BTCZ": {
+        "coin": "BTCZ",
+        "type": "UTXO",
+        "name": "BitcoinZ",
+        "coinpaprika_id": "btcz-bitcoinz",
+        "coingecko_id": "bitcoinz",
+        "livecoinwatch_id": "BTCZ",
+        "explorer_url": "https://explorer.btcz.rocks/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "address/",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "BitcoinZ Signed Message:\n",
+        "fname": "BitcoinZ",
+        "rpcport": 1979,
+        "taddr": 28,
+        "pubtype": 184,
+        "p2shtype": 189,
+        "wiftype": 128,
+        "txfee": 10000,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/177'",
+        "electrum": [
+            {
+                "url": "electrum2.btcz.rocks:50001",
+                "contact": [
+                    {
+                        "discord": "VandarGR#6065"
+                    }
+                ],
+                "ws_url": "electrum2.btcz.rocks:50004"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "BTCZ-BEP20": {
         "coin": "BTCZ-BEP20",
         "type": "BEP-20",
@@ -7232,10 +7355,9 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:34333",
+                "url": "chicago.ecoincore.com:34333",
                 "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
+                "disable_cert_verification": true
             },
             {
                 "url": "miami.ecoincore.com:34333",
@@ -7289,10 +7411,9 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:34333",
+                "url": "chicago.ecoincore.com:34333",
                 "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
+                "disable_cert_verification": true
             },
             {
                 "url": "miami.ecoincore.com:34333",
@@ -7683,6 +7804,71 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "CHTA": {
+        "coin": "CHTA",
+        "type": "UTXO",
+        "name": "Cheetahcoin",
+        "coinpaprika_id": "chta-cheetahcoin",
+        "coingecko_id": "",
+        "livecoinwatch_id": "CHTA",
+        "explorer_url": "http://chtaexplorer.mooo.com:3002/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Cheetahcoin",
+        "rpcport": 8536,
+        "pubtype": 28,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 40000,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 120,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/682'",
+        "electrum": [
+            {
+                "url": "electrum.shorelinecrypto.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.mooo.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.mooo.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "CHIPS": {
         "coin": "CHIPS",
         "type": "UTXO",
@@ -8051,6 +8237,51 @@
             },
             {
                 "url": "https://poly-rpc.gateway.pokt.network"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "CLC": {
+        "coin": "CLC",
+        "type": "Smart Chain",
+        "name": "Collider Coin",
+        "coinpaprika_id": "clc-collider-coin",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://clc.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "CLC",
+        "fname": "Collider Coin",
+        "rpcport": 31034,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "requires_notarization": false,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrumx.cryptocollider.com:10001",
+                "contact": [
+                    {
+                        "email": "electrumx@cryptocollider.com"
+                    },
+                    {
+                        "discord": "collider#6160"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -9986,15 +10217,15 @@
         "derivation_path": "m/44'/18'",
         "electrum": [
             {
-                "url": "electrumx.dgc.ewmcx.org:50001",
-                "protocol": "TCP",
-                "ws_url": "electrumx.dgc.ewmcx.org:50003"
-            },
-            {
                 "url": "failover.dgc.ewmcx.biz:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
                 "ws_url": "failover.dgc.ewmcx.biz:50003"
+            },
+            {
+                "url": "electrumx.dgc.ewmcx.org:50001",
+                "protocol": "TCP",
+                "ws_url": "electrumx.dgc.ewmcx.org:50003"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -10893,6 +11124,48 @@
         ],
         "explorer_block_url": "block/"
     },
+    "DP": {
+        "coin": "DP",
+        "type": "Smart Chain",
+        "name": "DigitalPrice",
+        "coinpaprika_id": "dp-digitalprice",
+        "coingecko_id": "digitalprice",
+        "livecoinwatch_id": "DP",
+        "explorer_url": "https://dp.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "DP",
+        "fname": "DigitalPrice",
+        "rpcport": 28388,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "requires_notarization": false,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "1.eu.dp.electrum.dexstats.info:10021",
+                "contact": [
+                    {
+                        "discord": "Zanzarismo#6500"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "DOI": {
         "coin": "DOI",
         "type": "UTXO",
@@ -10925,16 +11198,6 @@
         },
         "electrum": [
             {
-                "url": "pink-deer-69.doi.works:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/namecoin/electrum-nmc/issues",
-                        "twitter": "example_username"
-                    }
-                ]
-            },
-            {
                 "url": "big-parrot-60.doi.works:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -10955,6 +11218,17 @@
                     }
                 ],
                 "ws-url": "itchy-jellyfish-89.doi.works:50004"
+            },
+            {
+                "url": "pink-deer-69.doi.works:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues",
+                        "twitter": "example_username"
+                    }
+                ],
+                "ws-url": "pink-deer-69.doi.works:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -13145,24 +13419,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx1.fujicoin.org:50003",
                 "protocol": "SSL",
                 "contact": [
@@ -13171,6 +13427,25 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50003",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ],
+                "ws_url": "electrumx2.fujicoin.org:50005"
+            },
+            {
+                "url": "electrumx1.fujicoin.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -13217,24 +13492,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx1.fujicoin.org:50003",
                 "protocol": "SSL",
                 "contact": [
@@ -13243,6 +13500,25 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50003",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ],
+                "ws_url": "electrumx2.fujicoin.org:50005"
+            },
+            {
+                "url": "electrumx1.fujicoin.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -14498,8 +14774,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10022",
-                "protocol": "TCP",
+                "url": "electrum1.cipig.net:20022",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14507,11 +14783,12 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30022"
             },
             {
-                "url": "electrum2.cipig.net:10022",
-                "protocol": "TCP",
+                "url": "electrum2.cipig.net:20022",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14519,11 +14796,12 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30022"
             },
             {
-                "url": "electrum3.cipig.net:10022",
-                "protocol": "TCP",
+                "url": "electrum3.cipig.net:20022",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14531,7 +14809,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30022"
             }
         ],
         "explorer_block_url": "block/"
@@ -15040,15 +15319,6 @@
         "derivation_path": "m/44'/69420'",
         "electrum": [
             {
-                "url": "electrum.maxpuig.com:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "mecs#4770"
-                    }
-                ]
-            },
-            {
                 "url": "au.garlium.crapules.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -15067,6 +15337,16 @@
                     }
                 ],
                 "ws_url": "electrum.maxpuig.com:50004"
+            },
+            {
+                "url": "fr.garlium.crapules.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "orpheas#1503"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -15260,6 +15540,30 @@
                         "discord": "jackielove4u#0412"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.groestlcoin.org:50001",
+                "ws_url": "electrum1.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
+                "url": "electrum12.groestlcoin.org:50001",
+                "ws_url": "electrum12.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -15310,6 +15614,30 @@
                 "protocol": "SSL",
                 "disable_cert_verification": false,
                 "ws_url": "electrum11.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.groestlcoin.org:50001",
+                "ws_url": "electrum1.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
+                "url": "electrum12.groestlcoin.org:50001",
+                "ws_url": "electrum12.groestlcoin.org:50004",
                 "contact": [
                     {
                         "email": "jackielove4u@hotmail.com"
@@ -16431,6 +16759,67 @@
             }
         ],
         "explorer_block_url": "block.dws?"
+    },
+    "ILN": {
+        "coin": "ILN",
+        "type": "Smart Chain",
+        "name": "Ilien",
+        "coinpaprika_id": "iln-ilien9195",
+        "coingecko_id": "",
+        "livecoinwatch_id": "ILN",
+        "explorer_url": "https://explorer.ilien.io/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "ILN",
+        "fname": "Ilien",
+        "rpcport": 12986,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "p2p": 12985,
+        "magic": "feb4cb23",
+        "nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrum1.ilien.io:65011",
+                "contact": [
+                    {
+                        "email": "admin@ilien.io"
+                    },
+                    {
+                        "discord": "siu - Chainmakers#3920"
+                    }
+                ],
+                "ws_url": "electrum1.ilien.io:30069"
+            },
+            {
+                "url": "electrum2.ilien.io:65011",
+                "contact": [
+                    {
+                        "email": "admin@ilien.io"
+                    },
+                    {
+                        "discord": "siu - Chainmakers#3920"
+                    }
+                ],
+                "ws_url": "electrum2.ilien.io:30069"
+            }
+        ],
+        "explorer_block_url": "block/"
     },
     "ILN-BEP20": {
         "coin": "ILN-BEP20",
@@ -22945,6 +23334,110 @@
         ],
         "explorer_block_url": "block/"
     },
+    "MONA": {
+        "coin": "MONA",
+        "type": "UTXO",
+        "name": "MonaCoin",
+        "coinpaprika_id": "mona-monacoin",
+        "coingecko_id": "monacoin",
+        "livecoinwatch_id": "MONA",
+        "explorer_url": "https://blockbook.electrum-mona.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Monacoin Signed Message:\n",
+        "fname": "MonaCoin",
+        "rpcport": 9402,
+        "pubtype": 50,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 100000,
+        "dust": 100000,
+        "segwit": true,
+        "bech32_hrp": "mona",
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 90,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/22'",
+        "trezor_coin": "Monacoin",
+        "links": {
+            "github": "https://github.com/monacoinproject/monacoin",
+            "homepage": "https://monacoin.org"
+        },
+        "electrum": [
+            {
+                "url": "133.167.67.203:50001"
+            },
+            {
+                "url": "electrumx.tamami-foundation.org:50001"
+            },
+            {
+                "url": "electrumx1.monacoin.ninja:50001"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "MONA-segwit": {
+        "coin": "MONA-segwit",
+        "type": "UTXO",
+        "name": "MonaCoin",
+        "coinpaprika_id": "mona-monacoin",
+        "coingecko_id": "monacoin",
+        "livecoinwatch_id": "MONA",
+        "explorer_url": "https://blockbook.electrum-mona.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Monacoin Signed Message:\n",
+        "fname": "MonaCoin",
+        "rpcport": 9402,
+        "pubtype": 50,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 100000,
+        "dust": 100000,
+        "segwit": true,
+        "bech32_hrp": "mona",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "MONA",
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 90,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/22'",
+        "trezor_coin": "Monacoin",
+        "links": {
+            "github": "https://github.com/monacoinproject/monacoin",
+            "homepage": "https://monacoin.org"
+        },
+        "electrum": [
+            {
+                "url": "133.167.67.203:50001"
+            },
+            {
+                "url": "electrumx.tamami-foundation.org:50001"
+            },
+            {
+                "url": "electrumx1.monacoin.ninja:50001"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "MOVR": {
         "coin": "MOVR",
         "type": "Moonriver",
@@ -23189,6 +23682,71 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "NENG": {
+        "coin": "NENG",
+        "type": "UTXO",
+        "name": "Nengcoin",
+        "coinpaprika_id": "neng-nengcoin",
+        "coingecko_id": "",
+        "livecoinwatch_id": "NENG",
+        "explorer_url": "http://nengexplorer.mooo.com:3001/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Nengcoin",
+        "rpcport": 6376,
+        "pubtype": 53,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 200000,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/681'",
+        "electrum": [
+            {
+                "url": "electrum.shorelinecrypto.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.mooo.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.mooo.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ]
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "NEXO-ERC20": {
@@ -23475,6 +24033,9 @@
                 "url": "nmc2.bitcoins.sk:57002",
                 "protocol": "SSL",
                 "disable_cert_verification": true
+            },
+            {
+                "url": "46.229.238.187:57001"
             }
         ],
         "explorer_block_url": "block/"
@@ -23523,6 +24084,9 @@
                 "url": "nmc2.bitcoins.sk:57002",
                 "protocol": "SSL",
                 "disable_cert_verification": true
+            },
+            {
+                "url": "46.229.238.187:57001"
             }
         ],
         "explorer_block_url": "block/"
@@ -24767,6 +25331,97 @@
         ],
         "explorer_block_url": "block.dws?"
     },
+    "PIVX": {
+        "coin": "PIVX",
+        "type": "UTXO",
+        "name": "PIVX",
+        "coinpaprika_id": "pivx-pivx",
+        "coingecko_id": "pivx",
+        "livecoinwatch_id": "PIVX",
+        "explorer_url": "https://chainz.cryptoid.info/pivx/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "PIVX",
+        "rpcport": 51473,
+        "pubtype": 30,
+        "p2shtype": 13,
+        "wiftype": 212,
+        "txfee": 100000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/119'",
+        "electrum": [
+            {
+                "url": "electrum01.chainster.org:50001",
+                "ws_url": "electrum01.chainster.org:50003",
+                "contact": [
+                    {
+                        "discord": "312541186793406465"
+                    }
+                ]
+            },
+            {
+                "url": "electrum02.chainster.org:50001",
+                "ws_url": "electrum02.chainster.org:50003",
+                "contact": [
+                    {
+                        "discord": "312541186793406465"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
+    "PND": {
+        "coin": "PND",
+        "type": "UTXO",
+        "name": "Pandacoin",
+        "coinpaprika_id": "pnd-pandacoin",
+        "coingecko_id": "pandacoin",
+        "livecoinwatch_id": "PND",
+        "explorer_url": "https://chainz.cryptoid.info/pnd/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Pandacoin",
+        "isPoS": 1,
+        "rpcport": 22444,
+        "pubtype": 55,
+        "p2shtype": 22,
+        "wiftype": 183,
+        "decimals": 6,
+        "txfee": 10000000,
+        "dust": 1000000,
+        "segwit": true,
+        "bech32_hrp": "pn",
+        "mm2": 1,
+        "required_confirmations": 1,
+        "avg_blocktime": 600,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/37'",
+        "electrum": [
+            {
+                "url": "electrum.thepandacoin.net:50001",
+                "ws_url": "electrum.thepandacoin.net:443"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
     "POT": {
         "coin": "POT",
         "type": "UTXO",
@@ -24802,14 +25457,14 @@
         "derivation_path": "m/44'/81'",
         "electrum": [
             {
-                "url": "62.171.189.243:50001",
-                "protocol": "TCP"
-            },
-            {
                 "url": "pot-duo.ewmcx.net:50012",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
                 "ws_url": "pot-duo.ewmcx.net:50013"
+            },
+            {
+                "url": "62.171.189.243:50001",
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -25467,27 +26122,28 @@
         },
         "electrum": [
             {
-                "url": "electrumx.live:50010",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
-                "url": "txserver.live:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx.live:50012",
                 "protocol": "SSL",
                 "ws_url": "electrumx.live:30010",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
+            },
+            {
+                "url": "txserver.live:50002",
+                "protocol": "SSL",
+                "ws_url": "txserver.live:30001",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx.live:50010",
+                "protocol": "TCP",
                 "contact": [
                     {
                         "discord": "PRUX-Coin#1668"
@@ -27628,6 +28284,47 @@
         ],
         "explorer_block_url": "block/"
     },
+    "RTM": {
+        "coin": "RTM",
+        "type": "UTXO",
+        "name": "Raptoreum",
+        "coinpaprika_id": "rtm-raptoreum",
+        "coingecko_id": "raptoreum",
+        "livecoinwatch_id": "RTM",
+        "explorer_url": "https://explorer.raptoreum.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Raptoreum",
+        "rpcport": 9998,
+        "pubtype": 60,
+        "p2shtype": 16,
+        "wiftype": 128,
+        "txfee": 1000,
+        "mm2": 1,
+        "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
+        "required_confirmations": 3,
+        "avg_blocktime": 120,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/10226'",
+        "electrum": [
+            {
+                "url": "x1.raptoreum.com:50001",
+                "ws_url": "x1.raptoreum.com:50004"
+            },
+            {
+                "url": "x2.raptoreum.com:50001",
+                "ws_url": "x2.raptoreum.com:50004"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "RTM-BEP20": {
         "coin": "RTM-BEP20",
         "type": "BEP-20",
@@ -29742,10 +30439,6 @@
         },
         "electrum": [
             {
-                "url": "testnet.aranguren.org:51001",
-                "protocol": "TCP"
-            },
-            {
                 "url": "electrum1.cipig.net:20068",
                 "protocol": "SSL",
                 "contact": [
@@ -29770,6 +30463,19 @@
                     }
                 ],
                 "ws_url": "electrum2.cipig.net:30068"
+            },
+            {
+                "url": "electrum3.cipig.net:20068",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum3.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -29809,10 +30515,6 @@
         },
         "electrum": [
             {
-                "url": "testnet.aranguren.org:51001",
-                "protocol": "TCP"
-            },
-            {
                 "url": "electrum1.cipig.net:20068",
                 "protocol": "SSL",
                 "contact": [
@@ -29837,6 +30539,19 @@
                     }
                 ],
                 "ws_url": "electrum2.cipig.net:30068"
+            },
+            {
+                "url": "electrum3.cipig.net:20068",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "ws_url": "electrum3.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -30072,6 +30787,56 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "THC": {
+        "coin": "THC",
+        "type": "Smart Chain",
+        "name": "HempCoin",
+        "coinpaprika_id": "thc-hempcoin",
+        "coingecko_id": "hempcoin-thc",
+        "livecoinwatch_id": "THC",
+        "explorer_url": "https://thc.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "THC",
+        "fname": "HempCoin",
+        "rpcport": 36790,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "1.eu.thc.electrum.dexstats.info:10020",
+                "contact": [
+                    {
+                        "discord": "CHMEX#0686"
+                    }
+                ]
+            },
+            {
+                "url": "2.eu.thc.electrum.dexstats.info:10020",
+                "contact": [
+                    {
+                        "discord": "CHMEX#0686"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "THC-BEP20": {
         "coin": "THC-BEP20",
         "type": "BEP-20",
@@ -30189,6 +30954,17 @@
                     }
                 ],
                 "ws_url": "2.eu.tokel.electrum.dexstats.info:9077"
+            },
+            {
+                "url": "1.eu.tokel.electrum.dexstats.info:10077",
+                "contact": [
+                    {
+                        "email": "chmex@dexstats.info"
+                    },
+                    {
+                        "discord": "chmex#0686"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -33154,6 +33930,14 @@
                     }
                 ],
                 "ws_url": "e3.validitytech.com:11004"
+            },
+            {
+                "url": "e2.validitytech.com:11001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -33421,6 +34205,100 @@
         ],
         "explorer_block_url": "block/"
     },
+    "VIA": {
+        "coin": "VIA",
+        "type": "UTXO",
+        "name": "Viacoin",
+        "coinpaprika_id": "via-viacoin",
+        "coingecko_id": "viacoin",
+        "livecoinwatch_id": "VIA",
+        "explorer_url": "https://explorer.viacoin.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Viacoin Signed Message:\n",
+        "fname": "Viacoin",
+        "rpcport": 5222,
+        "pubtype": 71,
+        "p2shtype": 33,
+        "wiftype": 199,
+        "txfee": 100000,
+        "dust": 54600,
+        "required_confirmations": 7,
+        "mature_confirmations": 3600,
+        "avg_blocktime": 24,
+        "segwit": true,
+        "bech32_hrp": "via",
+        "mm2": 1,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/14'",
+        "trezor_coin": "Viacoin",
+        "links": {
+            "github": "https://github.com/viacoin",
+            "homepage": "https://viacoin.org"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5102"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "VIA-segwit": {
+        "coin": "VIA-segwit",
+        "type": "UTXO",
+        "name": "Viacoin",
+        "coinpaprika_id": "via-viacoin",
+        "coingecko_id": "viacoin",
+        "livecoinwatch_id": "VIA",
+        "explorer_url": "https://explorer.viacoin.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Viacoin Signed Message:\n",
+        "fname": "Viacoin",
+        "rpcport": 5222,
+        "pubtype": 71,
+        "p2shtype": 33,
+        "wiftype": 199,
+        "txfee": 100000,
+        "dust": 54600,
+        "required_confirmations": 7,
+        "mature_confirmations": 3600,
+        "avg_blocktime": 24,
+        "segwit": true,
+        "bech32_hrp": "via",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "VIA",
+        "mm2": 1,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/14'",
+        "trezor_coin": "Viacoin",
+        "links": {
+            "github": "https://github.com/viacoin",
+            "homepage": "https://viacoin.org"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5102"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "VITE-BEP20": {
         "coin": "VITE-BEP20",
         "type": "BEP-20",
@@ -33479,6 +34357,53 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "VRM": {
+        "coin": "VRM",
+        "type": "UTXO",
+        "name": "Verium Reserve",
+        "coinpaprika_id": "vrm-veriumreserve",
+        "coingecko_id": "",
+        "livecoinwatch_id": "VRM",
+        "explorer_url": "https://explorer-vrm.vericonomy.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Verium Reserve",
+        "rpcport": 33987,
+        "pubtype": 70,
+        "p2shtype": 132,
+        "wiftype": 198,
+        "txfee": 100000,
+        "force_min_relay_fee": true,
+        "isPoS": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 240,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [
+            {
+                "url": "electrum01-vrm.vericonomy.com:50001",
+                "contact": [
+                    {
+                        "email": "dev@vericoin.info"
+                    },
+                    {
+                        "twitter": "vericonomy"
+                    },
+                    {
+                        "github": "VeriConomy"
+                    }
+                ]
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "VRSC": {
@@ -33564,6 +34489,161 @@
             }
         ],
         "explorer_block_url": "block/"
+    },
+    "VPRM": {
+        "coin": "VPRM",
+        "type": "Smart Chain",
+        "name": "Vaporum",
+        "coinpaprika_id": "vprm-vaporum-coin",
+        "coingecko_id": "vaporum-coin",
+        "livecoinwatch_id": "VPRM",
+        "explorer_url": "http://explorer.vaporumcoin.us/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "VPRM",
+        "fname": "Vaporum",
+        "rpcport": 51609,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrumx2.vaporumcoin.us:50001",
+                "contact": [
+                    {
+                        "github": "VaporumCoin"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "VTC": {
+        "coin": "VTC",
+        "type": "UTXO",
+        "name": "Vertcoin",
+        "coinpaprika_id": "vtc-vertcoin",
+        "coingecko_id": "vertcoin",
+        "livecoinwatch_id": "VTC",
+        "explorer_url": "https://chainz.cryptoid.info/vtc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Vertcoin Signed Message:\n",
+        "fname": "Vertcoin",
+        "rpcport": 5888,
+        "pubtype": 71,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "vtc",
+        "mm2": 1,
+        "required_confirmations": 4,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/28'",
+        "trezor_coin": "Vertcoin",
+        "links": {
+            "github": "https://github.com/vertcoin-project/vertcoin-core",
+            "homepage": "https://vertcoin.org"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5028"
+            },
+            {
+                "url": "electrumx-brn.webhop.me:55001"
+            },
+            {
+                "url": "electrumx.javerity.com:5885",
+                "ws_url": "electrumx.javerity.com:5887",
+                "contact": [
+                    {
+                        "discord": "cruelnovo#4936"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
+    "VTC-segwit": {
+        "coin": "VTC-segwit",
+        "type": "UTXO",
+        "name": "Vertcoin",
+        "coinpaprika_id": "vtc-vertcoin",
+        "coingecko_id": "vertcoin",
+        "livecoinwatch_id": "VTC",
+        "explorer_url": "https://chainz.cryptoid.info/vtc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Vertcoin Signed Message:\n",
+        "fname": "Vertcoin",
+        "rpcport": 5888,
+        "pubtype": 71,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "vtc",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "VTC",
+        "mm2": 1,
+        "required_confirmations": 4,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/28'",
+        "trezor_coin": "Vertcoin",
+        "links": {
+            "github": "https://github.com/vertcoin-project/vertcoin-core",
+            "homepage": "https://vertcoin.org"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5028"
+            },
+            {
+                "url": "electrumx-brn.webhop.me:55001"
+            },
+            {
+                "url": "electrumx.javerity.com:5885",
+                "ws_url": "electrumx.javerity.com:5887",
+                "contact": [
+                    {
+                        "discord": "cruelnovo#4936"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block.dws?"
     },
     "WAVES-BEP20": {
         "coin": "WAVES-BEP20",
@@ -34251,6 +35331,73 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "XEP-segwit": {
+        "coin": "XEP-segwit",
+        "type": "UTXO",
+        "name": "Electra Protocol",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "XEP",
+        "explorer_url": "https://electraprotocol.network/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Electra Protocol",
+        "rpcport": 16816,
+        "pubtype": 55,
+        "p2shtype": 137,
+        "wiftype": 162,
+        "txversion": 2,
+        "txfee": 100000,
+        "mm2": 1,
+        "segwit": true,
+        "signature_version": "witness_v0",
+        "bech32_hrp": "ep",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "XEP",
+        "required_confirmations": 4,
+        "avg_blocktime": 80,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/597'",
+        "electrum": [
+            {
+                "url": "electrumx1.electraprotocol.eu:50001",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "ws_url": "electrumx1.electraprotocol.eu:50003"
+            },
+            {
+                "url": "electrumx2.electraprotocol.eu:50001",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "ws_url": "electrumx2.electraprotocol.eu:50003"
+            },
+            {
+                "url": "electrumx3.electraprotocol.eu:50001",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "ws_url": "electrumx3.electraprotocol.eu:50003"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "XEP-BEP20": {
         "coin": "XEP-BEP20",
         "type": "BEP-20",
@@ -34531,13 +35678,13 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP"
-            },
-            {
                 "url": "lenoir.ecoincore.com:10892",
                 "protocol": "SSL",
                 "ws_url": "lenoir.ecoincore.com:10894"
+            },
+            {
+                "url": "lenoir.ecoincore.com:10891",
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -34578,13 +35725,13 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP"
-            },
-            {
                 "url": "lenoir.ecoincore.com:10892",
                 "protocol": "SSL",
                 "ws_url": "lenoir.ecoincore.com:10894"
+            },
+            {
+                "url": "lenoir.ecoincore.com:10891",
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -34662,6 +35809,50 @@
                     }
                 ],
                 "ws_url": "electrumx3.neurai.top:50002"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "XPM": {
+        "coin": "XPM",
+        "type": "UTXO",
+        "name": "Primecoin",
+        "coinpaprika_id": "xpm-primecoin",
+        "coingecko_id": "primecoin",
+        "livecoinwatch_id": "XPM",
+        "explorer_url": "https://www.blockseek.io/xpm/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": true,
+        "fname": "Primecoin",
+        "rpcport": 8332,
+        "pubtype": 23,
+        "p2shtype": 83,
+        "wiftype": 151,
+        "txfee": 0,
+        "dust": 1000000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/24'",
+        "trezor_coin": "Primecoin",
+        "links": {
+            "github": "https://github.com/primecoin/primecoin",
+            "homepage": "https://primecoin.io"
+        },
+        "electrum": [
+            {
+                "url": "electrumx.mainnet.primecoin.org:50011"
+            },
+            {
+                "url": "electrumx.primecoin.org:50001"
             }
         ],
         "explorer_block_url": "block/"
@@ -35050,6 +36241,43 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "XVC": {
+        "coin": "XVC",
+        "type": "UTXO",
+        "name": "VanillaCash",
+        "coinpaprika_id": "xvc-vcash",
+        "coingecko_id": "vcash",
+        "livecoinwatch_id": "XVC",
+        "explorer_url": "https://chainz.cryptoid.info/xvc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "VanillaCash",
+        "isPoS": 1,
+        "rpcport": 48888,
+        "pubtype": 18,
+        "p2shtype": 30,
+        "wiftype": 181,
+        "txfee": 1000,
+        "dust": 10000,
+        "mm2": 1,
+        "required_confirmations": 7,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [
+            {
+                "url": "electrumx1.vanillacash.info:50011",
+                "ws_url": "electrumx1.vanillacash.info:50013"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
     "XVC-BEP20": {
         "coin": "XVC-BEP20",
         "type": "BEP-20",
@@ -35188,6 +36416,48 @@
                     }
                 ],
                 "ws_url": "electrum3.cipig.net:30050"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "XVG": {
+        "coin": "XVG",
+        "type": "UTXO",
+        "name": "Verge",
+        "coinpaprika_id": "xvg-verge",
+        "coingecko_id": "verge",
+        "livecoinwatch_id": "XVG",
+        "explorer_url": "https://xvgblockexplorer.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "VERGE Signed Message:\n",
+        "fname": "Verge",
+        "isPoS": 1,
+        "rpcport": 20102,
+        "pubtype": 30,
+        "p2shtype": 33,
+        "wiftype": 158,
+        "decimals": 6,
+        "segwit": true,
+        "bech32_hrp": "vg",
+        "txfee": 400000,
+        "dust": 400000,
+        "force_min_relay_fee": true,
+        "mm2": 1,
+        "required_confirmations": 10,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/77'",
+        "electrum": [
+            {
+                "url": "88.99.26.209:5036"
             }
         ],
         "explorer_block_url": "block/"
@@ -36333,15 +37603,15 @@
         "derivation_path": "m/44'/19167'",
         "electrum": [
             {
-                "url": "electrumx2.runonflux.io:50001",
-                "protocol": "TCP",
-                "ws_url": "electrumx2.runonflux.io:50004"
-            },
-            {
                 "url": "electrumx.runonflux.io:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
                 "ws_url": "electrumx.runonflux.io:50004"
+            },
+            {
+                "url": "electrumx2.runonflux.io:50001",
+                "protocol": "TCP",
+                "ws_url": "electrumx2.runonflux.io:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -39015,6 +40285,17 @@
                         "discord": "softbalanced#4045"
                     }
                 ]
+            },
+            {
+                "url": "swap.softbalanced.com:50001",
+                "contact": [
+                    {
+                        "email": "dev@softbalanced.com"
+                    },
+                    {
+                        "discord": "softbalanced#4045"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -39113,6 +40394,20 @@
                         "twitter": "whiveio"
                     }
                 ]
+            },
+            {
+                "url": "electrumx1.cointest.com:50001",
+                "contact": [
+                    {
+                        "email": "protocol@whive.io"
+                    },
+                    {
+                        "discord": "whiveio#9340"
+                    },
+                    {
+                        "twitter": "whiveio"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -39171,6 +40466,20 @@
             {
                 "url": "electrumx2.cointest.com:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "protocol@whive.io"
+                    },
+                    {
+                        "discord": "whiveio#9340"
+                    },
+                    {
+                        "twitter": "whiveio"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.cointest.com:50001",
                 "contact": [
                     {
                         "email": "protocol@whive.io"
@@ -39465,6 +40774,17 @@
                     }
                 ],
                 "ws_url": "zombie.dragonhound.info:30059"
+            },
+            {
+                "url": "zombie.dragonhound.info:10033",
+                "contact": [
+                    {
+                        "email": "smk@komodoplatform.com"
+                    },
+                    {
+                        "discord": "smk#7640"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -39562,6 +40882,19 @@
         },
         "electrum": [
             {
+                "url": "electrum3.runebase.io:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ],
+                "ws_url": "electrum3.runebase.io:50004"
+            },
+            {
                 "url": "electrum1.runebase.io:50001",
                 "protocol": "TCP",
                 "contact": [
@@ -39584,19 +40917,6 @@
                         "discord": "Bago#7842"
                     }
                 ]
-            },
-            {
-                "url": "electrum3.runebase.io:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ],
-                "ws_url": "electrum3.runebase.io:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -39647,6 +40967,14 @@
                 "url": "electrumx2.actioncoin.com:30001",
                 "ws_url": "electrumx2.actioncoin.com:20001",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@actioncoin.com"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.actioncoin.com:10001",
                 "contact": [
                     {
                         "email": "support@actioncoin.com"
@@ -40004,6 +41332,17 @@
                     }
                 ],
                 "ws_url": "explorer.crionic.org:50005"
+            },
+            {
+                "url": "coin.crionic.org:50001",
+                "contact": [
+                    {
+                        "email": "diabatiis@gmail.com"
+                    },
+                    {
+                        "discord": "Diabaths#1919"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -40068,6 +41407,17 @@
                     }
                 ],
                 "ws_url": "electrum2-mainnet.evrmorecoin.org:50004"
+            },
+            {
+                "url": "electrum1-mainnet.evrmorecoin.org:50001",
+                "contact": [
+                    {
+                        "email": "hans_schm1dt@protonmail.com"
+                    },
+                    {
+                        "discord": "Hans_Schmidt#0745"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"

--- a/utils/coins_config_tcp.json
+++ b/utils/coins_config_tcp.json
@@ -1967,7 +1967,8 @@
         "checkpoint_blocktime": 1652512363,
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10008",
+                "url": "electrum1.cipig.net:20008",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -1979,7 +1980,8 @@
                 "ws_url": "electrum1.cipig.net:30008"
             },
             {
-                "url": "electrum2.cipig.net:10008",
+                "url": "electrum2.cipig.net:20008",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -1991,42 +1993,6 @@
                 "ws_url": "electrum2.cipig.net:30008"
             },
             {
-                "url": "electrum3.cipig.net:10008",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30008"
-            },
-            {
-                "url": "electrum1.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20008",
                 "protocol": "SSL",
                 "contact": [
@@ -2036,7 +2002,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30008"
             }
         ],
         "explorer_block_url": "block/"
@@ -2490,30 +2457,6 @@
         "derivation_path": "m/44'/921'",
         "electrum": [
             {
-                "url": "electrum-ca.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
-            {
-                "url": "electrum-eu.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
-            {
-                "url": "electrum-us.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
-            {
                 "url": "electrum-ca.avn.network:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -2708,7 +2651,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10057",
+                "url": "electrum1.cipig.net:20057",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -2720,19 +2664,8 @@
                 "ws_url": "electrum1.cipig.net:30057"
             },
             {
-                "url": "electrum2.cipig.net:10057",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30057"
-            },
-            {
-                "url": "electrum3.cipig.net:10057",
+                "url": "electrum2.cipig.net:20057",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -2744,30 +2677,6 @@
                 "ws_url": "electrum3.cipig.net:30057"
             },
             {
-                "url": "electrum1.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20057",
                 "protocol": "SSL",
                 "contact": [
@@ -2777,7 +2686,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30057"
             }
         ],
         "explorer_block_url": "block/"
@@ -2920,44 +2830,6 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "AYA": {
-        "coin": "AYA",
-        "type": "UTXO",
-        "name": "Aryacoin",
-        "coinpaprika_id": "aya-aryacoin",
-        "coingecko_id": "aryacoin",
-        "livecoinwatch_id": "AYA",
-        "explorer_url": "https://explorer.aryacoin.io/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Aryacoin Signed Message:\n",
-        "fname": "Aryacoin",
-        "rpcport": 9332,
-        "pubtype": 23,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 54600,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/357'",
-        "electrum": [
-            {
-                "url": "88.99.26.209:5151"
             }
         ],
         "explorer_block_url": "block/"
@@ -3879,7 +3751,8 @@
         "slp_prefix": "simpleledger",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10055",
+                "url": "electrum1.cipig.net:20055",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -3891,7 +3764,8 @@
                 "ws_url": "electrum1.cipig.net:30055"
             },
             {
-                "url": "electrum2.cipig.net:10055",
+                "url": "electrum2.cipig.net:20055",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -3903,42 +3777,6 @@
                 "ws_url": "electrum2.cipig.net:30055"
             },
             {
-                "url": "electrum3.cipig.net:10055",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30055"
-            },
-            {
-                "url": "electrum1.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20055",
                 "protocol": "SSL",
                 "contact": [
@@ -3948,7 +3786,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30055"
             }
         ],
         "explorer_block_url": "block/"
@@ -4782,30 +4621,6 @@
         "derivation_path": "m/44'/10'",
         "electrum": [
             {
-                "url": "electrum1.blackcoin.nl:10001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.blackcoin.nl:20001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.blackcoin.nl:30001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
                 "url": "electrum1.blackcoin.nl:10002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -4933,30 +4748,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrum1.blackcoin.nl:10011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.blackcoin.nl:20011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.blackcoin.nl:30011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.blackcoin.nl:10012",
                 "protocol": "SSL",
@@ -5932,7 +5723,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10000",
+                "url": "electrum1.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -5944,7 +5736,8 @@
                 "ws_url": "electrum1.cipig.net:30000"
             },
             {
-                "url": "electrum2.cipig.net:10000",
+                "url": "electrum2.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -5956,42 +5749,6 @@
                 "ws_url": "electrum2.cipig.net:30000"
             },
             {
-                "url": "electrum3.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
-            },
-            {
-                "url": "electrum1.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20000",
                 "protocol": "SSL",
                 "contact": [
@@ -6001,7 +5758,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30000"
             }
         ],
         "explorer_block_url": "block/"
@@ -6049,7 +5807,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10000",
+                "url": "electrum1.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -6061,7 +5820,8 @@
                 "ws_url": "electrum1.cipig.net:30000"
             },
             {
-                "url": "electrum2.cipig.net:10000",
+                "url": "electrum2.cipig.net:20000",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -6073,42 +5833,6 @@
                 "ws_url": "electrum2.cipig.net:30000"
             },
             {
-                "url": "electrum3.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
-            },
-            {
-                "url": "electrum1.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20000",
                 "protocol": "SSL",
                 "contact": [
@@ -6118,7 +5842,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30000"
             }
         ],
         "explorer_block_url": "block/"
@@ -6181,51 +5906,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "BTCZ": {
-        "coin": "BTCZ",
-        "type": "UTXO",
-        "name": "BitcoinZ",
-        "coinpaprika_id": "btcz-bitcoinz",
-        "coingecko_id": "bitcoinz",
-        "livecoinwatch_id": "BTCZ",
-        "explorer_url": "https://explorer.btcz.rocks/",
-        "explorer_tx_url": "tx/",
-        "explorer_address_url": "address/",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "BitcoinZ Signed Message:\n",
-        "fname": "BitcoinZ",
-        "rpcport": 1979,
-        "taddr": 28,
-        "pubtype": 184,
-        "p2shtype": 189,
-        "wiftype": 128,
-        "txfee": 10000,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/177'",
-        "electrum": [
-            {
-                "url": "electrum2.btcz.rocks:50001",
-                "contact": [
-                    {
-                        "discord": "VandarGR#6065"
-                    }
-                ],
-                "ws_url": "electrum2.btcz.rocks:50004"
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "BTCZ-BEP20": {
@@ -7477,7 +7157,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10029",
+                "url": "electrum1.cipig.net:20029",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -7489,7 +7170,8 @@
                 "ws_url": "electrum1.cipig.net:30029"
             },
             {
-                "url": "electrum2.cipig.net:10029",
+                "url": "electrum2.cipig.net:20029",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -7501,42 +7183,6 @@
                 "ws_url": "electrum2.cipig.net:30029"
             },
             {
-                "url": "electrum3.cipig.net:10029",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30029"
-            },
-            {
-                "url": "electrum1.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20029",
                 "protocol": "SSL",
                 "contact": [
@@ -7546,7 +7192,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30029"
             }
         ],
         "explorer_block_url": "block/"
@@ -7585,11 +7232,6 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "chicago.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
                 "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -7605,17 +7247,6 @@
                 "url": "oakland.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true
-            },
-            {
-                "url": "seattle.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "woolloomooloo.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "woolloomooloo.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7658,11 +7289,6 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "chicago.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
                 "url": "lenoir.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -7678,17 +7304,6 @@
                 "url": "oakland.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true
-            },
-            {
-                "url": "seattle.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "woolloomooloo.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "woolloomooloo.ecoincore.com:34335"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -8068,71 +7683,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
-    "CHTA": {
-        "coin": "CHTA",
-        "type": "UTXO",
-        "name": "Cheetahcoin",
-        "coinpaprika_id": "chta-cheetahcoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "CHTA",
-        "explorer_url": "http://chtaexplorer.mooo.com:3002/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Cheetahcoin",
-        "rpcport": 8536,
-        "pubtype": 28,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 40000,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 120,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/682'",
-        "electrum": [
-            {
-                "url": "electrum.shorelinecrypto.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.mooo.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.mooo.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "CHIPS": {
         "coin": "CHIPS",
         "type": "UTXO",
@@ -8164,7 +7714,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10053",
+                "url": "electrum1.cipig.net:20053",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -8176,7 +7727,8 @@
                 "ws_url": "electrum1.cipig.net:30053"
             },
             {
-                "url": "electrum2.cipig.net:10053",
+                "url": "electrum2.cipig.net:20053",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -8188,42 +7740,6 @@
                 "ws_url": "electrum2.cipig.net:30053"
             },
             {
-                "url": "electrum3.cipig.net:10053",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30053"
-            },
-            {
-                "url": "electrum1.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20053",
                 "protocol": "SSL",
                 "contact": [
@@ -8233,7 +7749,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30053"
             }
         ],
         "explorer_block_url": "block/"
@@ -8534,51 +8051,6 @@
             },
             {
                 "url": "https://poly-rpc.gateway.pokt.network"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "CLC": {
-        "coin": "CLC",
-        "type": "Smart Chain",
-        "name": "Collider Coin",
-        "coinpaprika_id": "clc-collider-coin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://clc.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "CLC",
-        "fname": "Collider Coin",
-        "rpcport": 31034,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "requires_notarization": false,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx.cryptocollider.com:10001",
-                "contact": [
-                    {
-                        "email": "electrumx@cryptocollider.com"
-                    },
-                    {
-                        "discord": "collider#6160"
-                    }
-                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -9492,6 +8964,19 @@
                         "discord": "ruaxxx#3151"
                     }
                 ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -9553,6 +9038,19 @@
                 "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum03.cyberyen.work:50004",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum01.cyberyen.work:50002",
+                "protocol": "SSL",
+                "ws_url": "electrum01.cyberyen.work:50004",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -9970,7 +9468,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10061",
+                "url": "electrum1.cipig.net:20061",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9982,7 +9481,8 @@
                 "ws_url": "electrum1.cipig.net:30061"
             },
             {
-                "url": "electrum2.cipig.net:10061",
+                "url": "electrum2.cipig.net:20061",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9994,42 +9494,6 @@
                 "ws_url": "electrum2.cipig.net:30061"
             },
             {
-                "url": "electrum3.cipig.net:10061",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30061"
-            },
-            {
-                "url": "electrum1.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20061",
                 "protocol": "SSL",
                 "contact": [
@@ -10039,7 +9503,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30061"
             }
         ],
         "explorer_block_url": "block/"
@@ -10366,7 +9831,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10059",
+                "url": "electrum1.cipig.net:20059",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10378,42 +9844,6 @@
                 "ws_url": "electrum1.cipig.net:30059"
             },
             {
-                "url": "electrum2.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
-            },
-            {
-                "url": "electrum3.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
-            },
-            {
-                "url": "electrum1.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20059",
                 "protocol": "SSL",
                 "contact": [
@@ -10423,7 +9853,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum3.cipig.net:20059",
@@ -10435,7 +9866,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30059"
             }
         ],
         "explorer_block_url": "block/"
@@ -10482,7 +9914,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10059",
+                "url": "electrum1.cipig.net:20059",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10494,42 +9927,6 @@
                 "ws_url": "electrum1.cipig.net:30059"
             },
             {
-                "url": "electrum2.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
-            },
-            {
-                "url": "electrum3.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
-            },
-            {
-                "url": "electrum1.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20059",
                 "protocol": "SSL",
                 "contact": [
@@ -10539,7 +9936,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30059"
             },
             {
                 "url": "electrum3.cipig.net:20059",
@@ -10551,7 +9949,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30059"
             }
         ],
         "explorer_block_url": "block/"
@@ -10908,7 +10307,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10920,7 +10320,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10932,42 +10333,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -10977,7 +10342,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -11202,7 +10568,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10060",
+                "url": "electrum1.cipig.net:20060",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11214,7 +10581,8 @@
                 "ws_url": "electrum1.cipig.net:30060"
             },
             {
-                "url": "electrum2.cipig.net:10060",
+                "url": "electrum2.cipig.net:20060",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11226,42 +10594,6 @@
                 "ws_url": "electrum2.cipig.net:30060"
             },
             {
-                "url": "electrum3.cipig.net:10060",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30060"
-            },
-            {
-                "url": "electrum1.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20060",
                 "protocol": "SSL",
                 "contact": [
@@ -11271,7 +10603,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30060"
             }
         ],
         "explorer_block_url": "block/"
@@ -11560,48 +10893,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "DP": {
-        "coin": "DP",
-        "type": "Smart Chain",
-        "name": "DigitalPrice",
-        "coinpaprika_id": "dp-digitalprice",
-        "coingecko_id": "digitalprice",
-        "livecoinwatch_id": "DP",
-        "explorer_url": "https://dp.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "DP",
-        "fname": "DigitalPrice",
-        "rpcport": 28388,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "requires_notarization": false,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "1.eu.dp.electrum.dexstats.info:10021",
-                "contact": [
-                    {
-                        "discord": "Zanzarismo#6500"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "DOI": {
         "coin": "DOI",
         "type": "UTXO",
@@ -11664,28 +10955,6 @@
                     }
                 ],
                 "ws-url": "itchy-jellyfish-89.doi.works:50004"
-            },
-            {
-                "url": "pink-deer-69.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/namecoin/electrum-nmc/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "pink-deer-69.doi.works:50004"
-            },
-            {
-                "url": "ugly-bird-70.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/doichain/electrum-doi/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "ugly-bird-70.doi.works:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -11723,7 +10992,8 @@
         "derivation_path": "m/44'/249'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10052",
+                "url": "electrum1.cipig.net:20052",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11735,7 +11005,8 @@
                 "ws_url": "electrum1.cipig.net:30052"
             },
             {
-                "url": "electrum2.cipig.net:10052",
+                "url": "electrum2.cipig.net:20052",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -11747,42 +11018,6 @@
                 "ws_url": "electrum2.cipig.net:30052"
             },
             {
-                "url": "electrum3.cipig.net:10052",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30052"
-            },
-            {
-                "url": "electrum1.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20052",
                 "protocol": "SSL",
                 "contact": [
@@ -11792,7 +11027,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30052"
             }
         ],
         "explorer_block_url": "block/"
@@ -12163,7 +11399,8 @@
         "derivation_path": "m/44'/41'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10062",
+                "url": "electrum1.cipig.net:20062",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -12175,7 +11412,8 @@
                 "ws_url": "electrum1.cipig.net:30062"
             },
             {
-                "url": "electrum2.cipig.net:10062",
+                "url": "electrum2.cipig.net:20062",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -12187,42 +11425,6 @@
                 "ws_url": "electrum2.cipig.net:30062"
             },
             {
-                "url": "electrum3.cipig.net:10062",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30062"
-            },
-            {
-                "url": "electrum1.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20062",
                 "protocol": "SSL",
                 "contact": [
@@ -12232,7 +11434,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30062"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -13840,24 +13043,6 @@
                         "github": "https://github.com/firoorg/electrumx-firo/issues"
                     }
                 ]
-            },
-            {
-                "url": "electrumx03.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx05.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -13986,16 +13171,6 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx2.fujicoin.org:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -14068,16 +13243,6 @@
                     }
                 ],
                 "ws_url": "electrumx1.fujicoin.org:50005"
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx2.fujicoin.org:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -14439,7 +13604,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10054",
+                "url": "electrum1.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14451,7 +13617,8 @@
                 "ws_url": "electrum1.cipig.net:30054"
             },
             {
-                "url": "electrum2.cipig.net:10054",
+                "url": "electrum2.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14463,42 +13630,6 @@
                 "ws_url": "electrum2.cipig.net:30054"
             },
             {
-                "url": "electrum3.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
-            },
-            {
-                "url": "electrum1.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20054",
                 "protocol": "SSL",
                 "contact": [
@@ -14508,7 +13639,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30054"
             }
         ],
         "explorer_block_url": "block/"
@@ -14555,7 +13687,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10054",
+                "url": "electrum1.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14567,7 +13700,8 @@
                 "ws_url": "electrum1.cipig.net:30054"
             },
             {
-                "url": "electrum2.cipig.net:10054",
+                "url": "electrum2.cipig.net:20054",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14579,42 +13713,6 @@
                 "ws_url": "electrum2.cipig.net:30054"
             },
             {
-                "url": "electrum3.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
-            },
-            {
-                "url": "electrum1.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20054",
                 "protocol": "SSL",
                 "contact": [
@@ -14624,7 +13722,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30054"
             }
         ],
         "explorer_block_url": "block/"
@@ -15408,8 +14507,7 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum1.cipig.net:30022"
+                ]
             },
             {
                 "url": "electrum2.cipig.net:10022",
@@ -15421,49 +14519,11 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ],
-                "ws_url": "electrum2.cipig.net:30022"
+                ]
             },
             {
                 "url": "electrum3.cipig.net:10022",
                 "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30022"
-            },
-            {
-                "url": "electrum1.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20022",
-                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -16007,36 +15067,6 @@
                     }
                 ],
                 "ws_url": "electrum.maxpuig.com:50004"
-            },
-            {
-                "url": "fr.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "pl.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "uk.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -16218,402 +15248,6 @@
         },
         "electrum": [
             {
-                "url": "electrum1.groestlcoin.org:50001",
-                "ws_url": "electrum1.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum12.groestlcoin.org:50001",
-                "ws_url": "electrum12.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum13.groestlcoin.org:50001",
-                "ws_url": "electrum13.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum14.groestlcoin.org:50001",
-                "ws_url": "electrum14.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum15.groestlcoin.org:50001",
-                "ws_url": "electrum15.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum16.groestlcoin.org:50001",
-                "ws_url": "electrum16.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum17.groestlcoin.org:50001",
-                "ws_url": "electrum17.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum19.groestlcoin.org:50001",
-                "ws_url": "electrum19.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.groestlcoin.org:50001",
-                "ws_url": "electrum2.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum20.groestlcoin.org:50001",
-                "ws_url": "electrum20.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum21.groestlcoin.org:50001",
-                "ws_url": "electrum21.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum22.groestlcoin.org:50001",
-                "ws_url": "electrum22.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum23.groestlcoin.org:50001",
-                "ws_url": "electrum23.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum24.groestlcoin.org:50001",
-                "ws_url": "electrum24.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum25.groestlcoin.org:50001",
-                "ws_url": "electrum25.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum26.groestlcoin.org:50001",
-                "ws_url": "electrum26.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum27.groestlcoin.org:50001",
-                "ws_url": "electrum27.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum28.groestlcoin.org:50001",
-                "ws_url": "electrum28.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum29.groestlcoin.org:50001",
-                "ws_url": "electrum29.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.groestlcoin.org:50001",
-                "ws_url": "electrum3.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum30.groestlcoin.org:50001",
-                "ws_url": "electrum30.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum33.groestlcoin.org:50001",
-                "ws_url": "electrum33.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum34.groestlcoin.org:50001",
-                "ws_url": "electrum34.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum35.groestlcoin.org:50001",
-                "ws_url": "electrum35.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum36.groestlcoin.org:50001",
-                "ws_url": "electrum36.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum37.groestlcoin.org:50001",
-                "ws_url": "electrum37.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum38.groestlcoin.org:50001",
-                "ws_url": "electrum38.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum39.groestlcoin.org:50001",
-                "ws_url": "electrum39.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum40.groestlcoin.org:50001",
-                "ws_url": "electrum40.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum5.groestlcoin.org:50001",
-                "ws_url": "electrum5.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum7.groestlcoin.org:50001",
-                "ws_url": "electrum7.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum8.groestlcoin.org:50001",
-                "ws_url": "electrum8.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum9.groestlcoin.org:50001",
-                "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -16671,402 +15305,6 @@
             "homepage": "https://www.groestlcoin.org"
         },
         "electrum": [
-            {
-                "url": "electrum1.groestlcoin.org:50001",
-                "ws_url": "electrum1.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum12.groestlcoin.org:50001",
-                "ws_url": "electrum12.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum13.groestlcoin.org:50001",
-                "ws_url": "electrum13.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum14.groestlcoin.org:50001",
-                "ws_url": "electrum14.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum15.groestlcoin.org:50001",
-                "ws_url": "electrum15.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum16.groestlcoin.org:50001",
-                "ws_url": "electrum16.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum17.groestlcoin.org:50001",
-                "ws_url": "electrum17.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum19.groestlcoin.org:50001",
-                "ws_url": "electrum19.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.groestlcoin.org:50001",
-                "ws_url": "electrum2.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum20.groestlcoin.org:50001",
-                "ws_url": "electrum20.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum21.groestlcoin.org:50001",
-                "ws_url": "electrum21.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum22.groestlcoin.org:50001",
-                "ws_url": "electrum22.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum23.groestlcoin.org:50001",
-                "ws_url": "electrum23.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum24.groestlcoin.org:50001",
-                "ws_url": "electrum24.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum25.groestlcoin.org:50001",
-                "ws_url": "electrum25.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum26.groestlcoin.org:50001",
-                "ws_url": "electrum26.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum27.groestlcoin.org:50001",
-                "ws_url": "electrum27.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum28.groestlcoin.org:50001",
-                "ws_url": "electrum28.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum29.groestlcoin.org:50001",
-                "ws_url": "electrum29.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.groestlcoin.org:50001",
-                "ws_url": "electrum3.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum30.groestlcoin.org:50001",
-                "ws_url": "electrum30.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum33.groestlcoin.org:50001",
-                "ws_url": "electrum33.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum34.groestlcoin.org:50001",
-                "ws_url": "electrum34.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum35.groestlcoin.org:50001",
-                "ws_url": "electrum35.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum36.groestlcoin.org:50001",
-                "ws_url": "electrum36.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum37.groestlcoin.org:50001",
-                "ws_url": "electrum37.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum38.groestlcoin.org:50001",
-                "ws_url": "electrum38.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum39.groestlcoin.org:50001",
-                "ws_url": "electrum39.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum40.groestlcoin.org:50001",
-                "ws_url": "electrum40.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum5.groestlcoin.org:50001",
-                "ws_url": "electrum5.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum7.groestlcoin.org:50001",
-                "ws_url": "electrum7.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum8.groestlcoin.org:50001",
-                "ws_url": "electrum8.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum9.groestlcoin.org:50001",
-                "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
             {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
@@ -18193,67 +16431,6 @@
             }
         ],
         "explorer_block_url": "block.dws?"
-    },
-    "ILN": {
-        "coin": "ILN",
-        "type": "Smart Chain",
-        "name": "Ilien",
-        "coinpaprika_id": "iln-ilien9195",
-        "coingecko_id": "",
-        "livecoinwatch_id": "ILN",
-        "explorer_url": "https://explorer.ilien.io/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "ILN",
-        "fname": "Ilien",
-        "rpcport": 12986,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "p2p": 12985,
-        "magic": "feb4cb23",
-        "nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrum1.ilien.io:65011",
-                "contact": [
-                    {
-                        "email": "admin@ilien.io"
-                    },
-                    {
-                        "discord": "siu - Chainmakers#3920"
-                    }
-                ],
-                "ws_url": "electrum1.ilien.io:30069"
-            },
-            {
-                "url": "electrum2.ilien.io:65011",
-                "contact": [
-                    {
-                        "email": "admin@ilien.io"
-                    },
-                    {
-                        "discord": "siu - Chainmakers#3920"
-                    }
-                ],
-                "ws_url": "electrum2.ilien.io:30069"
-            }
-        ],
-        "explorer_block_url": "block/"
     },
     "ILN-BEP20": {
         "coin": "ILN-BEP20",
@@ -20809,7 +18986,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10001",
+                "url": "electrum1.cipig.net:20001",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -20821,7 +18999,8 @@
                 "ws_url": "electrum1.cipig.net:30001"
             },
             {
-                "url": "electrum2.cipig.net:10001",
+                "url": "electrum2.cipig.net:20001",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -20833,42 +19012,6 @@
                 "ws_url": "electrum2.cipig.net:30001"
             },
             {
-                "url": "electrum3.cipig.net:10001",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30001"
-            },
-            {
-                "url": "electrum1.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20001",
                 "protocol": "SSL",
                 "contact": [
@@ -20878,7 +19021,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30001"
             }
         ],
         "explorer_block_url": "block/",
@@ -21212,7 +19356,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10024",
+                "url": "electrum1.cipig.net:20024",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21224,7 +19369,8 @@
                 "ws_url": "electrum1.cipig.net:30024"
             },
             {
-                "url": "electrum2.cipig.net:10024",
+                "url": "electrum2.cipig.net:20024",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21236,42 +19382,6 @@
                 "ws_url": "electrum2.cipig.net:30024"
             },
             {
-                "url": "electrum3.cipig.net:10024",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30024"
-            },
-            {
-                "url": "electrum1.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20024",
                 "protocol": "SSL",
                 "contact": [
@@ -21281,7 +19391,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30024"
             }
         ],
         "explorer_block_url": "block/"
@@ -21378,31 +19489,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30019"
-            },
-            {
-                "url": "electrum2.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30019"
-            },
-            {
-                "url": "electrum3.cipig.net:10019",
+                "url": "electrum1.cipig.net:20019",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21414,18 +19502,6 @@
                 "ws_url": "electrum3.cipig.net:30019"
             },
             {
-                "url": "electrum1.cipig.net:20019",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum2.cipig.net:20019",
                 "protocol": "SSL",
                 "contact": [
@@ -21435,7 +19511,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30019"
             },
             {
                 "url": "electrum3.cipig.net:20019",
@@ -21447,7 +19524,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30019"
             }
         ],
         "explorer_block_url": "block/"
@@ -21485,31 +19563,22 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
-            },
-            {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
-            },
-            {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
-            },
-            {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum1.cipig.net:30067"
             },
             {
                 "url": "electrum2.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum2.cipig.net:30067"
             },
             {
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum3.cipig.net:30067"
             }
         ],
         "explorer_block_url": "block/"
@@ -21551,31 +19620,22 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
-            },
-            {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
-            },
-            {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
-            },
-            {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum1.cipig.net:30067"
             },
             {
                 "url": "electrum2.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum2.cipig.net:30067"
             },
             {
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "electrum3.cipig.net:30067"
             }
         ],
         "explorer_block_url": "block/"
@@ -22957,7 +21017,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10063",
+                "url": "electrum1.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -22969,7 +21030,8 @@
                 "ws_url": "electrum1.cipig.net:30063"
             },
             {
-                "url": "electrum2.cipig.net:10063",
+                "url": "electrum2.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -22981,42 +21043,6 @@
                 "ws_url": "electrum2.cipig.net:30063"
             },
             {
-                "url": "electrum3.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
-            },
-            {
-                "url": "electrum1.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20063",
                 "protocol": "SSL",
                 "contact": [
@@ -23026,7 +21052,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30063"
             }
         ],
         "explorer_block_url": "block/"
@@ -23074,7 +21101,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10063",
+                "url": "electrum1.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -23086,7 +21114,8 @@
                 "ws_url": "electrum1.cipig.net:30063"
             },
             {
-                "url": "electrum2.cipig.net:10063",
+                "url": "electrum2.cipig.net:20063",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -23098,42 +21127,6 @@
                 "ws_url": "electrum2.cipig.net:30063"
             },
             {
-                "url": "electrum3.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
-            },
-            {
-                "url": "electrum1.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20063",
                 "protocol": "SSL",
                 "contact": [
@@ -23143,7 +21136,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30063"
             }
         ],
         "explorer_block_url": "block/"
@@ -23194,16 +21188,6 @@
                 "url": "electrum7.getlynx.io:50002",
                 "protocol": "SSL",
                 "ws_url": "electrum7.getlynx.io:50004"
-            },
-            {
-                "url": "electrum8.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum8.getlynx.io:50004"
-            },
-            {
-                "url": "electrum9.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum9.getlynx.io:50004"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -24115,7 +22099,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10023",
+                "url": "electrum1.cipig.net:20023",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24127,7 +22112,8 @@
                 "ws_url": "electrum1.cipig.net:30023"
             },
             {
-                "url": "electrum2.cipig.net:10023",
+                "url": "electrum2.cipig.net:20023",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24139,42 +22125,6 @@
                 "ws_url": "electrum2.cipig.net:30023"
             },
             {
-                "url": "electrum3.cipig.net:10023",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30023"
-            },
-            {
-                "url": "electrum1.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20023",
                 "protocol": "SSL",
                 "contact": [
@@ -24184,7 +22134,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30023"
             }
         ],
         "explorer_block_url": "block/"
@@ -24302,39 +22253,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrum1.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.cipig.net:20069",
                 "ws_url": "electrum1.cipig.net:30069",
@@ -25027,110 +22945,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "MONA": {
-        "coin": "MONA",
-        "type": "UTXO",
-        "name": "MonaCoin",
-        "coinpaprika_id": "mona-monacoin",
-        "coingecko_id": "monacoin",
-        "livecoinwatch_id": "MONA",
-        "explorer_url": "https://blockbook.electrum-mona.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Monacoin Signed Message:\n",
-        "fname": "MonaCoin",
-        "rpcport": 9402,
-        "pubtype": 50,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 100000,
-        "segwit": true,
-        "bech32_hrp": "mona",
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 90,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/22'",
-        "trezor_coin": "Monacoin",
-        "links": {
-            "github": "https://github.com/monacoinproject/monacoin",
-            "homepage": "https://monacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "133.167.67.203:50001"
-            },
-            {
-                "url": "electrumx.tamami-foundation.org:50001"
-            },
-            {
-                "url": "electrumx1.monacoin.ninja:50001"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "MONA-segwit": {
-        "coin": "MONA-segwit",
-        "type": "UTXO",
-        "name": "MonaCoin",
-        "coinpaprika_id": "mona-monacoin",
-        "coingecko_id": "monacoin",
-        "livecoinwatch_id": "MONA",
-        "explorer_url": "https://blockbook.electrum-mona.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Monacoin Signed Message:\n",
-        "fname": "MonaCoin",
-        "rpcport": 9402,
-        "pubtype": 50,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 100000,
-        "segwit": true,
-        "bech32_hrp": "mona",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "MONA",
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 90,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/22'",
-        "trezor_coin": "Monacoin",
-        "links": {
-            "github": "https://github.com/monacoinproject/monacoin",
-            "homepage": "https://monacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "133.167.67.203:50001"
-            },
-            {
-                "url": "electrumx.tamami-foundation.org:50001"
-            },
-            {
-                "url": "electrumx1.monacoin.ninja:50001"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "MOVR": {
         "coin": "MOVR",
         "type": "Moonriver",
@@ -25377,71 +23191,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
-    "NENG": {
-        "coin": "NENG",
-        "type": "UTXO",
-        "name": "Nengcoin",
-        "coinpaprika_id": "neng-nengcoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "NENG",
-        "explorer_url": "http://nengexplorer.mooo.com:3001/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Nengcoin",
-        "rpcport": 6376,
-        "pubtype": 53,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 200000,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/681'",
-        "electrum": [
-            {
-                "url": "electrum.shorelinecrypto.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.mooo.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.mooo.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "NEXO-ERC20": {
         "coin": "NEXO-ERC20",
         "type": "ERC-20",
@@ -25648,39 +23397,6 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum1.cipig.net:20036",
                 "protocol": "SSL",
                 "contact": [
@@ -25756,9 +23472,6 @@
         },
         "electrum": [
             {
-                "url": "46.229.238.187:57001"
-            },
-            {
                 "url": "nmc2.bitcoins.sk:57002",
                 "protocol": "SSL",
                 "disable_cert_verification": true
@@ -25806,9 +23519,6 @@
             "homepage": "https://namecoin.org"
         },
         "electrum": [
-            {
-                "url": "46.229.238.187:57001"
-            },
             {
                 "url": "nmc2.bitcoins.sk:57002",
                 "protocol": "SSL",
@@ -25999,7 +23709,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -26011,7 +23722,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -26023,42 +23735,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -26068,7 +23744,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -27090,97 +24767,6 @@
         ],
         "explorer_block_url": "block.dws?"
     },
-    "PIVX": {
-        "coin": "PIVX",
-        "type": "UTXO",
-        "name": "PIVX",
-        "coinpaprika_id": "pivx-pivx",
-        "coingecko_id": "pivx",
-        "livecoinwatch_id": "PIVX",
-        "explorer_url": "https://chainz.cryptoid.info/pivx/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "PIVX",
-        "rpcport": 51473,
-        "pubtype": 30,
-        "p2shtype": 13,
-        "wiftype": 212,
-        "txfee": 100000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/119'",
-        "electrum": [
-            {
-                "url": "electrum01.chainster.org:50001",
-                "ws_url": "electrum01.chainster.org:50003",
-                "contact": [
-                    {
-                        "discord": "312541186793406465"
-                    }
-                ]
-            },
-            {
-                "url": "electrum02.chainster.org:50001",
-                "ws_url": "electrum02.chainster.org:50003",
-                "contact": [
-                    {
-                        "discord": "312541186793406465"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "PND": {
-        "coin": "PND",
-        "type": "UTXO",
-        "name": "Pandacoin",
-        "coinpaprika_id": "pnd-pandacoin",
-        "coingecko_id": "pandacoin",
-        "livecoinwatch_id": "PND",
-        "explorer_url": "https://chainz.cryptoid.info/pnd/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Pandacoin",
-        "isPoS": 1,
-        "rpcport": 22444,
-        "pubtype": 55,
-        "p2shtype": 22,
-        "wiftype": 183,
-        "decimals": 6,
-        "txfee": 10000000,
-        "dust": 1000000,
-        "segwit": true,
-        "bech32_hrp": "pn",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/37'",
-        "electrum": [
-            {
-                "url": "electrum.thepandacoin.net:50001",
-                "ws_url": "electrum.thepandacoin.net:443"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
     "POT": {
         "coin": "POT",
         "type": "UTXO",
@@ -27907,16 +25493,6 @@
                         "discord": "PRUX-Coin#1668"
                     }
                 ]
-            },
-            {
-                "url": "txserver.live:50002",
-                "protocol": "SSL",
-                "ws_url": "txserver.live:30001",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -28147,7 +25723,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28159,7 +25736,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28171,42 +25749,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28216,7 +25758,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28262,7 +25805,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28274,7 +25818,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28286,42 +25831,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28331,7 +25840,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28377,7 +25887,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28389,7 +25900,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28401,42 +25913,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28446,7 +25922,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28757,7 +26234,8 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
+                "url": "electrum1.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28769,7 +26247,8 @@
                 "ws_url": "electrum1.cipig.net:30071"
             },
             {
-                "url": "electrum2.cipig.net:10071",
+                "url": "electrum2.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28781,42 +26260,6 @@
                 "ws_url": "electrum2.cipig.net:30071"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
                 "contact": [
@@ -28826,7 +26269,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -28874,7 +26318,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28886,7 +26331,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28898,42 +26344,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -28943,7 +26353,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -28993,7 +26404,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29005,7 +26417,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29017,42 +26430,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -29062,7 +26439,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -29183,7 +26561,8 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
+                "url": "electrum1.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29195,7 +26574,8 @@
                 "ws_url": "electrum1.cipig.net:30071"
             },
             {
-                "url": "electrum2.cipig.net:10071",
+                "url": "electrum2.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29207,42 +26587,6 @@
                 "ws_url": "electrum2.cipig.net:30071"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
                 "contact": [
@@ -29252,7 +26596,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -29293,7 +26638,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
+                "url": "electrum1.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29305,7 +26651,8 @@
                 "ws_url": "electrum1.cipig.net:30071"
             },
             {
-                "url": "electrum2.cipig.net:10071",
+                "url": "electrum2.cipig.net:20071",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -29317,42 +26664,6 @@
                 "ws_url": "electrum2.cipig.net:30071"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
                 "contact": [
@@ -29362,7 +26673,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30071"
             }
         ],
         "explorer_block_url": "block/"
@@ -29785,39 +27097,6 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum1.cipig.net:20020",
                 "ws_url": "electrum1.cipig.net:30020",
                 "protocol": "SSL",
@@ -29890,39 +27169,6 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
-            {
-                "url": "electrum1.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
             {
                 "url": "electrum1.cipig.net:20021",
                 "ws_url": "electrum1.cipig.net:30021",
@@ -30382,47 +27628,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "RTM": {
-        "coin": "RTM",
-        "type": "UTXO",
-        "name": "Raptoreum",
-        "coinpaprika_id": "rtm-raptoreum",
-        "coingecko_id": "raptoreum",
-        "livecoinwatch_id": "RTM",
-        "explorer_url": "https://explorer.raptoreum.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Raptoreum",
-        "rpcport": 9998,
-        "pubtype": 60,
-        "p2shtype": 16,
-        "wiftype": 128,
-        "txfee": 1000,
-        "mm2": 1,
-        "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
-        "required_confirmations": 3,
-        "avg_blocktime": 120,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/10226'",
-        "electrum": [
-            {
-                "url": "x1.raptoreum.com:50001",
-                "ws_url": "x1.raptoreum.com:50004"
-            },
-            {
-                "url": "x2.raptoreum.com:50001",
-                "ws_url": "x2.raptoreum.com:50004"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "RTM-BEP20": {
         "coin": "RTM-BEP20",
         "type": "BEP-20",
@@ -30521,7 +27726,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10051",
+                "url": "electrum1.cipig.net:20051",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -30533,7 +27739,8 @@
                 "ws_url": "electrum1.cipig.net:30051"
             },
             {
-                "url": "electrum2.cipig.net:10051",
+                "url": "electrum2.cipig.net:20051",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -30545,42 +27752,6 @@
                 "ws_url": "electrum2.cipig.net:30051"
             },
             {
-                "url": "electrum3.cipig.net:10051",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30051"
-            },
-            {
-                "url": "electrum1.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20051",
                 "protocol": "SSL",
                 "contact": [
@@ -30590,7 +27761,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30051"
             }
         ],
         "explorer_block_url": "block/"
@@ -31447,7 +28619,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10011",
+                "url": "electrum1.cipig.net:20011",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31459,7 +28632,8 @@
                 "ws_url": "electrum1.cipig.net:30011"
             },
             {
-                "url": "electrum2.cipig.net:10011",
+                "url": "electrum2.cipig.net:20011",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31471,42 +28645,6 @@
                 "ws_url": "electrum2.cipig.net:30011"
             },
             {
-                "url": "electrum3.cipig.net:10011",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30011"
-            },
-            {
-                "url": "electrum1.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20011",
                 "protocol": "SSL",
                 "contact": [
@@ -31516,7 +28654,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30011"
             }
         ],
         "explorer_block_url": "block/"
@@ -31679,7 +28818,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10005",
+                "url": "electrum1.cipig.net:20005",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31691,7 +28831,8 @@
                 "ws_url": "electrum1.cipig.net:30005"
             },
             {
-                "url": "electrum2.cipig.net:10005",
+                "url": "electrum2.cipig.net:20005",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31703,42 +28844,6 @@
                 "ws_url": "electrum2.cipig.net:30005"
             },
             {
-                "url": "electrum3.cipig.net:10005",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30005"
-            },
-            {
-                "url": "electrum1.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20005",
                 "protocol": "SSL",
                 "contact": [
@@ -31748,7 +28853,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30005"
             }
         ],
         "explorer_block_url": "block/"
@@ -32402,7 +29508,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10064",
+                "url": "electrum1.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32414,7 +29521,8 @@
                 "ws_url": "electrum1.cipig.net:30064"
             },
             {
-                "url": "electrum2.cipig.net:10064",
+                "url": "electrum2.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32426,42 +29534,6 @@
                 "ws_url": "electrum2.cipig.net:30064"
             },
             {
-                "url": "electrum3.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
-            },
-            {
-                "url": "electrum1.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20064",
                 "protocol": "SSL",
                 "contact": [
@@ -32471,7 +29543,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30064"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32519,7 +29592,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10064",
+                "url": "electrum1.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32531,7 +29605,8 @@
                 "ws_url": "electrum1.cipig.net:30064"
             },
             {
-                "url": "electrum2.cipig.net:10064",
+                "url": "electrum2.cipig.net:20064",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -32543,42 +29618,6 @@
                 "ws_url": "electrum2.cipig.net:30064"
             },
             {
-                "url": "electrum3.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
-            },
-            {
-                "url": "electrum1.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20064",
                 "protocol": "SSL",
                 "contact": [
@@ -32588,7 +29627,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30064"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32702,42 +29742,6 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30068"
-            },
-            {
-                "url": "electrum2.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
-            },
-            {
-                "url": "electrum3.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
-            },
-            {
                 "url": "testnet.aranguren.org:51001",
                 "protocol": "TCP"
             },
@@ -32751,7 +29755,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30068"
             },
             {
                 "url": "electrum2.cipig.net:20068",
@@ -32763,19 +29768,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -32815,42 +29809,6 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30068"
-            },
-            {
-                "url": "electrum2.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
-            },
-            {
-                "url": "electrum3.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
-            },
-            {
                 "url": "testnet.aranguren.org:51001",
                 "protocol": "TCP"
             },
@@ -32864,7 +29822,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum1.cipig.net:30068"
             },
             {
                 "url": "electrum2.cipig.net:20068",
@@ -32876,19 +29835,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                ],
+                "ws_url": "electrum2.cipig.net:30068"
             }
         ],
         "explorer_block_url": "block/"
@@ -33124,56 +30072,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
-    "THC": {
-        "coin": "THC",
-        "type": "Smart Chain",
-        "name": "HempCoin",
-        "coinpaprika_id": "thc-hempcoin",
-        "coingecko_id": "hempcoin-thc",
-        "livecoinwatch_id": "THC",
-        "explorer_url": "https://thc.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "THC",
-        "fname": "HempCoin",
-        "rpcport": 36790,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "1.eu.thc.electrum.dexstats.info:10020",
-                "contact": [
-                    {
-                        "discord": "CHMEX#0686"
-                    }
-                ]
-            },
-            {
-                "url": "2.eu.thc.electrum.dexstats.info:10020",
-                "contact": [
-                    {
-                        "discord": "CHMEX#0686"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "THC-BEP20": {
         "coin": "THC-BEP20",
         "type": "BEP-20",
@@ -33267,7 +30165,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "1.eu.tokel.electrum.dexstats.info:10077",
+                "url": "1.eu.tokel.electrum.dexstats.info:11077",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "chmex@dexstats.info"
@@ -33279,7 +30178,7 @@
                 "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
             },
             {
-                "url": "1.eu.tokel.electrum.dexstats.info:11077",
+                "url": "2.eu.tokel.electrum.dexstats.info:11077",
                 "protocol": "SSL",
                 "contact": [
                     {
@@ -33288,7 +30187,8 @@
                     {
                         "discord": "chmex#0686"
                     }
-                ]
+                ],
+                "ws_url": "2.eu.tokel.electrum.dexstats.info:9077"
             }
         ],
         "explorer_block_url": "block/"
@@ -36234,22 +33134,6 @@
         },
         "electrum": [
             {
-                "url": "e2.validitytech.com:11001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "e3.validitytech.com:11001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
                 "url": "e2.validitytech.com:11002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -36537,100 +33421,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "VIA": {
-        "coin": "VIA",
-        "type": "UTXO",
-        "name": "Viacoin",
-        "coinpaprika_id": "via-viacoin",
-        "coingecko_id": "viacoin",
-        "livecoinwatch_id": "VIA",
-        "explorer_url": "https://explorer.viacoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Viacoin Signed Message:\n",
-        "fname": "Viacoin",
-        "rpcport": 5222,
-        "pubtype": 71,
-        "p2shtype": 33,
-        "wiftype": 199,
-        "txfee": 100000,
-        "dust": 54600,
-        "required_confirmations": 7,
-        "mature_confirmations": 3600,
-        "avg_blocktime": 24,
-        "segwit": true,
-        "bech32_hrp": "via",
-        "mm2": 1,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/14'",
-        "trezor_coin": "Viacoin",
-        "links": {
-            "github": "https://github.com/viacoin",
-            "homepage": "https://viacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5102"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "VIA-segwit": {
-        "coin": "VIA-segwit",
-        "type": "UTXO",
-        "name": "Viacoin",
-        "coinpaprika_id": "via-viacoin",
-        "coingecko_id": "viacoin",
-        "livecoinwatch_id": "VIA",
-        "explorer_url": "https://explorer.viacoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Viacoin Signed Message:\n",
-        "fname": "Viacoin",
-        "rpcport": 5222,
-        "pubtype": 71,
-        "p2shtype": 33,
-        "wiftype": 199,
-        "txfee": 100000,
-        "dust": 54600,
-        "required_confirmations": 7,
-        "mature_confirmations": 3600,
-        "avg_blocktime": 24,
-        "segwit": true,
-        "bech32_hrp": "via",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "VIA",
-        "mm2": 1,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/14'",
-        "trezor_coin": "Viacoin",
-        "links": {
-            "github": "https://github.com/viacoin",
-            "homepage": "https://viacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5102"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "VITE-BEP20": {
         "coin": "VITE-BEP20",
         "type": "BEP-20",
@@ -36691,53 +33481,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
-    "VRM": {
-        "coin": "VRM",
-        "type": "UTXO",
-        "name": "Verium Reserve",
-        "coinpaprika_id": "vrm-veriumreserve",
-        "coingecko_id": "",
-        "livecoinwatch_id": "VRM",
-        "explorer_url": "https://explorer-vrm.vericonomy.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Verium Reserve",
-        "rpcport": 33987,
-        "pubtype": 70,
-        "p2shtype": 132,
-        "wiftype": 198,
-        "txfee": 100000,
-        "force_min_relay_fee": true,
-        "isPoS": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 240,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrum01-vrm.vericonomy.com:50001",
-                "contact": [
-                    {
-                        "email": "dev@vericoin.info"
-                    },
-                    {
-                        "twitter": "vericonomy"
-                    },
-                    {
-                        "github": "VeriConomy"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "VRSC": {
         "coin": "VRSC",
         "type": "Smart Chain",
@@ -36768,48 +33511,6 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
-            {
-                "url": "el0.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
-            {
-                "url": "el1.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
-            {
-                "url": "el2.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
             {
                 "url": "el0.verus.io:17486",
                 "protocol": "SSL",
@@ -36863,161 +33564,6 @@
             }
         ],
         "explorer_block_url": "block/"
-    },
-    "VPRM": {
-        "coin": "VPRM",
-        "type": "Smart Chain",
-        "name": "Vaporum",
-        "coinpaprika_id": "vprm-vaporum-coin",
-        "coingecko_id": "vaporum-coin",
-        "livecoinwatch_id": "VPRM",
-        "explorer_url": "http://explorer.vaporumcoin.us/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "VPRM",
-        "fname": "Vaporum",
-        "rpcport": 51609,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx2.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "VTC": {
-        "coin": "VTC",
-        "type": "UTXO",
-        "name": "Vertcoin",
-        "coinpaprika_id": "vtc-vertcoin",
-        "coingecko_id": "vertcoin",
-        "livecoinwatch_id": "VTC",
-        "explorer_url": "https://chainz.cryptoid.info/vtc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Vertcoin Signed Message:\n",
-        "fname": "Vertcoin",
-        "rpcport": 5888,
-        "pubtype": 71,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "vtc",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/28'",
-        "trezor_coin": "Vertcoin",
-        "links": {
-            "github": "https://github.com/vertcoin-project/vertcoin-core",
-            "homepage": "https://vertcoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5028"
-            },
-            {
-                "url": "electrumx-brn.webhop.me:55001"
-            },
-            {
-                "url": "electrumx.javerity.com:5885",
-                "ws_url": "electrumx.javerity.com:5887",
-                "contact": [
-                    {
-                        "discord": "cruelnovo#4936"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "VTC-segwit": {
-        "coin": "VTC-segwit",
-        "type": "UTXO",
-        "name": "Vertcoin",
-        "coinpaprika_id": "vtc-vertcoin",
-        "coingecko_id": "vertcoin",
-        "livecoinwatch_id": "VTC",
-        "explorer_url": "https://chainz.cryptoid.info/vtc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Vertcoin Signed Message:\n",
-        "fname": "Vertcoin",
-        "rpcport": 5888,
-        "pubtype": 71,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "vtc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "VTC",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/28'",
-        "trezor_coin": "Vertcoin",
-        "links": {
-            "github": "https://github.com/vertcoin-project/vertcoin-core",
-            "homepage": "https://vertcoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5028"
-            },
-            {
-                "url": "electrumx-brn.webhop.me:55001"
-            },
-            {
-                "url": "electrumx.javerity.com:5885",
-                "ws_url": "electrumx.javerity.com:5887",
-                "contact": [
-                    {
-                        "discord": "cruelnovo#4936"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "WAVES-BEP20": {
         "coin": "WAVES-BEP20",
@@ -37705,73 +34251,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
-    "XEP-segwit": {
-        "coin": "XEP-segwit",
-        "type": "UTXO",
-        "name": "Electra Protocol",
-        "coinpaprika_id": "",
-        "coingecko_id": "",
-        "livecoinwatch_id": "XEP",
-        "explorer_url": "https://electraprotocol.network/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Electra Protocol",
-        "rpcport": 16816,
-        "pubtype": 55,
-        "p2shtype": 137,
-        "wiftype": 162,
-        "txversion": 2,
-        "txfee": 100000,
-        "mm2": 1,
-        "segwit": true,
-        "signature_version": "witness_v0",
-        "bech32_hrp": "ep",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "XEP",
-        "required_confirmations": 4,
-        "avg_blocktime": 80,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/597'",
-        "electrum": [
-            {
-                "url": "electrumx1.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx1.electraprotocol.eu:50003"
-            },
-            {
-                "url": "electrumx2.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx2.electraprotocol.eu:50003"
-            },
-            {
-                "url": "electrumx3.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx3.electraprotocol.eu:50003"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "XEP-BEP20": {
         "coin": "XEP-BEP20",
         "type": "BEP-20",
@@ -38053,12 +34532,12 @@
         "electrum": [
             {
                 "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
+                "protocol": "TCP"
             },
             {
                 "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "lenoir.ecoincore.com:10894"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38100,12 +34579,12 @@
         "electrum": [
             {
                 "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
+                "protocol": "TCP"
             },
             {
                 "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "protocol": "SSL",
+                "ws_url": "lenoir.ecoincore.com:10894"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38183,50 +34662,6 @@
                     }
                 ],
                 "ws_url": "electrumx3.neurai.top:50002"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XPM": {
-        "coin": "XPM",
-        "type": "UTXO",
-        "name": "Primecoin",
-        "coinpaprika_id": "xpm-primecoin",
-        "coingecko_id": "primecoin",
-        "livecoinwatch_id": "XPM",
-        "explorer_url": "https://www.blockseek.io/xpm/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": true,
-        "fname": "Primecoin",
-        "rpcport": 8332,
-        "pubtype": 23,
-        "p2shtype": 83,
-        "wiftype": 151,
-        "txfee": 0,
-        "dust": 1000000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/24'",
-        "trezor_coin": "Primecoin",
-        "links": {
-            "github": "https://github.com/primecoin/primecoin",
-            "homepage": "https://primecoin.io"
-        },
-        "electrum": [
-            {
-                "url": "electrumx.mainnet.primecoin.org:50011"
-            },
-            {
-                "url": "electrumx.primecoin.org:50001"
             }
         ],
         "explorer_block_url": "block/"
@@ -38615,43 +35050,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
-    "XVC": {
-        "coin": "XVC",
-        "type": "UTXO",
-        "name": "VanillaCash",
-        "coinpaprika_id": "xvc-vcash",
-        "coingecko_id": "vcash",
-        "livecoinwatch_id": "XVC",
-        "explorer_url": "https://chainz.cryptoid.info/xvc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "VanillaCash",
-        "isPoS": 1,
-        "rpcport": 48888,
-        "pubtype": 18,
-        "p2shtype": 30,
-        "wiftype": 181,
-        "txfee": 1000,
-        "dust": 10000,
-        "mm2": 1,
-        "required_confirmations": 7,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrumx1.vanillacash.info:50011",
-                "ws_url": "electrumx1.vanillacash.info:50013"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
     "XVC-BEP20": {
         "coin": "XVC-BEP20",
         "type": "BEP-20",
@@ -38753,7 +35151,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -38765,7 +35164,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -38777,42 +35177,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -38822,49 +35186,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XVG": {
-        "coin": "XVG",
-        "type": "UTXO",
-        "name": "Verge",
-        "coinpaprika_id": "xvg-verge",
-        "coingecko_id": "verge",
-        "livecoinwatch_id": "XVG",
-        "explorer_url": "https://xvgblockexplorer.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "VERGE Signed Message:\n",
-        "fname": "Verge",
-        "isPoS": 1,
-        "rpcport": 20102,
-        "pubtype": 30,
-        "p2shtype": 33,
-        "wiftype": 158,
-        "decimals": 6,
-        "segwit": true,
-        "bech32_hrp": "vg",
-        "txfee": 400000,
-        "dust": 400000,
-        "force_min_relay_fee": true,
-        "mm2": 1,
-        "required_confirmations": 10,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/77'",
-        "electrum": [
-            {
-                "url": "88.99.26.209:5036"
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -39439,7 +35762,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10058",
+                "url": "electrum1.cipig.net:20058",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39451,7 +35775,8 @@
                 "ws_url": "electrum1.cipig.net:30058"
             },
             {
-                "url": "electrum2.cipig.net:10058",
+                "url": "electrum2.cipig.net:20058",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39463,42 +35788,6 @@
                 "ws_url": "electrum2.cipig.net:30058"
             },
             {
-                "url": "electrum3.cipig.net:10058",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30058"
-            },
-            {
-                "url": "electrum1.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20058",
                 "protocol": "SSL",
                 "contact": [
@@ -39508,7 +35797,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30058"
             }
         ],
         "explorer_block_url": "block/"
@@ -39548,7 +35838,8 @@
         "derivation_path": "m/44'/323'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10065",
+                "url": "electrum1.cipig.net:20065",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39560,7 +35851,8 @@
                 "ws_url": "electrum1.cipig.net:30065"
             },
             {
-                "url": "electrum2.cipig.net:10065",
+                "url": "electrum2.cipig.net:20065",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -39572,42 +35864,6 @@
                 "ws_url": "electrum2.cipig.net:30065"
             },
             {
-                "url": "electrum3.cipig.net:10065",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30065"
-            },
-            {
-                "url": "electrum1.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20065",
                 "protocol": "SSL",
                 "contact": [
@@ -39617,7 +35873,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30065"
             }
         ],
         "explorer_block_url": "block/"
@@ -39717,8 +35974,7 @@
         "electrum": [
             {
                 "url": "207.180.252.200:50011",
-                "protocol": "TCP",
-                "ws_url": "207.180.252.200:50013"
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -40001,7 +36257,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40013,7 +36270,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40025,42 +36283,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40070,7 +36292,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40303,7 +36526,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40315,7 +36539,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40327,42 +36552,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40372,7 +36561,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40419,7 +36609,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40431,7 +36622,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40443,42 +36635,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40488,7 +36644,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40535,7 +36692,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40547,7 +36705,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40559,42 +36718,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40604,7 +36727,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40651,7 +36775,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40663,7 +36788,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40675,42 +36801,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40720,7 +36810,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40767,7 +36858,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40779,7 +36871,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40791,42 +36884,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40836,7 +36893,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40883,7 +36941,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40895,7 +36954,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -40907,42 +36967,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -40952,7 +36976,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -40999,7 +37024,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41011,7 +37037,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41023,42 +37050,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -41068,7 +37059,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -41115,7 +37107,8 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
+                "url": "electrum1.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41127,7 +37120,8 @@
                 "ws_url": "electrum1.cipig.net:30050"
             },
             {
-                "url": "electrum2.cipig.net:10050",
+                "url": "electrum2.cipig.net:20050",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -41139,42 +37133,6 @@
                 "ws_url": "electrum2.cipig.net:30050"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -41184,7 +37142,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30050"
             }
         ],
         "explorer_block_url": "block/"
@@ -43046,17 +39005,6 @@
         },
         "electrum": [
             {
-                "url": "swap.softbalanced.com:50001",
-                "contact": [
-                    {
-                        "email": "dev@softbalanced.com"
-                    },
-                    {
-                        "discord": "softbalanced#4045"
-                    }
-                ]
-            },
-            {
                 "url": "swap.softbalanced.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -43137,34 +39085,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx1.cointest.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -43233,34 +39153,6 @@
             "type": "UTXO"
         },
         "electrum": [
-            {
-                "url": "electrumx1.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
             {
                 "url": "electrumx1.cointest.com:50002",
                 "protocol": "SSL",
@@ -43457,7 +39349,8 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10002",
+                "url": "electrum1.cipig.net:20002",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -43469,7 +39362,8 @@
                 "ws_url": "electrum1.cipig.net:30002"
             },
             {
-                "url": "electrum2.cipig.net:10002",
+                "url": "electrum2.cipig.net:20002",
+                "protocol": "SSL",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -43481,42 +39375,6 @@
                 "ws_url": "electrum2.cipig.net:30002"
             },
             {
-                "url": "electrum3.cipig.net:10002",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30002"
-            },
-            {
-                "url": "electrum1.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.cipig.net:20002",
                 "protocol": "SSL",
                 "contact": [
@@ -43526,7 +39384,8 @@
                     {
                         "discord": "cipi#4502"
                     }
-                ]
+                ],
+                "ws_url": "electrum3.cipig.net:30002"
             }
         ],
         "explorer_block_url": "block/"
@@ -43581,30 +39440,6 @@
         },
         "required_confirmations": 3,
         "electrum": [
-            {
-                "url": "zombie.dragonhound.info:10033",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30058"
-            },
-            {
-                "url": "zombie.dragonhound.info:10133",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30059"
-            },
             {
                 "url": "zombie.dragonhound.info:20033",
                 "protocol": "SSL",
@@ -43798,22 +39633,6 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
-            {
-                "url": "electrumx1.actioncoin.com:10001",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.actioncoin.com:10001",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
-            },
             {
                 "url": "electrumx1.actioncoin.com:30001",
                 "ws_url": "electrumx1.actioncoin.com:20001",
@@ -44087,25 +39906,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx.mazanode.com:50001",
-                "contact": [
-                    {
-                        "email": "brian@mazacoin.org"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.mazacha.in:50001",
-                "contact": [
-                    {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx.mazanode.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -44127,6 +39927,16 @@
                     }
                 ],
                 "ws_url": "electrumx2.mazacha.in:50005"
+            },
+            {
+                "url": "electrum.seed.mazanode.com:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ],
+                "ws_url": "electrum.seed.mazanode.com:50005"
             }
         ],
         "explorer_block_url": "block/"
@@ -44169,28 +39979,6 @@
             "homepage": "https://coin.crionic.org"
         },
         "electrum": [
-            {
-                "url": "coin.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "explorer.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
             {
                 "url": "coin.crionic.org:50002",
                 "protocol": "SSL",
@@ -44255,28 +40043,6 @@
             "homepage": "https://evrmorecoin.org"
         },
         "electrum": [
-            {
-                "url": "electrum1-mainnet.evrmorecoin.org:50001",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2-mainnet.evrmorecoin.org:50001",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ]
-            },
             {
                 "url": "electrum1-mainnet.evrmorecoin.org:50002",
                 "protocol": "SSL",

--- a/utils/coins_config_wss.json
+++ b/utils/coins_config_wss.json
@@ -6894,7 +6894,7 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "miami.ecoincore.com:34335",
+                "url": "lenoir.ecoincore.com:34335",
                 "protocol": "WSS"
             },
             {
@@ -6902,7 +6902,7 @@
                 "protocol": "WSS"
             },
             {
-                "url": "lenoir.ecoincore.com:34335",
+                "url": "miami.ecoincore.com:34335",
                 "protocol": "WSS"
             }
         ],
@@ -6946,7 +6946,7 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "miami.ecoincore.com:34335",
+                "url": "lenoir.ecoincore.com:34335",
                 "protocol": "WSS"
             },
             {
@@ -6954,7 +6954,7 @@
                 "protocol": "WSS"
             },
             {
-                "url": "lenoir.ecoincore.com:34335",
+                "url": "miami.ecoincore.com:34335",
                 "protocol": "WSS"
             }
         ],

--- a/utils/coins_config_wss.json
+++ b/utils/coins_config_wss.json
@@ -132,6 +132,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -181,6 +190,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -233,6 +251,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -479,6 +515,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -534,6 +579,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -818,6 +881,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -867,6 +939,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -923,6 +1004,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1028,6 +1127,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1138,6 +1255,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1245,6 +1380,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1294,6 +1438,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1404,6 +1566,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1462,6 +1642,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -1608,6 +1797,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1657,6 +1855,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1801,6 +2017,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1850,6 +2075,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -1994,6 +2228,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2118,6 +2361,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2266,6 +2518,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2376,6 +2646,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2430,6 +2709,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -2491,6 +2788,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2540,6 +2846,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2597,6 +2912,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -2750,6 +3083,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2799,6 +3141,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2851,6 +3202,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -3054,6 +3423,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3111,6 +3498,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3460,6 +3856,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3704,6 +4118,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -3804,6 +4227,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3862,6 +4303,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3958,6 +4408,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -3970,6 +4429,44 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/",
         "forex_id": "IDR"
+    },
+    "BITN": {
+        "coin": "BITN",
+        "type": "UTXO",
+        "name": "Bitnet",
+        "coinpaprika_id": "bit-bitnet",
+        "coingecko_id": "",
+        "livecoinwatch_id": "________BIT",
+        "explorer_url": "https://bitexplorer.io/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "address/",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Bitnet Signed Message:\n",
+        "fname": "Bitnet",
+        "rpcport": 9332,
+        "pubtype": 25,
+        "p2shtype": 22,
+        "wiftype": 158,
+        "txfee": 700000,
+        "segwit": true,
+        "bech32_hrp": "bit",
+        "mm2": 1,
+        "required_confirmations": 1,
+        "avg_blocktime": 600,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [
+            {
+                "url": "bitexplorer.io:50004",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block/"
     },
     "BLK": {
         "coin": "BLK",
@@ -4058,6 +4555,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -4155,6 +4661,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4204,6 +4719,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -4340,6 +4873,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4395,6 +4937,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -4505,6 +5065,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4556,6 +5125,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -4616,6 +5203,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5017,6 +5622,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5027,6 +5641,46 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "BTCZ": {
+        "coin": "BTCZ",
+        "type": "UTXO",
+        "name": "BitcoinZ",
+        "coinpaprika_id": "btcz-bitcoinz",
+        "coingecko_id": "bitcoinz",
+        "livecoinwatch_id": "BTCZ",
+        "explorer_url": "https://explorer.btcz.rocks/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "address/",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "BitcoinZ Signed Message:\n",
+        "fname": "BitcoinZ",
+        "rpcport": 1979,
+        "taddr": 28,
+        "pubtype": 184,
+        "p2shtype": 189,
+        "wiftype": 128,
+        "txfee": 10000,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/177'",
+        "electrum": [
+            {
+                "url": "electrum2.btcz.rocks:50004",
+                "protocol": "WSS"
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "BTCZ-BEP20": {
@@ -5067,6 +5721,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -5214,6 +5877,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5264,6 +5936,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -5321,6 +6002,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5521,6 +6220,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5711,6 +6419,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -5768,6 +6494,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -5868,6 +6603,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5979,6 +6732,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -6029,6 +6791,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6123,11 +6894,15 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:34335",
+                "url": "miami.ecoincore.com:34335",
                 "protocol": "WSS"
             },
             {
-                "url": "miami.ecoincore.com:34335",
+                "url": "woolloomooloo.ecoincore.com:34335",
+                "protocol": "WSS"
+            },
+            {
+                "url": "lenoir.ecoincore.com:34335",
                 "protocol": "WSS"
             }
         ],
@@ -6171,11 +6946,15 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:34335",
+                "url": "miami.ecoincore.com:34335",
                 "protocol": "WSS"
             },
             {
-                "url": "miami.ecoincore.com:34335",
+                "url": "woolloomooloo.ecoincore.com:34335",
+                "protocol": "WSS"
+            },
+            {
+                "url": "lenoir.ecoincore.com:34335",
                 "protocol": "WSS"
             }
         ],
@@ -6219,6 +6998,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -6334,6 +7131,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -6392,6 +7207,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6488,6 +7312,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6589,6 +7422,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -6697,6 +7548,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -6895,6 +7764,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -6950,6 +7828,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7104,6 +8000,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7254,6 +8168,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7497,6 +8429,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -7547,6 +8488,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7764,6 +8723,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7821,6 +8798,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -8106,6 +9092,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -8169,6 +9173,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -8227,6 +9249,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8436,6 +9476,10 @@
         "derivation_path": "m/44'/18'",
         "electrum": [
             {
+                "url": "electrumx.dgc.ewmcx.org:50003",
+                "protocol": "WSS"
+            },
+            {
                 "url": "failover.dgc.ewmcx.biz:50003",
                 "protocol": "WSS"
             }
@@ -8480,6 +9524,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8540,6 +9602,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -8633,6 +9704,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -8741,6 +9821,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -8791,6 +9880,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8948,6 +10055,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -8997,6 +10113,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -9050,6 +10175,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9099,6 +10233,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -9289,6 +10432,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9339,6 +10491,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9400,6 +10570,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9455,6 +10634,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9567,6 +10764,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9720,6 +10935,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9818,6 +11042,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9862,6 +11095,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10003,6 +11254,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -10238,6 +11498,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -10350,6 +11628,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10500,6 +11796,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -10550,6 +11855,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10612,6 +11935,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -10670,6 +12011,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -10771,6 +12121,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -10821,6 +12180,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10926,6 +12303,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -10978,6 +12364,10 @@
             {
                 "url": "electrumx1.fujicoin.org:50005",
                 "protocol": "WSS"
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -11026,6 +12416,10 @@
             {
                 "url": "electrumx1.fujicoin.org:50005",
                 "protocol": "WSS"
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -11067,6 +12461,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11120,6 +12523,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11169,6 +12581,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11221,6 +12642,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -11281,6 +12720,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11517,6 +12965,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11571,6 +13028,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -11633,6 +13108,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11683,6 +13167,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -11927,6 +13429,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -11987,6 +13507,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12039,6 +13568,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12049,6 +13587,52 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "GLEEC": {
+        "coin": "GLEEC",
+        "type": "Smart Chain",
+        "name": "Gleec",
+        "coinpaprika_id": "gleec-gleec-coin",
+        "coingecko_id": "gleec-coin",
+        "livecoinwatch_id": "GLEEC",
+        "explorer_url": "https://gleec.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "GLEEC",
+        "fname": "Gleec",
+        "rpcport": 23226,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrum1.cipig.net:30022",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.cipig.net:30022",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.cipig.net:30022",
+                "protocol": "WSS"
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "GLM-ERC20": {
@@ -12089,6 +13673,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12198,6 +13800,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12248,6 +13859,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -12349,6 +13969,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12547,6 +14185,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12607,6 +14263,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12657,7 +14322,15 @@
         },
         "electrum": [
             {
-                "url": "electrum11.groestlcoin.org:50004",
+                "url": "electrum1.groestlcoin.org:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum12.groestlcoin.org:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum13.groestlcoin.org:50004",
                 "protocol": "WSS"
             }
         ],
@@ -12705,7 +14378,15 @@
         },
         "electrum": [
             {
-                "url": "electrum11.groestlcoin.org:50004",
+                "url": "electrum1.groestlcoin.org:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum12.groestlcoin.org:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum13.groestlcoin.org:50004",
                 "protocol": "WSS"
             }
         ],
@@ -12799,6 +14480,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12953,6 +14652,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -13003,6 +14711,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13063,6 +14789,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13128,6 +14872,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13236,6 +14998,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13390,6 +15170,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13448,6 +15246,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13648,6 +15464,51 @@
         ],
         "explorer_block_url": "block.dws?"
     },
+    "ILN": {
+        "coin": "ILN",
+        "type": "Smart Chain",
+        "name": "Ilien",
+        "coinpaprika_id": "iln-ilien9195",
+        "coingecko_id": "",
+        "livecoinwatch_id": "ILN",
+        "explorer_url": "https://explorer.ilien.io/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "ILN",
+        "fname": "Ilien",
+        "rpcport": 12986,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "p2p": 12985,
+        "magic": "feb4cb23",
+        "nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrum1.ilien.io:30069",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.ilien.io:30069",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "ILN-BEP20": {
         "coin": "ILN-BEP20",
         "type": "BEP-20",
@@ -13686,6 +15547,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13836,6 +15706,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13896,6 +15784,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -13946,6 +15843,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14007,6 +15922,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14056,6 +15980,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14117,6 +16059,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14166,6 +16117,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -14267,6 +16227,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14366,6 +16335,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -14564,6 +16542,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14614,6 +16601,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14820,6 +16825,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14870,6 +16884,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14982,6 +17014,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15032,6 +17073,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15581,6 +17640,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15885,6 +17962,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -16032,6 +18118,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -16081,6 +18176,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -16137,6 +18241,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -16338,6 +18460,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -16533,6 +18664,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16645,6 +18794,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16752,6 +18919,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -16854,6 +19039,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -17089,6 +19283,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -17144,6 +19347,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17204,6 +19425,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -17305,6 +19535,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17370,6 +19618,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17430,6 +19696,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -17480,6 +19755,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -17696,6 +19980,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17754,6 +20056,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -17900,6 +20211,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -17950,6 +20270,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18142,6 +20480,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18196,6 +20543,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18346,6 +20711,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18404,6 +20787,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -18506,6 +20898,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18614,6 +21024,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18672,6 +21100,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -18770,6 +21207,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18825,6 +21271,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18934,6 +21398,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -19037,6 +21519,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -19306,6 +21797,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19355,6 +21855,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -19411,6 +21920,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19564,6 +22091,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19669,6 +22205,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19780,6 +22334,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19834,6 +22397,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19947,6 +22528,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20097,6 +22696,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -20151,6 +22759,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20210,6 +22836,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -20355,6 +22990,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -20410,6 +23054,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20479,6 +23141,87 @@
             }
         ],
         "explorer_block_url": "block/"
+    },
+    "PIVX": {
+        "coin": "PIVX",
+        "type": "UTXO",
+        "name": "PIVX",
+        "coinpaprika_id": "pivx-pivx",
+        "coingecko_id": "pivx",
+        "livecoinwatch_id": "PIVX",
+        "explorer_url": "https://chainz.cryptoid.info/pivx/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "PIVX",
+        "rpcport": 51473,
+        "pubtype": 30,
+        "p2shtype": 13,
+        "wiftype": 212,
+        "txfee": 100000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/119'",
+        "electrum": [
+            {
+                "url": "electrum01.chainster.org:50003",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum02.chainster.org:50003",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
+    "PND": {
+        "coin": "PND",
+        "type": "UTXO",
+        "name": "Pandacoin",
+        "coinpaprika_id": "pnd-pandacoin",
+        "coingecko_id": "pandacoin",
+        "livecoinwatch_id": "PND",
+        "explorer_url": "https://chainz.cryptoid.info/pnd/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Pandacoin",
+        "isPoS": 1,
+        "rpcport": 22444,
+        "pubtype": 55,
+        "p2shtype": 22,
+        "wiftype": 183,
+        "decimals": 6,
+        "txfee": 10000000,
+        "dust": 1000000,
+        "segwit": true,
+        "bech32_hrp": "pn",
+        "mm2": 1,
+        "required_confirmations": 1,
+        "avg_blocktime": 600,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/37'",
+        "electrum": [
+            {
+                "url": "electrum.thepandacoin.net:443",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
     },
     "POT": {
         "coin": "POT",
@@ -20559,6 +23302,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20671,6 +23432,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20831,6 +23610,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20938,6 +23735,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -20988,6 +23794,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21091,6 +23915,10 @@
             {
                 "url": "electrumx.live:30010",
                 "protocol": "WSS"
+            },
+            {
+                "url": "txserver.live:30001",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -21132,6 +23960,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -21187,6 +24024,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21457,6 +24312,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -21510,6 +24374,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21575,6 +24457,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21853,6 +24753,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22066,6 +24984,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22173,6 +25109,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22231,6 +25185,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -22437,6 +25409,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22543,6 +25533,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -22653,6 +25661,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22718,6 +25744,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22734,6 +25778,47 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "RTM": {
+        "coin": "RTM",
+        "type": "UTXO",
+        "name": "Raptoreum",
+        "coinpaprika_id": "rtm-raptoreum",
+        "coingecko_id": "raptoreum",
+        "livecoinwatch_id": "RTM",
+        "explorer_url": "https://explorer.raptoreum.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Raptoreum",
+        "rpcport": 9998,
+        "pubtype": 60,
+        "p2shtype": 16,
+        "wiftype": 128,
+        "txfee": 1000,
+        "mm2": 1,
+        "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
+        "required_confirmations": 3,
+        "avg_blocktime": 120,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/10226'",
+        "electrum": [
+            {
+                "url": "x1.raptoreum.com:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "x2.raptoreum.com:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -22776,6 +25861,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -22881,6 +25975,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22939,6 +26051,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -23041,6 +26162,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23091,6 +26221,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -23189,6 +26328,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23244,6 +26392,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23443,6 +26609,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23540,6 +26715,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23646,6 +26839,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23846,6 +27057,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23901,6 +27121,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24143,6 +27381,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -24192,6 +27439,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -24244,6 +27500,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24459,6 +27733,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24516,6 +27808,10 @@
             {
                 "url": "electrum2.cipig.net:30068",
                 "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.cipig.net:30068",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -24561,6 +27857,10 @@
             {
                 "url": "electrum2.cipig.net:30068",
                 "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.cipig.net:30068",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -24603,6 +27903,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24757,6 +28075,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -24807,6 +28134,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -24903,6 +28239,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24961,6 +28315,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -25052,6 +28415,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25102,6 +28474,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -25199,6 +28580,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -25302,6 +28692,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -25362,6 +28770,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25412,6 +28829,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -25468,6 +28894,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -25756,6 +29200,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25810,6 +29263,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26001,6 +29472,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26158,6 +29647,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26215,6 +29722,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -26545,6 +30061,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -26602,6 +30136,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -26880,6 +30423,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26930,6 +30482,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27350,6 +30920,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -27403,6 +30982,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27462,6 +31059,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27567,6 +31182,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -27615,6 +31239,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27675,6 +31317,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27784,6 +31444,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -27841,6 +31510,98 @@
         ],
         "explorer_block_url": "block/"
     },
+    "VTC": {
+        "coin": "VTC",
+        "type": "UTXO",
+        "name": "Vertcoin",
+        "coinpaprika_id": "vtc-vertcoin",
+        "coingecko_id": "vertcoin",
+        "livecoinwatch_id": "VTC",
+        "explorer_url": "https://chainz.cryptoid.info/vtc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Vertcoin Signed Message:\n",
+        "fname": "Vertcoin",
+        "rpcport": 5888,
+        "pubtype": 71,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "vtc",
+        "mm2": 1,
+        "required_confirmations": 4,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/28'",
+        "trezor_coin": "Vertcoin",
+        "links": {
+            "github": "https://github.com/vertcoin-project/vertcoin-core",
+            "homepage": "https://vertcoin.org"
+        },
+        "electrum": [
+            {
+                "url": "electrumx.javerity.com:5887",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
+    "VTC-segwit": {
+        "coin": "VTC-segwit",
+        "type": "UTXO",
+        "name": "Vertcoin",
+        "coinpaprika_id": "vtc-vertcoin",
+        "coingecko_id": "vertcoin",
+        "livecoinwatch_id": "VTC",
+        "explorer_url": "https://chainz.cryptoid.info/vtc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Vertcoin Signed Message:\n",
+        "fname": "Vertcoin",
+        "rpcport": 5888,
+        "pubtype": 71,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "vtc",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "VTC",
+        "mm2": 1,
+        "required_confirmations": 4,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/28'",
+        "trezor_coin": "Vertcoin",
+        "links": {
+            "github": "https://github.com/vertcoin-project/vertcoin-core",
+            "homepage": "https://vertcoin.org"
+        },
+        "electrum": [
+            {
+                "url": "electrumx.javerity.com:5887",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
     "WAVES-BEP20": {
         "coin": "WAVES-BEP20",
         "type": "BEP-20",
@@ -27879,6 +31640,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -27936,6 +31706,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28046,6 +31834,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28104,6 +31910,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28209,6 +32033,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28356,6 +32189,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -28416,6 +32267,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -28426,6 +32286,58 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "XEP-segwit": {
+        "coin": "XEP-segwit",
+        "type": "UTXO",
+        "name": "Electra Protocol",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "XEP",
+        "explorer_url": "https://electraprotocol.network/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Electra Protocol",
+        "rpcport": 16816,
+        "pubtype": 55,
+        "p2shtype": 137,
+        "wiftype": 162,
+        "txversion": 2,
+        "txfee": 100000,
+        "mm2": 1,
+        "segwit": true,
+        "signature_version": "witness_v0",
+        "bech32_hrp": "ep",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "XEP",
+        "required_confirmations": 4,
+        "avg_blocktime": 80,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/597'",
+        "electrum": [
+            {
+                "url": "electrumx1.electraprotocol.eu:50003",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrumx2.electraprotocol.eu:50003",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrumx3.electraprotocol.eu:50003",
+                "protocol": "WSS"
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "XEP-BEP20": {
@@ -28466,6 +32378,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28518,6 +32439,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28626,6 +32565,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28809,6 +32757,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -28859,6 +32816,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28924,6 +32899,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29035,6 +33028,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -29046,6 +33048,43 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
+    },
+    "XVC": {
+        "coin": "XVC",
+        "type": "UTXO",
+        "name": "VanillaCash",
+        "coinpaprika_id": "xvc-vcash",
+        "coingecko_id": "vcash",
+        "livecoinwatch_id": "XVC",
+        "explorer_url": "https://chainz.cryptoid.info/xvc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "VanillaCash",
+        "isPoS": 1,
+        "rpcport": 48888,
+        "pubtype": 18,
+        "p2shtype": 30,
+        "wiftype": 181,
+        "txfee": 1000,
+        "dust": 10000,
+        "mm2": 1,
+        "required_confirmations": 7,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [
+            {
+                "url": "electrumx1.vanillacash.info:50013",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
     },
     "XVC-BEP20": {
         "coin": "XVC-BEP20",
@@ -29084,6 +33123,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -29192,6 +33240,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -29288,6 +33345,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -29343,6 +33409,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29541,6 +33625,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -29596,6 +33689,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29763,6 +33874,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -29812,6 +33932,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -29914,6 +34043,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30075,6 +34222,10 @@
         "derivation_path": "m/44'/19167'",
         "electrum": [
             {
+                "url": "electrumx2.runonflux.io:50004",
+                "protocol": "WSS"
+            },
+            {
                 "url": "electrumx.runonflux.io:50004",
                 "protocol": "WSS"
             }
@@ -30119,6 +34270,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30178,6 +34347,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30685,6 +34863,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30747,6 +34943,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30814,6 +35028,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30879,6 +35111,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30939,6 +35189,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30997,6 +35265,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31063,6 +35349,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31121,6 +35425,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31188,6 +35510,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31250,6 +35590,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31355,6 +35713,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31413,6 +35789,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31477,6 +35871,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31544,6 +35956,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31604,6 +36034,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31662,6 +36110,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31728,6 +36194,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31786,6 +36270,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31848,6 +36350,24 @@
                 "gui_auth": true
             },
             {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31908,6 +36428,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31958,6 +36487,24 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
+            },
+            {
+                "url": "http://eth1.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth2.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
+            },
+            {
+                "url": "http://eth3.cipig.net:8555",
+                "contact": {
+                    "email": "cipi@komodoplatform.com"
+                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32018,6 +36565,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -32146,6 +36702,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -32306,6 +36871,15 @@
                 "gui_auth": true
             },
             {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
+            },
+            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -32437,6 +37011,15 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
+            },
+            {
+                "url": "http://bsc1.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc2.cipig.net:8655"
+            },
+            {
+                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"

--- a/utils/coins_config_wss.json
+++ b/utils/coins_config_wss.json
@@ -132,15 +132,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -190,15 +181,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -251,24 +233,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -515,15 +479,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -579,24 +534,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -832,16 +769,12 @@
         },
         "electrum": [
             {
-                "url": "elec-seeder-one.artbytecoin.org:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "elec-seeder-one.artbytecoin.org:50013"
+                "url": "elec-seeder-one.artbytecoin.org:50013",
+                "protocol": "WSS"
             },
             {
-                "url": "elec-seeder-two.artbytecoin.org:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "elec-seeder-two.artbytecoin.org:50013"
+                "url": "elec-seeder-two.artbytecoin.org:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -883,15 +816,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -943,15 +867,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -1008,24 +923,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1131,24 +1028,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1259,24 +1138,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1384,15 +1245,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1442,24 +1294,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1570,24 +1404,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -1646,15 +1462,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -1801,15 +1608,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -1859,24 +1657,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -1967,76 +1747,16 @@
         "checkpoint_blocktime": 1652512363,
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10008",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30008"
+                "url": "electrum1.cipig.net:30008",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10008",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30008"
+                "url": "electrum2.cipig.net:30008",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10008",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30008"
-            },
-            {
-                "url": "electrum1.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20008",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30008",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -2079,15 +1799,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2139,15 +1850,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2243,21 +1945,12 @@
         "derivation_path": "m/44'/85'",
         "electrum": [
             {
-                "url": "electrumx.aur.ewmcx.info:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "electrumx.aur.ewmcx.info:50003"
+                "url": "electrumx.aur.ewmcx.info:50003",
+                "protocol": "WSS"
             },
             {
-                "url": "failover.aur.ewmcx.biz:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "failover.aur.ewmcx.biz:50003"
-            },
-            {
-                "url": "lenoir.ecoincore.com:12343",
-                "protocol": "SSL",
-                "disable_cert_verification": false
+                "url": "failover.aur.ewmcx.biz:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -2299,15 +1992,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2436,15 +2120,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -2490,58 +2165,16 @@
         "derivation_path": "m/44'/921'",
         "electrum": [
             {
-                "url": "electrum-ca.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
+                "url": "electrum-ca.avn.network:50003",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum-eu.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
+                "url": "electrum-eu.avn.network:50003",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum-us.avn.network:50001",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ]
-            },
-            {
-                "url": "electrum-ca.avn.network:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ],
-                "ws_url": "electrum-ca.avn.network:50003"
-            },
-            {
-                "url": "electrum-eu.avn.network:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ],
-                "ws_url": "electrum-eu.avn.network:50003"
-            },
-            {
-                "url": "electrum-us.avn.network:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "contact@avn.network"
-                    }
-                ],
-                "ws_url": "electrum-us.avn.network:50003"
+                "url": "electrum-us.avn.network:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -2633,24 +2266,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2708,76 +2323,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10057",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30057"
+                "url": "electrum1.cipig.net:30057",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10057",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30057"
+                "url": "electrum3.cipig.net:30057",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10057",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30057"
-            },
-            {
-                "url": "electrum1.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20057",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum2.cipig.net:30057",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -2819,15 +2374,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -2886,24 +2432,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -2920,44 +2448,6 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "AYA": {
-        "coin": "AYA",
-        "type": "UTXO",
-        "name": "Aryacoin",
-        "coinpaprika_id": "aya-aryacoin",
-        "coingecko_id": "aryacoin",
-        "livecoinwatch_id": "AYA",
-        "explorer_url": "https://explorer.aryacoin.io/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Aryacoin Signed Message:\n",
-        "fname": "Aryacoin",
-        "rpcport": 9332,
-        "pubtype": 23,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 54600,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/357'",
-        "electrum": [
-            {
-                "url": "88.99.26.209:5151"
             }
         ],
         "explorer_block_url": "block/"
@@ -2999,15 +2489,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3059,15 +2540,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3125,24 +2597,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -3296,15 +2750,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -3354,15 +2799,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3415,24 +2851,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -3636,24 +3054,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -3711,15 +3111,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -3879,76 +3270,16 @@
         "slp_prefix": "simpleledger",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10055",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30055"
+                "url": "electrum1.cipig.net:30055",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10055",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30055"
+                "url": "electrum2.cipig.net:30055",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10055",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30055"
-            },
-            {
-                "url": "electrum1.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20055",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30055",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -4127,24 +3458,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -4391,15 +3704,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4500,24 +3804,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -4576,15 +3862,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -4681,15 +3958,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -4702,50 +3970,6 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/",
         "forex_id": "IDR"
-    },
-    "BITN": {
-        "coin": "BITN",
-        "type": "UTXO",
-        "name": "Bitnet",
-        "coinpaprika_id": "bit-bitnet",
-        "coingecko_id": "",
-        "livecoinwatch_id": "________BIT",
-        "explorer_url": "https://bitexplorer.io/",
-        "explorer_tx_url": "tx/",
-        "explorer_address_url": "address/",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Bitnet Signed Message:\n",
-        "fname": "Bitnet",
-        "rpcport": 9332,
-        "pubtype": 25,
-        "p2shtype": 22,
-        "wiftype": 158,
-        "txfee": 700000,
-        "segwit": true,
-        "bech32_hrp": "bit",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "bitexplorer.io:50001",
-                "protocol": "TCP",
-                "ws_url": "bitexplorer.io:50004",
-                "contact": [
-                    {
-                        "discord": "c4pt#7855"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
     },
     "BLK": {
         "coin": "BLK",
@@ -4782,61 +4006,16 @@
         "derivation_path": "m/44'/10'",
         "electrum": [
             {
-                "url": "electrum1.blackcoin.nl:10001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
+                "url": "electrum1.blackcoin.nl:10004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.blackcoin.nl:20001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
+                "url": "electrum2.blackcoin.nl:20004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.blackcoin.nl:30001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.blackcoin.nl:10002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "electrum1.blackcoin.nl:10004"
-            },
-            {
-                "url": "electrum2.blackcoin.nl:20002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "electrum2.blackcoin.nl:20004"
-            },
-            {
-                "url": "electrum3.blackcoin.nl:30002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "electrum3.blackcoin.nl:30004"
+                "url": "electrum3.blackcoin.nl:30004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -4879,15 +4058,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -4934,61 +4104,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.blackcoin.nl:10011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
+                "url": "electrum1.blackcoin.nl:10014",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.blackcoin.nl:20011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
+                "url": "electrum2.blackcoin.nl:20014",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.blackcoin.nl:30011",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.blackcoin.nl:10012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "electrum1.blackcoin.nl:10014"
-            },
-            {
-                "url": "electrum2.blackcoin.nl:20012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "electrum2.blackcoin.nl:20014"
-            },
-            {
-                "url": "electrum3.blackcoin.nl:30012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "electrum3.blackcoin.nl:30014"
+                "url": "electrum3.blackcoin.nl:30014",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -5030,15 +4155,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5050,49 +4166,6 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
-    },
-    "BOLI": {
-        "coin": "BOLI",
-        "type": "UTXO",
-        "name": "Bolivarcoin",
-        "coinpaprika_id": "boli-bolivarcoin",
-        "coingecko_id": "bolivarcoin",
-        "livecoinwatch_id": "BOLI",
-        "explorer_url": "https://chainz.cryptoid.info/boli/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "DarkCoin Signed Message:\n",
-        "fname": "Bolivarcoin",
-        "confpath": "USERHOME/.bolivarcoincore/bolivarcoin.conf",
-        "rpcport": 3563,
-        "pubtype": 85,
-        "p2shtype": 5,
-        "wiftype": 213,
-        "segwit": false,
-        "txfee": 10000,
-        "mm2": 1,
-        "required_confirmations": 3,
-        "avg_blocktime": 180,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/278'",
-        "links": {
-            "github": "https://github.com/BOLI-Project/BolivarCoin",
-            "homepage": "https://bolis.info"
-        },
-        "electrum": [
-            {
-                "url": "electrum2.bolivarcoin.tech:23001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "BONE-ERC20": {
         "coin": "BONE-ERC20",
@@ -5131,24 +4204,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5285,15 +4340,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5349,24 +4395,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5477,15 +4505,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -5537,24 +4556,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5615,24 +4616,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -5830,16 +4813,12 @@
         },
         "electrum": [
             {
-                "url": "bsty-bkp.coinmunity.gold:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "bsty-bkp.coinmunity.gold:50013"
+                "url": "bsty-bkp.coinmunity.gold:50013",
+                "protocol": "WSS"
             },
             {
-                "url": "bsty-main.coinmunity.gold:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "bsty-main.coinmunity.gold:50013"
+                "url": "bsty-main.coinmunity.gold:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -5879,16 +4858,12 @@
         },
         "electrum": [
             {
-                "url": "bsty-bkp.coinmunity.gold:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "bsty-bkp.coinmunity.gold:50013"
+                "url": "bsty-bkp.coinmunity.gold:50013",
+                "protocol": "WSS"
             },
             {
-                "url": "bsty-main.coinmunity.gold:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "bsty-main.coinmunity.gold:50013"
+                "url": "bsty-main.coinmunity.gold:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -5932,76 +4907,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30000"
+                "url": "electrum1.cipig.net:30000",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30000"
+                "url": "electrum2.cipig.net:30000",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
-            },
-            {
-                "url": "electrum1.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30000",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -6049,76 +4964,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30000"
+                "url": "electrum1.cipig.net:30000",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30000"
+                "url": "electrum2.cipig.net:30000",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10000",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30000"
-            },
-            {
-                "url": "electrum1.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20000",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30000",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -6162,15 +5017,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -6181,51 +5027,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "BTCZ": {
-        "coin": "BTCZ",
-        "type": "UTXO",
-        "name": "BitcoinZ",
-        "coinpaprika_id": "btcz-bitcoinz",
-        "coingecko_id": "bitcoinz",
-        "livecoinwatch_id": "BTCZ",
-        "explorer_url": "https://explorer.btcz.rocks/",
-        "explorer_tx_url": "tx/",
-        "explorer_address_url": "address/",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "BitcoinZ Signed Message:\n",
-        "fname": "BitcoinZ",
-        "rpcport": 1979,
-        "taddr": 28,
-        "pubtype": 184,
-        "p2shtype": 189,
-        "wiftype": 128,
-        "txfee": 10000,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/177'",
-        "electrum": [
-            {
-                "url": "electrum2.btcz.rocks:50001",
-                "contact": [
-                    {
-                        "discord": "VandarGR#6065"
-                    }
-                ],
-                "ws_url": "electrum2.btcz.rocks:50004"
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "BTCZ-BEP20": {
@@ -6266,15 +5067,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6320,52 +5112,16 @@
         },
         "electrum": [
             {
-                "url": "electrumx.bitwebcore.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "mraksoll@gmail.com"
-                    },
-                    {
-                        "discord": "mraksoll#0596"
-                    },
-                    {
-                        "github": "https://github.com/bitweb-project/electrumx/issues"
-                    }
-                ],
-                "ws_url": "electrumx.bitwebcore.net:20003"
+                "url": "electrumx.bitwebcore.net:20003",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx6.scalaris.info:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "mraksoll@gmail.com"
-                    },
-                    {
-                        "discord": "mraksoll#0596"
-                    },
-                    {
-                        "github": "https://github.com/bitweb-project/electrumx/issues"
-                    }
-                ],
-                "ws_url": "electrumx6.scalaris.info:20003"
+                "url": "electrumx6.scalaris.info:20003",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx7.scalaris.info:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "mraksoll@gmail.com"
-                    },
-                    {
-                        "discord": "mraksoll#0596"
-                    },
-                    {
-                        "github": "https://github.com/bitweb-project/electrumx/issues"
-                    }
-                ],
-                "ws_url": "electrumx7.scalaris.info:20003"
+                "url": "electrumx7.scalaris.info:20003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -6405,52 +5161,16 @@
         },
         "electrum": [
             {
-                "url": "electrumx.bitwebcore.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "mraksoll@gmail.com"
-                    },
-                    {
-                        "discord": "mraksoll#0596"
-                    },
-                    {
-                        "github": "https://github.com/bitweb-project/electrumx/issues"
-                    }
-                ],
-                "ws_url": "electrumx.bitwebcore.net:20003"
+                "url": "electrumx.bitwebcore.net:20003",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx6.scalaris.info:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "mraksoll@gmail.com"
-                    },
-                    {
-                        "discord": "mraksoll#0596"
-                    },
-                    {
-                        "github": "https://github.com/bitweb-project/electrumx/issues"
-                    }
-                ],
-                "ws_url": "electrumx6.scalaris.info:20003"
+                "url": "electrumx6.scalaris.info:20003",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx7.scalaris.info:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "mraksoll@gmail.com"
-                    },
-                    {
-                        "discord": "mraksoll#0596"
-                    },
-                    {
-                        "github": "https://github.com/bitweb-project/electrumx/issues"
-                    }
-                ],
-                "ws_url": "electrumx7.scalaris.info:20003"
+                "url": "electrumx7.scalaris.info:20003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -6492,15 +5212,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6553,15 +5264,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -6619,24 +5321,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -6744,15 +5428,8 @@
         },
         "electrum": [
             {
-                "url": "btx-electrumx.coinsmunity.com:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "[MadCatMining]#0677"
-                    }
-                ],
-                "ws_url": "btx-electrumx.coinsmunity.com:50003"
+                "url": "btx-electrumx.coinsmunity.com:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -6798,15 +5475,8 @@
         },
         "electrum": [
             {
-                "url": "btx-electrumx.coinsmunity.com:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "[MadCatMining]#0677"
-                    }
-                ],
-                "ws_url": "btx-electrumx.coinsmunity.com:50003"
+                "url": "btx-electrumx.coinsmunity.com:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -6849,15 +5519,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -7050,24 +5711,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7125,15 +5768,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -7234,24 +5868,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7363,15 +5979,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -7424,15 +6031,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -7477,76 +6075,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10029",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30029"
+                "url": "electrum1.cipig.net:30029",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10029",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30029"
+                "url": "electrum2.cipig.net:30029",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10029",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30029"
-            },
-            {
-                "url": "electrum1.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20029",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30029",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -7585,37 +6123,12 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "chicago.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
+                "url": "lenoir.ecoincore.com:34335",
+                "protocol": "WSS"
             },
             {
-                "url": "lenoir.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
-            },
-            {
-                "url": "miami.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
-            },
-            {
-                "url": "oakland.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "seattle.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "woolloomooloo.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "woolloomooloo.ecoincore.com:34335"
+                "url": "miami.ecoincore.com:34335",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7658,37 +6171,12 @@
         "derivation_path": "m/44'/34'",
         "electrum": [
             {
-                "url": "chicago.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
+                "url": "lenoir.ecoincore.com:34335",
+                "protocol": "WSS"
             },
             {
-                "url": "lenoir.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "lenoir.ecoincore.com:34335"
-            },
-            {
-                "url": "miami.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "miami.ecoincore.com:34335"
-            },
-            {
-                "url": "oakland.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "seattle.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "woolloomooloo.ecoincore.com:34333",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "woolloomooloo.ecoincore.com:34335"
+                "url": "miami.ecoincore.com:34335",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -7731,24 +6219,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -7864,24 +6334,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -7940,15 +6392,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -8047,15 +6490,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -8066,71 +6500,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "CHTA": {
-        "coin": "CHTA",
-        "type": "UTXO",
-        "name": "Cheetahcoin",
-        "coinpaprika_id": "chta-cheetahcoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "CHTA",
-        "explorer_url": "http://chtaexplorer.mooo.com:3002/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Cheetahcoin",
-        "rpcport": 8536,
-        "pubtype": 28,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 40000,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 120,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/682'",
-        "electrum": [
-            {
-                "url": "electrum.shorelinecrypto.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.mooo.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.mooo.com:10007",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "CHIPS": {
@@ -8164,76 +6533,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10053",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30053"
+                "url": "electrum1.cipig.net:30053",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10053",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30053"
+                "url": "electrum2.cipig.net:30053",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10053",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30053"
-            },
-            {
-                "url": "electrum1.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30053",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -8280,24 +6589,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8406,24 +6697,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8538,51 +6811,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "CLC": {
-        "coin": "CLC",
-        "type": "Smart Chain",
-        "name": "Collider Coin",
-        "coinpaprika_id": "clc-collider-coin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://clc.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "CLC",
-        "fname": "Collider Coin",
-        "rpcport": 31034,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "requires_notarization": false,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx.cryptocollider.com:10001",
-                "contact": [
-                    {
-                        "email": "electrumx@cryptocollider.com"
-                    },
-                    {
-                        "discord": "collider#6160"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "COMP-AVX20": {
         "coin": "COMP-AVX20",
         "type": "AVX-20",
@@ -8667,15 +6895,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -8731,24 +6950,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -8903,24 +7104,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9071,24 +7254,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9332,15 +7497,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -9391,24 +7547,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -9468,30 +7606,16 @@
         },
         "electrum": [
             {
-                "url": "electrum02.cyberyen.work:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum02.cyberyen.work:50004",
-                "contact": [
-                    {
-                        "email": "ruaxxx@ruaxxx.com"
-                    },
-                    {
-                        "discord": "ruaxxx#3151"
-                    }
-                ]
+                "url": "electrum02.cyberyen.work:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum03.cyberyen.work:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum03.cyberyen.work:50004",
-                "contact": [
-                    {
-                        "email": "ruaxxx@ruaxxx.com"
-                    },
-                    {
-                        "discord": "ruaxxx#3151"
-                    }
-                ]
+                "url": "electrum03.cyberyen.work:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum01.cyberyen.work:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -9537,30 +7661,16 @@
         },
         "electrum": [
             {
-                "url": "electrum02.cyberyen.work:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum02.cyberyen.work:50004",
-                "contact": [
-                    {
-                        "email": "ruaxxx@ruaxxx.com"
-                    },
-                    {
-                        "discord": "ruaxxx#3151"
-                    }
-                ]
+                "url": "electrum02.cyberyen.work:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum03.cyberyen.work:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum03.cyberyen.work:50004",
-                "contact": [
-                    {
-                        "email": "ruaxxx@ruaxxx.com"
-                    },
-                    {
-                        "discord": "ruaxxx#3151"
-                    }
-                ]
+                "url": "electrum03.cyberyen.work:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum01.cyberyen.work:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -9654,24 +7764,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -9729,15 +7821,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -9970,76 +8053,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10061",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30061"
+                "url": "electrum1.cipig.net:30061",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10061",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30061"
+                "url": "electrum2.cipig.net:30061",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10061",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30061"
-            },
-            {
-                "url": "electrum1.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20061",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30061",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -10081,24 +8104,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10164,24 +8169,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -10240,24 +8227,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10366,76 +8335,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30059"
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
-            },
-            {
-                "url": "electrum1.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30059",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -10482,76 +8391,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30059"
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30059"
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10059",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30059"
-            },
-            {
-                "url": "electrum1.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20059",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30059",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -10587,15 +8436,8 @@
         "derivation_path": "m/44'/18'",
         "electrum": [
             {
-                "url": "electrumx.dgc.ewmcx.org:50001",
-                "protocol": "TCP",
-                "ws_url": "electrumx.dgc.ewmcx.org:50003"
-            },
-            {
-                "url": "failover.dgc.ewmcx.biz:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "failover.dgc.ewmcx.biz:50003"
+                "url": "failover.dgc.ewmcx.biz:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -10638,24 +8480,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -10718,15 +8542,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -10771,38 +8586,12 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.diminutivecoin.com:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "support@diminutivecoin.com"
-                    },
-                    {
-                        "twitter": "coin_dimi"
-                    },
-                    {
-                        "reddit": "DiminutiveCoin_DIMI"
-                    },
-                    {
-                        "github": "MadCatMining"
-                    },
-                    {
-                        "discord": "[MadCatMining]#0677"
-                    }
-                ],
-                "ws_url": "electrumx1.diminutivecoin.com:50013"
+                "url": "electrumx1.diminutivecoin.com:50013",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx2.diminutivecoin.com:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "support@diminutivecoin.com"
-                    }
-                ],
-                "ws_url": "electrumx2.diminutivecoin.com:50013"
+                "url": "electrumx2.diminutivecoin.com:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -10844,15 +8633,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -10908,76 +8688,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -11019,15 +8739,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11080,24 +8791,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -11202,76 +8895,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10060",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30060"
+                "url": "electrum1.cipig.net:30060",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10060",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30060"
+                "url": "electrum2.cipig.net:30060",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10060",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30060"
-            },
-            {
-                "url": "electrum1.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20060",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30060",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -11313,15 +8946,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11375,15 +8999,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11435,15 +9050,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -11493,15 +9099,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11560,136 +9157,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "DP": {
-        "coin": "DP",
-        "type": "Smart Chain",
-        "name": "DigitalPrice",
-        "coinpaprika_id": "dp-digitalprice",
-        "coingecko_id": "digitalprice",
-        "livecoinwatch_id": "DP",
-        "explorer_url": "https://dp.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "DP",
-        "fname": "DigitalPrice",
-        "rpcport": 28388,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "requires_notarization": false,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "1.eu.dp.electrum.dexstats.info:10021",
-                "contact": [
-                    {
-                        "discord": "Zanzarismo#6500"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "DOI": {
-        "coin": "DOI",
-        "type": "UTXO",
-        "name": "Doichain",
-        "coinpaprika_id": "doi-doichain",
-        "coingecko_id": "doichain",
-        "livecoinwatch_id": "DOI",
-        "explorer_url": "https://explorer.doichain.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Doichain",
-        "rpcport": 8339,
-        "pubtype": 52,
-        "p2shtype": 13,
-        "wiftype": 180,
-        "txfee": 1000,
-        "dust": 5460,
-        "segwit": true,
-        "bech32_hrp": "dc",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "pink-deer-69.doi.works:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/namecoin/electrum-nmc/issues",
-                        "twitter": "example_username"
-                    }
-                ]
-            },
-            {
-                "url": "big-parrot-60.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/doichain/electrum-doi/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "big-parrot-60.doi.works:50004"
-            },
-            {
-                "url": "itchy-jellyfish-89.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/doichain/electrum-doi/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "itchy-jellyfish-89.doi.works:50004"
-            },
-            {
-                "url": "pink-deer-69.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/namecoin/electrum-nmc/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "pink-deer-69.doi.works:50004"
-            },
-            {
-                "url": "ugly-bird-70.doi.works:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/doichain/electrum-doi/issues",
-                        "twitter": "example_username"
-                    }
-                ],
-                "ws-url": "ugly-bird-70.doi.works:50004"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "ECA": {
         "coin": "ECA",
         "type": "UTXO",
@@ -11723,76 +9190,16 @@
         "derivation_path": "m/44'/249'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10052",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30052"
+                "url": "electrum1.cipig.net:30052",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10052",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30052"
+                "url": "electrum2.cipig.net:30052",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10052",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30052"
-            },
-            {
-                "url": "electrum1.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20052",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30052",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -11829,22 +9236,16 @@
         "derivation_path": "m/44'/78'",
         "electrum": [
             {
-                "url": "electrum2.egulden.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "electrum2.egulden.org:50004"
+                "url": "electrum2.egulden.org:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.egulden.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "electrum3.egulden.org:50004"
+                "url": "electrum3.egulden.org:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "holland.ecoincore.com:11017",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "holland.ecoincore.com:11019"
+                "url": "holland.ecoincore.com:11019",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -11886,15 +9287,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -11947,24 +9339,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12026,15 +9400,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12092,24 +9457,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -12163,76 +9510,16 @@
         "derivation_path": "m/44'/41'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10062",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30062"
+                "url": "electrum1.cipig.net:30062",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10062",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30062"
+                "url": "electrum2.cipig.net:30062",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10062",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30062"
-            },
-            {
-                "url": "electrum1.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20062",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30062",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -12280,24 +9567,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12451,15 +9720,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12558,15 +9818,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -12611,24 +9862,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -12770,15 +10003,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13014,24 +10238,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13144,24 +10350,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13312,15 +10500,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -13371,24 +10550,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13451,24 +10612,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -13527,15 +10670,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13637,15 +10771,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -13696,24 +10821,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -13780,88 +10887,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "FIRO": {
-        "coin": "FIRO",
-        "type": "UTXO",
-        "name": "Firo",
-        "coinpaprika_id": "firo-firo",
-        "coingecko_id": "zcoin",
-        "livecoinwatch_id": "FIRO",
-        "explorer_url": "https://explorer.firo.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Firo Signed Message:\n",
-        "fname": "Firo",
-        "rpcport": 8888,
-        "pubtype": 82,
-        "p2shtype": 7,
-        "wiftype": 210,
-        "txfee": 1000,
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 300,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "trezor_coin": "Firo",
-        "links": {
-            "github": "https://github.com/firoorg/firo",
-            "homepage": "https://firo.org"
-        },
-        "electrum": [
-            {
-                "url": "electrumx.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx01.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx02.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx03.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx05.firo.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "github": "https://github.com/firoorg/electrumx-firo/issues"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "FIRO-BEP20": {
         "coin": "FIRO-BEP20",
         "type": "BEP-20",
@@ -13899,15 +10924,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -13960,42 +10976,8 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx1.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx1.fujicoin.org:50005"
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx2.fujicoin.org:50005"
+                "url": "electrumx1.fujicoin.org:50005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -14042,42 +11024,8 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx1.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx1.fujicoin.org:50005"
-            },
-            {
-                "url": "electrumx2.fujicoin.org:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "motty#8318"
-                    }
-                ],
-                "ws_url": "electrumx2.fujicoin.org:50005"
+                "url": "electrumx1.fujicoin.org:50005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -14119,15 +11067,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -14181,15 +11120,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14239,15 +11169,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -14300,24 +11221,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14380,15 +11283,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14439,76 +11333,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30054"
+                "url": "electrum1.cipig.net:30054",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30054"
+                "url": "electrum2.cipig.net:30054",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
-            },
-            {
-                "url": "electrum1.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30054",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -14555,76 +11389,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30054"
+                "url": "electrum1.cipig.net:30054",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30054"
+                "url": "electrum2.cipig.net:30054",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10054",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30054"
-            },
-            {
-                "url": "electrum1.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20054",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30054",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -14743,15 +11517,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14806,24 +11571,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -14886,15 +11633,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -14945,24 +11683,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15207,24 +11927,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -15285,15 +11987,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15346,15 +12039,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15365,115 +12049,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "GLEEC": {
-        "coin": "GLEEC",
-        "type": "Smart Chain",
-        "name": "Gleec",
-        "coinpaprika_id": "gleec-gleec-coin",
-        "coingecko_id": "gleec-coin",
-        "livecoinwatch_id": "GLEEC",
-        "explorer_url": "https://gleec.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "GLEEC",
-        "fname": "Gleec",
-        "rpcport": 23226,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrum1.cipig.net:10022",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30022"
-            },
-            {
-                "url": "electrum2.cipig.net:10022",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30022"
-            },
-            {
-                "url": "electrum3.cipig.net:10022",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30022"
-            },
-            {
-                "url": "electrum1.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20022",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "GLM-ERC20": {
@@ -15514,24 +12089,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15641,15 +12198,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -15700,15 +12248,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -15810,24 +12349,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -15980,63 +12501,8 @@
         "derivation_path": "m/44'/69420'",
         "electrum": [
             {
-                "url": "electrum.maxpuig.com:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "mecs#4770"
-                    }
-                ]
-            },
-            {
-                "url": "au.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "electrum.maxpuig.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ],
-                "ws_url": "electrum.maxpuig.com:50004"
-            },
-            {
-                "url": "fr.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "pl.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
-            },
-            {
-                "url": "uk.garlium.crapules.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "orpheas#1503"
-                    }
-                ]
+                "url": "electrum.maxpuig.com:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -16079,24 +12545,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -16159,15 +12607,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -16218,414 +12657,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.groestlcoin.org:50001",
-                "ws_url": "electrum1.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum12.groestlcoin.org:50001",
-                "ws_url": "electrum12.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum13.groestlcoin.org:50001",
-                "ws_url": "electrum13.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum14.groestlcoin.org:50001",
-                "ws_url": "electrum14.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum15.groestlcoin.org:50001",
-                "ws_url": "electrum15.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum16.groestlcoin.org:50001",
-                "ws_url": "electrum16.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum17.groestlcoin.org:50001",
-                "ws_url": "electrum17.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum19.groestlcoin.org:50001",
-                "ws_url": "electrum19.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.groestlcoin.org:50001",
-                "ws_url": "electrum2.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum20.groestlcoin.org:50001",
-                "ws_url": "electrum20.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum21.groestlcoin.org:50001",
-                "ws_url": "electrum21.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum22.groestlcoin.org:50001",
-                "ws_url": "electrum22.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum23.groestlcoin.org:50001",
-                "ws_url": "electrum23.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum24.groestlcoin.org:50001",
-                "ws_url": "electrum24.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum25.groestlcoin.org:50001",
-                "ws_url": "electrum25.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum26.groestlcoin.org:50001",
-                "ws_url": "electrum26.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum27.groestlcoin.org:50001",
-                "ws_url": "electrum27.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum28.groestlcoin.org:50001",
-                "ws_url": "electrum28.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum29.groestlcoin.org:50001",
-                "ws_url": "electrum29.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.groestlcoin.org:50001",
-                "ws_url": "electrum3.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum30.groestlcoin.org:50001",
-                "ws_url": "electrum30.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum33.groestlcoin.org:50001",
-                "ws_url": "electrum33.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum34.groestlcoin.org:50001",
-                "ws_url": "electrum34.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum35.groestlcoin.org:50001",
-                "ws_url": "electrum35.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum36.groestlcoin.org:50001",
-                "ws_url": "electrum36.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum37.groestlcoin.org:50001",
-                "ws_url": "electrum37.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum38.groestlcoin.org:50001",
-                "ws_url": "electrum38.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum39.groestlcoin.org:50001",
-                "ws_url": "electrum39.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum40.groestlcoin.org:50001",
-                "ws_url": "electrum40.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum5.groestlcoin.org:50001",
-                "ws_url": "electrum5.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum7.groestlcoin.org:50001",
-                "ws_url": "electrum7.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum8.groestlcoin.org:50001",
-                "ws_url": "electrum8.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum9.groestlcoin.org:50001",
-                "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum11.groestlcoin.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "ws_url": "electrum11.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
+                "url": "electrum11.groestlcoin.org:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -16672,414 +12705,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.groestlcoin.org:50001",
-                "ws_url": "electrum1.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum12.groestlcoin.org:50001",
-                "ws_url": "electrum12.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum13.groestlcoin.org:50001",
-                "ws_url": "electrum13.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum14.groestlcoin.org:50001",
-                "ws_url": "electrum14.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum15.groestlcoin.org:50001",
-                "ws_url": "electrum15.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum16.groestlcoin.org:50001",
-                "ws_url": "electrum16.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum17.groestlcoin.org:50001",
-                "ws_url": "electrum17.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum19.groestlcoin.org:50001",
-                "ws_url": "electrum19.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.groestlcoin.org:50001",
-                "ws_url": "electrum2.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum20.groestlcoin.org:50001",
-                "ws_url": "electrum20.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum21.groestlcoin.org:50001",
-                "ws_url": "electrum21.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum22.groestlcoin.org:50001",
-                "ws_url": "electrum22.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum23.groestlcoin.org:50001",
-                "ws_url": "electrum23.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum24.groestlcoin.org:50001",
-                "ws_url": "electrum24.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum25.groestlcoin.org:50001",
-                "ws_url": "electrum25.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum26.groestlcoin.org:50001",
-                "ws_url": "electrum26.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum27.groestlcoin.org:50001",
-                "ws_url": "electrum27.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum28.groestlcoin.org:50001",
-                "ws_url": "electrum28.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum29.groestlcoin.org:50001",
-                "ws_url": "electrum29.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.groestlcoin.org:50001",
-                "ws_url": "electrum3.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum30.groestlcoin.org:50001",
-                "ws_url": "electrum30.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum33.groestlcoin.org:50001",
-                "ws_url": "electrum33.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum34.groestlcoin.org:50001",
-                "ws_url": "electrum34.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum35.groestlcoin.org:50001",
-                "ws_url": "electrum35.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum36.groestlcoin.org:50001",
-                "ws_url": "electrum36.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum37.groestlcoin.org:50001",
-                "ws_url": "electrum37.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum38.groestlcoin.org:50001",
-                "ws_url": "electrum38.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum39.groestlcoin.org:50001",
-                "ws_url": "electrum39.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum40.groestlcoin.org:50001",
-                "ws_url": "electrum40.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum5.groestlcoin.org:50001",
-                "ws_url": "electrum5.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum7.groestlcoin.org:50001",
-                "ws_url": "electrum7.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum8.groestlcoin.org:50001",
-                "ws_url": "electrum8.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum9.groestlcoin.org:50001",
-                "ws_url": "electrum9.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
-            },
-            {
-                "url": "electrum11.groestlcoin.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "ws_url": "electrum11.groestlcoin.org:50004",
-                "contact": [
-                    {
-                        "email": "jackielove4u@hotmail.com"
-                    },
-                    {
-                        "discord": "jackielove4u#0412"
-                    }
-                ]
+                "url": "electrum11.groestlcoin.org:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -17172,24 +12799,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17344,15 +12953,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -17403,24 +13003,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17481,24 +13063,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17564,24 +13128,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17690,24 +13236,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -17862,24 +13390,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -17938,24 +13448,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18146,114 +13638,15 @@
         },
         "electrum": [
             {
-                "url": "il8p.electrumx.transcenders.name:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "coins@ewmci.com"
-                    },
-                    {
-                        "discord": "[CryptoStan]#9341"
-                    },
-                    {
-                        "twitter": "EwmciL"
-                    },
-                    {
-                        "reddit": "InfiniLooP"
-                    },
-                    {
-                        "github": "WikiMin3R"
-                    }
-                ],
-                "ws_url": "il8p.electrumx.transcenders.name:50003"
+                "url": "il8p.electrumx.transcenders.name:50003",
+                "protocol": "WSS"
             },
             {
-                "url": "il9p.electrumx.transcenders.name:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "coins@ewmci.com"
-                    },
-                    {
-                        "discord": "[CryptoStan]#9341"
-                    },
-                    {
-                        "twitter": "EwmciL"
-                    },
-                    {
-                        "reddit": "InfiniLooP"
-                    },
-                    {
-                        "github": "WikiMin3R"
-                    }
-                ],
-                "ws_url": "il9p.electrumx.transcenders.name:50003"
+                "url": "il9p.electrumx.transcenders.name:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
-    },
-    "ILN": {
-        "coin": "ILN",
-        "type": "Smart Chain",
-        "name": "Ilien",
-        "coinpaprika_id": "iln-ilien9195",
-        "coingecko_id": "",
-        "livecoinwatch_id": "ILN",
-        "explorer_url": "https://explorer.ilien.io/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "ILN",
-        "fname": "Ilien",
-        "rpcport": 12986,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "p2p": 12985,
-        "magic": "feb4cb23",
-        "nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrum1.ilien.io:65011",
-                "contact": [
-                    {
-                        "email": "admin@ilien.io"
-                    },
-                    {
-                        "discord": "siu - Chainmakers#3920"
-                    }
-                ],
-                "ws_url": "electrum1.ilien.io:30069"
-            },
-            {
-                "url": "electrum2.ilien.io:65011",
-                "contact": [
-                    {
-                        "email": "admin@ilien.io"
-                    },
-                    {
-                        "discord": "siu - Chainmakers#3920"
-                    }
-                ],
-                "ws_url": "electrum2.ilien.io:30069"
-            }
-        ],
-        "explorer_block_url": "block/"
     },
     "ILN-BEP20": {
         "coin": "ILN-BEP20",
@@ -18293,15 +13686,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -18452,24 +13836,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -18530,15 +13896,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18589,24 +13946,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18668,15 +14007,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18726,24 +14056,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -18805,15 +14117,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -18863,15 +14166,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -18973,15 +14267,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19081,15 +14366,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -19288,15 +14564,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19347,24 +14614,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19571,15 +14820,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19630,24 +14870,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -19760,15 +14982,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -19819,24 +15032,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -20386,24 +15581,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -20708,15 +15885,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -20809,76 +15977,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10001",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30001"
+                "url": "electrum1.cipig.net:30001",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10001",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30001"
+                "url": "electrum2.cipig.net:30001",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10001",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30001"
-            },
-            {
-                "url": "electrum1.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30001",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/",
@@ -20922,15 +16030,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -20982,15 +16081,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -21047,24 +16137,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21212,76 +16284,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10024",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30024"
+                "url": "electrum1.cipig.net:30024",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10024",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30024"
+                "url": "electrum2.cipig.net:30024",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10024",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30024"
-            },
-            {
-                "url": "electrum1.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20024",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30024",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -21324,15 +16336,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -21378,76 +16381,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30019"
+                "url": "electrum3.cipig.net:30019",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30019"
+                "url": "electrum2.cipig.net:30019",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10019",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30019"
-            },
-            {
-                "url": "electrum1.cipig.net:20019",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20019",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20019",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30019",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -21485,31 +16428,16 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
+                "url": "electrum1.cipig.net:30067",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
+                "url": "electrum2.cipig.net:30067",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
-            },
-            {
-                "url": "electrum1.cipig.net:20067",
-                "disable_cert_verification": false,
-                "protocol": "SSL"
-            },
-            {
-                "url": "electrum2.cipig.net:20067",
-                "disable_cert_verification": false,
-                "protocol": "SSL"
-            },
-            {
-                "url": "electrum3.cipig.net:20067",
-                "disable_cert_verification": false,
-                "protocol": "SSL"
+                "url": "electrum3.cipig.net:30067",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -21551,130 +16479,19 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10067",
-                "ws_url": "electrum1.cipig.net:30067"
+                "url": "electrum1.cipig.net:30067",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10067",
-                "ws_url": "electrum2.cipig.net:30067"
+                "url": "electrum2.cipig.net:30067",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10067",
-                "ws_url": "electrum3.cipig.net:30067"
-            },
-            {
-                "url": "electrum1.cipig.net:20067",
-                "disable_cert_verification": false,
-                "protocol": "SSL"
-            },
-            {
-                "url": "electrum2.cipig.net:20067",
-                "disable_cert_verification": false,
-                "protocol": "SSL"
-            },
-            {
-                "url": "electrum3.cipig.net:20067",
-                "disable_cert_verification": false,
-                "protocol": "SSL"
+                "url": "electrum3.cipig.net:30067",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
-    },
-    "LCC": {
-        "coin": "LCC",
-        "type": "UTXO",
-        "name": "Litecoin Cash",
-        "coinpaprika_id": "lcc-litecoin-cash",
-        "coingecko_id": "litecoin-cash",
-        "livecoinwatch_id": "LCC",
-        "explorer_url": "https://chainz.cryptoid.info/lcc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Litecoin Signed Message:\n",
-        "fname": "Litecoin Cash",
-        "rpcport": 62457,
-        "pubtype": 28,
-        "p2shtype": 50,
-        "wiftype": 176,
-        "decimals": 7,
-        "fork_id": "0x40",
-        "signature_version": "base",
-        "txfee": 20000,
-        "segwit": true,
-        "bech32_hrp": "lcc",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "electrum": [
-            {
-                "url": "188.166.117.139:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "88.99.26.209:5140",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "LCC-segwit": {
-        "coin": "LCC-segwit",
-        "type": "UTXO",
-        "name": "Litecoin Cash",
-        "coinpaprika_id": "lcc-litecoin-cash",
-        "coingecko_id": "litecoin-cash",
-        "livecoinwatch_id": "LCC",
-        "explorer_url": "https://chainz.cryptoid.info/lcc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Litecoin Signed Message:\n",
-        "fname": "Litecoin Cash",
-        "rpcport": 62457,
-        "pubtype": 28,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "decimals": 7,
-        "fork_id": "0x40",
-        "signature_version": "base",
-        "txfee": 20000,
-        "segwit": true,
-        "bech32_hrp": "lcc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "LCC",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "electrum": [
-            {
-                "url": "188.166.117.139:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "88.99.26.209:5140",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "LDO-ERC20": {
         "coin": "LDO-ERC20",
@@ -21714,24 +16531,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -21846,24 +16645,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -21971,24 +16752,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22091,15 +16854,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -22335,15 +17089,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -22399,24 +17144,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -22479,15 +17206,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -22548,94 +17266,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "WCN": {
-        "coin": "WCN",
-        "type": "UTXO",
-        "name": "Widecoin",
-        "coinpaprika_id": "wcn-widecoin",
-        "coingecko_id": "widecoin",
-        "livecoinwatch_id": "WCN",
-        "explorer_url": "https://explorer.widecoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Widecoin",
-        "rpcport": 8552,
-        "pubtype": 73,
-        "p2shtype": 33,
-        "wiftype": 153,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "wc",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/613'",
-        "electrum": [
-            {
-                "url": "electrumx.widecoin.org:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx2.widecoin.org:50001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "WCN-segwit": {
-        "coin": "WCN-segwit",
-        "type": "UTXO",
-        "name": "Widecoin",
-        "coinpaprika_id": "wcn-widecoin",
-        "coingecko_id": "widecoin",
-        "livecoinwatch_id": "WCN",
-        "explorer_url": "https://explorer.widecoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Widecoin",
-        "rpcport": 8552,
-        "pubtype": 73,
-        "p2shtype": 33,
-        "wiftype": 153,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "wc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "WCN",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/613'",
-        "electrum": [
-            {
-                "url": "electrumx.widecoin.org:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx2.widecoin.org:50001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "LEASH-ERC20": {
         "coin": "LEASH-ERC20",
         "type": "ERC-20",
@@ -22673,24 +17303,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -22758,24 +17370,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -22836,15 +17430,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -22895,15 +17480,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -22957,76 +17533,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30063"
+                "url": "electrum1.cipig.net:30063",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30063"
+                "url": "electrum2.cipig.net:30063",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
-            },
-            {
-                "url": "electrum1.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30063",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -23074,76 +17590,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30063"
+                "url": "electrum1.cipig.net:30063",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30063"
+                "url": "electrum2.cipig.net:30063",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10063",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30063"
-            },
-            {
-                "url": "electrum1.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20063",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30063",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -23181,29 +17637,16 @@
         "derivation_path": "m/44'/191'",
         "electrum": [
             {
-                "url": "electrum5.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum5.getlynx.io:50004"
+                "url": "electrum5.getlynx.io:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum6.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum6.getlynx.io:50004"
+                "url": "electrum6.getlynx.io:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum7.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum7.getlynx.io:50004"
-            },
-            {
-                "url": "electrum8.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum8.getlynx.io:50004"
-            },
-            {
-                "url": "electrum9.getlynx.io:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum9.getlynx.io:50004"
+                "url": "electrum7.getlynx.io:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -23251,24 +17694,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23329,15 +17754,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -23484,15 +17900,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23543,24 +17950,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23753,15 +18142,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -23816,24 +18196,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -23984,24 +18346,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24062,15 +18406,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -24115,76 +18450,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10023",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30023"
+                "url": "electrum1.cipig.net:30023",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10023",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30023"
+                "url": "electrum2.cipig.net:30023",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10023",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30023"
-            },
-            {
-                "url": "electrum1.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20023",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30023",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -24231,24 +18506,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24303,76 +18560,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum1.cipig.net:30069",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum2.cipig.net:30069",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10069",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.cipig.net:20069",
-                "ws_url": "electrum1.cipig.net:30069",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20069",
-                "ws_url": "electrum2.cipig.net:30069",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20069",
-                "ws_url": "electrum3.cipig.net:30069",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30069",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -24415,24 +18612,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24493,15 +18672,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -24600,15 +18770,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -24664,24 +18825,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -24791,24 +18934,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -24914,15 +19039,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25023,110 +19139,6 @@
             },
             {
                 "url": "https://poly-rpc.gateway.pokt.network"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "MONA": {
-        "coin": "MONA",
-        "type": "UTXO",
-        "name": "MonaCoin",
-        "coinpaprika_id": "mona-monacoin",
-        "coingecko_id": "monacoin",
-        "livecoinwatch_id": "MONA",
-        "explorer_url": "https://blockbook.electrum-mona.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Monacoin Signed Message:\n",
-        "fname": "MonaCoin",
-        "rpcport": 9402,
-        "pubtype": 50,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 100000,
-        "segwit": true,
-        "bech32_hrp": "mona",
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 90,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/22'",
-        "trezor_coin": "Monacoin",
-        "links": {
-            "github": "https://github.com/monacoinproject/monacoin",
-            "homepage": "https://monacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "133.167.67.203:50001"
-            },
-            {
-                "url": "electrumx.tamami-foundation.org:50001"
-            },
-            {
-                "url": "electrumx1.monacoin.ninja:50001"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "MONA-segwit": {
-        "coin": "MONA-segwit",
-        "type": "UTXO",
-        "name": "MonaCoin",
-        "coinpaprika_id": "mona-monacoin",
-        "coingecko_id": "monacoin",
-        "livecoinwatch_id": "MONA",
-        "explorer_url": "https://blockbook.electrum-mona.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Monacoin Signed Message:\n",
-        "fname": "MonaCoin",
-        "rpcport": 9402,
-        "pubtype": 50,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 100000,
-        "dust": 100000,
-        "segwit": true,
-        "bech32_hrp": "mona",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "MONA",
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 90,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/22'",
-        "trezor_coin": "Monacoin",
-        "links": {
-            "github": "https://github.com/monacoinproject/monacoin",
-            "homepage": "https://monacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "133.167.67.203:50001"
-            },
-            {
-                "url": "electrumx.tamami-foundation.org:50001"
-            },
-            {
-                "url": "electrumx1.monacoin.ninja:50001"
             }
         ],
         "explorer_block_url": "block/"
@@ -25244,14 +19256,12 @@
         "derivation_path": "m/44'/130'",
         "electrum": [
             {
-                "url": "electrum2.nav.community:40002",
-                "protocol": "SSL",
-                "ws_url": "electrum2.nav.community:40004"
+                "url": "electrum2.nav.community:40004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.nav.community:40002",
-                "protocol": "SSL",
-                "ws_url": "electrum3.nav.community:40004"
+                "url": "electrum3.nav.community:40004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -25294,15 +19304,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -25356,15 +19357,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -25375,71 +19367,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "NENG": {
-        "coin": "NENG",
-        "type": "UTXO",
-        "name": "Nengcoin",
-        "coinpaprika_id": "neng-nengcoin",
-        "coingecko_id": "",
-        "livecoinwatch_id": "NENG",
-        "explorer_url": "http://nengexplorer.mooo.com:3001/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Nengcoin",
-        "rpcport": 6376,
-        "pubtype": 53,
-        "p2shtype": 5,
-        "wiftype": 176,
-        "txfee": 200000,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/681'",
-        "electrum": [
-            {
-                "url": "electrum.shorelinecrypto.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.mooo.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.mooo.com:10001",
-                "contact": [
-                    {
-                        "email": "support@shorelinecrypto.com"
-                    },
-                    {
-                        "discord": "honglu69#5911"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "NEXO-ERC20": {
@@ -25484,24 +19411,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -25616,288 +19525,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "NINJA": {
-        "coin": "NINJA",
-        "type": "Smart Chain",
-        "name": "Ninja",
-        "coinpaprika_id": "",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://ninja.komodo.earth/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "NINJA",
-        "fname": "Ninja",
-        "rpcport": 8427,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrum1.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:10036",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.cipig.net:20036",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20036",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20036",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "NMC": {
-        "coin": "NMC",
-        "type": "UTXO",
-        "name": "Namecoin",
-        "coinpaprika_id": "nmc-namecoin",
-        "coingecko_id": "namecoin",
-        "livecoinwatch_id": "NMC",
-        "explorer_url": "https://nmc.tokenview.com/en/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Namecoin",
-        "rpcport": 8336,
-        "pubtype": 52,
-        "p2shtype": 13,
-        "wiftype": 180,
-        "txfee": 0,
-        "segwit": true,
-        "bech32_hrp": "nc",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/7'",
-        "trezor_coin": "Namecoin",
-        "links": {
-            "github": "https://github.com/namecoin/namecoin-core",
-            "homepage": "https://namecoin.org"
-        },
-        "electrum": [
-            {
-                "url": "46.229.238.187:57001"
-            },
-            {
-                "url": "nmc2.bitcoins.sk:57002",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "NMC-segwit": {
-        "coin": "NMC-segwit",
-        "type": "UTXO",
-        "name": "Namecoin",
-        "coinpaprika_id": "nmc-namecoin",
-        "coingecko_id": "namecoin",
-        "livecoinwatch_id": "NMC",
-        "explorer_url": "https://nmc.tokenview.com/en/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Namecoin",
-        "rpcport": 8336,
-        "pubtype": 52,
-        "p2shtype": 13,
-        "wiftype": 180,
-        "txfee": 0,
-        "segwit": true,
-        "bech32_hrp": "nc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "NMC",
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/7'",
-        "trezor_coin": "Namecoin",
-        "links": {
-            "github": "https://github.com/namecoin/namecoin-core",
-            "homepage": "https://namecoin.org"
-        },
-        "electrum": [
-            {
-                "url": "46.229.238.187:57001"
-            },
-            {
-                "url": "nmc2.bitcoins.sk:57002",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "NVC": {
-        "coin": "NVC",
-        "type": "UTXO",
-        "name": "Novacoin",
-        "coinpaprika_id": "nvc-novacoin",
-        "coingecko_id": "novacoin",
-        "livecoinwatch_id": "NVC",
-        "explorer_url": "https://explorer.novaco.in/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": true,
-        "sign_message_prefix": "Novacoin Signed Message:\n",
-        "fname": "Novacoin",
-        "isPoS": 1,
-        "rpcport": 8344,
-        "pubtype": 8,
-        "p2shtype": 20,
-        "wiftype": 136,
-        "decimals": 6,
-        "txfee": 1000,
-        "dust": 10000,
-        "mm2": 1,
-        "mature_confirmations": 500,
-        "required_confirmations": 1,
-        "avg_blocktime": 450,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/50'",
-        "electrum": [
-            {
-                "url": "electrumx.nvc.ewmcx.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "coins@ewmci.com"
-                    },
-                    {
-                        "discord": "[CryptoStan]#9341"
-                    },
-                    {
-                        "twitter": "EwmciL"
-                    },
-                    {
-                        "reddit": "NovacoinCommunity"
-                    },
-                    {
-                        "github": "novacoin-project"
-                    }
-                ]
-            },
-            {
-                "url": "failover.nvc.ewmcx.biz:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "coins@ewmci.com"
-                    },
-                    {
-                        "discord": "[CryptoStan]#9341"
-                    },
-                    {
-                        "twitter": "EwmciL"
-                    },
-                    {
-                        "reddit": "NovacoinCommunity"
-                    },
-                    {
-                        "github": "novacoin-project"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "NVC-BEP20": {
         "coin": "NVC-BEP20",
         "type": "BEP-20",
@@ -25935,15 +19562,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -25999,76 +19617,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -26111,24 +19669,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26240,15 +19780,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26303,24 +19834,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26434,24 +19947,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26602,15 +20097,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26665,24 +20151,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -26742,15 +20210,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -26896,15 +20355,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -26960,24 +20410,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27048,139 +20480,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "PINK": {
-        "coin": "PINK",
-        "type": "UTXO",
-        "name": "Pinkcoin",
-        "coinpaprika_id": "pink-pinkcoin",
-        "coingecko_id": "pinkcoin",
-        "livecoinwatch_id": "PINK",
-        "explorer_url": "https://chainz.cryptoid.info/pink/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": true,
-        "sign_message_prefix": "Pinkcoin Signed Message:\n",
-        "fname": "Pinkcoin",
-        "rpcport": 9135,
-        "isPoS": 1,
-        "pubtype": 3,
-        "p2shtype": 28,
-        "wiftype": 131,
-        "txfee": 10000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/117'",
-        "links": {
-            "github": "https://github.com/Pink2Dev/Pink2",
-            "homepage": "https://getstarted.with.pink"
-        },
-        "electrum": [
-            {
-                "url": "pink-one.ewm-cx.net:50001",
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "PIVX": {
-        "coin": "PIVX",
-        "type": "UTXO",
-        "name": "PIVX",
-        "coinpaprika_id": "pivx-pivx",
-        "coingecko_id": "pivx",
-        "livecoinwatch_id": "PIVX",
-        "explorer_url": "https://chainz.cryptoid.info/pivx/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "PIVX",
-        "rpcport": 51473,
-        "pubtype": 30,
-        "p2shtype": 13,
-        "wiftype": 212,
-        "txfee": 100000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/119'",
-        "electrum": [
-            {
-                "url": "electrum01.chainster.org:50001",
-                "ws_url": "electrum01.chainster.org:50003",
-                "contact": [
-                    {
-                        "discord": "312541186793406465"
-                    }
-                ]
-            },
-            {
-                "url": "electrum02.chainster.org:50001",
-                "ws_url": "electrum02.chainster.org:50003",
-                "contact": [
-                    {
-                        "discord": "312541186793406465"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "PND": {
-        "coin": "PND",
-        "type": "UTXO",
-        "name": "Pandacoin",
-        "coinpaprika_id": "pnd-pandacoin",
-        "coingecko_id": "pandacoin",
-        "livecoinwatch_id": "PND",
-        "explorer_url": "https://chainz.cryptoid.info/pnd/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Pandacoin",
-        "isPoS": 1,
-        "rpcport": 22444,
-        "pubtype": 55,
-        "p2shtype": 22,
-        "wiftype": 183,
-        "decimals": 6,
-        "txfee": 10000000,
-        "dust": 1000000,
-        "segwit": true,
-        "bech32_hrp": "pn",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/37'",
-        "electrum": [
-            {
-                "url": "electrum.thepandacoin.net:50001",
-                "ws_url": "electrum.thepandacoin.net:443"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
     "POT": {
         "coin": "POT",
         "type": "UTXO",
@@ -27216,14 +20515,8 @@
         "derivation_path": "m/44'/81'",
         "electrum": [
             {
-                "url": "62.171.189.243:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "pot-duo.ewmcx.net:50012",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "ws_url": "pot-duo.ewmcx.net:50013"
+                "url": "pot-duo.ewmcx.net:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -27266,24 +20559,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27398,24 +20673,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -27524,16 +20781,12 @@
         },
         "electrum": [
             {
-                "url": "allingas.peercoinexplorer.net:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "ws_url": "allingas.peercoinexplorer.net:50004"
+                "url": "allingas.peercoinexplorer.net:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum.peercoinexplorer.net:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "ws_url": "electrum.peercoinexplorer.net:50004"
+                "url": "electrum.peercoinexplorer.net:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -27576,24 +20829,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27703,15 +20938,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -27762,24 +20988,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -27881,42 +21089,8 @@
         },
         "electrum": [
             {
-                "url": "electrumx.live:50010",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
-                "url": "txserver.live:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx.live:50012",
-                "protocol": "SSL",
-                "ws_url": "electrumx.live:30010",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
-            },
-            {
-                "url": "txserver.live:50002",
-                "protocol": "SSL",
-                "ws_url": "txserver.live:30001",
-                "contact": [
-                    {
-                        "discord": "PRUX-Coin#1668"
-                    }
-                ]
+                "url": "electrumx.live:30010",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -27958,15 +21132,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28022,24 +21187,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28147,76 +21294,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -28262,76 +21349,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -28377,76 +21404,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -28488,15 +21455,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -28552,24 +21510,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28635,24 +21575,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -28757,76 +21679,16 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30071"
+                "url": "electrum1.cipig.net:30071",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30071"
+                "url": "electrum2.cipig.net:30071",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30071",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -28874,76 +21736,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -28993,76 +21795,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -29109,24 +21851,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29183,76 +21907,16 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30071"
+                "url": "electrum1.cipig.net:30071",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30071"
+                "url": "electrum2.cipig.net:30071",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30071",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -29293,76 +21957,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30071"
+                "url": "electrum1.cipig.net:30071",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30071"
+                "url": "electrum2.cipig.net:30071",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10071",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30071"
-            },
-            {
-                "url": "electrum1.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20071",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30071",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -29407,14 +22011,12 @@
         },
         "electrum": [
             {
-                "url": "electrum02.reddcoin.com:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum02.reddcoin.com:50004"
+                "url": "electrum02.reddcoin.com:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum03.reddcoin.com:50002",
-                "protocol": "SSL",
-                "ws_url": "electrum03.reddcoin.com:50004"
+                "url": "electrum03.reddcoin.com:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -29462,24 +22064,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29589,24 +22173,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -29665,24 +22231,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -29785,76 +22333,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum1.cipig.net:30020",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum2.cipig.net:30020",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10020",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.cipig.net:20020",
-                "ws_url": "electrum1.cipig.net:30020",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20020",
-                "ws_url": "electrum2.cipig.net:30020",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20020",
-                "ws_url": "electrum3.cipig.net:30020",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30020",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -29891,76 +22379,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum1.cipig.net:30021",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum2.cipig.net:30021",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10021",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.cipig.net:20021",
-                "ws_url": "electrum1.cipig.net:30021",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20021",
-                "ws_url": "electrum2.cipig.net:30021",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20021",
-                "ws_url": "electrum3.cipig.net:30021",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30021",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -30007,24 +22435,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30135,24 +22545,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30261,24 +22653,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30344,24 +22718,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -30378,47 +22734,6 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "RTM": {
-        "coin": "RTM",
-        "type": "UTXO",
-        "name": "Raptoreum",
-        "coinpaprika_id": "rtm-raptoreum",
-        "coingecko_id": "raptoreum",
-        "livecoinwatch_id": "RTM",
-        "explorer_url": "https://explorer.raptoreum.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Raptoreum",
-        "rpcport": 9998,
-        "pubtype": 60,
-        "p2shtype": 16,
-        "wiftype": 128,
-        "txfee": 1000,
-        "mm2": 1,
-        "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
-        "required_confirmations": 3,
-        "avg_blocktime": 120,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/10226'",
-        "electrum": [
-            {
-                "url": "x1.raptoreum.com:50001",
-                "ws_url": "x1.raptoreum.com:50004"
-            },
-            {
-                "url": "x2.raptoreum.com:50001",
-                "ws_url": "x2.raptoreum.com:50004"
             }
         ],
         "explorer_block_url": "block/"
@@ -30461,15 +22776,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30521,76 +22827,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10051",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30051"
+                "url": "electrum1.cipig.net:30051",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10051",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30051"
+                "url": "electrum2.cipig.net:30051",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10051",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30051"
-            },
-            {
-                "url": "electrum1.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20051",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30051",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -30633,24 +22879,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -30711,15 +22939,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30822,15 +23041,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -30881,15 +23091,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -30988,15 +23189,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31052,24 +23244,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31269,15 +23443,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31377,24 +23542,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -31447,76 +23594,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10011",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30011"
+                "url": "electrum1.cipig.net:30011",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10011",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30011"
+                "url": "electrum2.cipig.net:30011",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10011",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30011"
-            },
-            {
-                "url": "electrum1.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20011",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30011",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -31559,24 +23646,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -31679,76 +23748,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10005",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30005"
+                "url": "electrum1.cipig.net:30005",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10005",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30005"
+                "url": "electrum2.cipig.net:30005",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10005",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30005"
-            },
-            {
-                "url": "electrum1.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20005",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -31837,15 +23846,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -31901,24 +23901,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32161,15 +24143,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -32219,15 +24192,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -32280,24 +24244,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32402,76 +24348,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30064"
+                "url": "electrum1.cipig.net:30064",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30064"
+                "url": "electrum2.cipig.net:30064",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
-            },
-            {
-                "url": "electrum1.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30064",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32519,76 +24405,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30064"
+                "url": "electrum1.cipig.net:30064",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30064"
+                "url": "electrum2.cipig.net:30064",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10064",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30064"
-            },
-            {
-                "url": "electrum1.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20064",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30064",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32631,24 +24457,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -32702,80 +24510,12 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30068"
+                "url": "electrum1.cipig.net:30068",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
-            },
-            {
-                "url": "electrum3.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
-            },
-            {
-                "url": "testnet.aranguren.org:51001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrum1.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum2.cipig.net:30068",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -32815,80 +24555,12 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30068"
+                "url": "electrum1.cipig.net:30068",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30068"
-            },
-            {
-                "url": "electrum3.cipig.net:10068",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30068"
-            },
-            {
-                "url": "testnet.aranguren.org:51001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrum1.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20068",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum2.cipig.net:30068",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -32931,24 +24603,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -33103,15 +24757,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -33122,56 +24767,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "THC": {
-        "coin": "THC",
-        "type": "Smart Chain",
-        "name": "HempCoin",
-        "coinpaprika_id": "thc-hempcoin",
-        "coingecko_id": "hempcoin-thc",
-        "livecoinwatch_id": "THC",
-        "explorer_url": "https://thc.explorer.dexstats.info/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "THC",
-        "fname": "HempCoin",
-        "rpcport": 36790,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "requires_notarization": true,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "1.eu.thc.electrum.dexstats.info:10020",
-                "contact": [
-                    {
-                        "discord": "CHMEX#0686"
-                    }
-                ]
-            },
-            {
-                "url": "2.eu.thc.electrum.dexstats.info:10020",
-                "contact": [
-                    {
-                        "discord": "CHMEX#0686"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "THC-BEP20": {
@@ -33212,15 +24807,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33267,28 +24853,12 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "1.eu.tokel.electrum.dexstats.info:10077",
-                "contact": [
-                    {
-                        "email": "chmex@dexstats.info"
-                    },
-                    {
-                        "discord": "chmex#0686"
-                    }
-                ],
-                "ws_url": "1.eu.tokel.electrum.dexstats.info:9077"
+                "url": "1.eu.tokel.electrum.dexstats.info:9077",
+                "protocol": "WSS"
             },
             {
-                "url": "1.eu.tokel.electrum.dexstats.info:11077",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "chmex@dexstats.info"
-                    },
-                    {
-                        "discord": "chmex#0686"
-                    }
-                ]
+                "url": "2.eu.tokel.electrum.dexstats.info:9077",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -33331,24 +24901,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -33411,15 +24963,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -33464,10 +25007,8 @@
         "derivation_path": "m/44'/83'",
         "electrum": [
             {
-                "url": "failover.trc-uis.ewmcx.biz:50006",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "failover.trc-uis.ewmcx.biz:50007"
+                "url": "failover.trc-uis.ewmcx.biz:50007",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -33509,15 +25050,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33570,15 +25102,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33676,15 +25199,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33788,24 +25302,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -33866,15 +25362,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -33925,15 +25412,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -33990,24 +25468,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -34296,15 +25756,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -34359,24 +25810,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -34477,10 +25910,8 @@
         },
         "electrum": [
             {
-                "url": "failover.trc-uis.ewmcx.biz:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": false,
-                "ws_url": "failover.trc-uis.ewmcx.biz:50003"
+                "url": "failover.trc-uis.ewmcx.biz:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -34568,24 +25999,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -34745,24 +26158,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -34820,15 +26215,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -35015,16 +26401,12 @@
         },
         "electrum": [
             {
-                "url": "uno-bkp.coinmunity.gold:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "uno-bkp.coinmunity.gold:50003"
+                "url": "uno-bkp.coinmunity.gold:50003",
+                "protocol": "WSS"
             },
             {
-                "url": "uno-main.coinmunity.gold:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "uno-main.coinmunity.gold:50003"
+                "url": "uno-main.coinmunity.gold:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -35163,24 +26545,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -35238,15 +26602,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -35525,15 +26880,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -35584,24 +26930,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36022,15 +27350,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -36084,24 +27403,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36163,24 +27464,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -36234,42 +27517,12 @@
         },
         "electrum": [
             {
-                "url": "e2.validitytech.com:11001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
+                "url": "e2.validitytech.com:11004",
+                "protocol": "WSS"
             },
             {
-                "url": "e3.validitytech.com:11001",
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ]
-            },
-            {
-                "url": "e2.validitytech.com:11002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "e2.validitytech.com:11004"
-            },
-            {
-                "url": "e3.validitytech.com:11002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "discord": "michelvankessel#7656"
-                    }
-                ],
-                "ws_url": "e3.validitytech.com:11004"
+                "url": "e3.validitytech.com:11004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -36312,15 +27565,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -36371,24 +27615,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36449,24 +27675,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -36537,100 +27745,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "VIA": {
-        "coin": "VIA",
-        "type": "UTXO",
-        "name": "Viacoin",
-        "coinpaprika_id": "via-viacoin",
-        "coingecko_id": "viacoin",
-        "livecoinwatch_id": "VIA",
-        "explorer_url": "https://explorer.viacoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Viacoin Signed Message:\n",
-        "fname": "Viacoin",
-        "rpcport": 5222,
-        "pubtype": 71,
-        "p2shtype": 33,
-        "wiftype": 199,
-        "txfee": 100000,
-        "dust": 54600,
-        "required_confirmations": 7,
-        "mature_confirmations": 3600,
-        "avg_blocktime": 24,
-        "segwit": true,
-        "bech32_hrp": "via",
-        "mm2": 1,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/14'",
-        "trezor_coin": "Viacoin",
-        "links": {
-            "github": "https://github.com/viacoin",
-            "homepage": "https://viacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5102"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "VIA-segwit": {
-        "coin": "VIA-segwit",
-        "type": "UTXO",
-        "name": "Viacoin",
-        "coinpaprika_id": "via-viacoin",
-        "coingecko_id": "viacoin",
-        "livecoinwatch_id": "VIA",
-        "explorer_url": "https://explorer.viacoin.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Viacoin Signed Message:\n",
-        "fname": "Viacoin",
-        "rpcport": 5222,
-        "pubtype": 71,
-        "p2shtype": 33,
-        "wiftype": 199,
-        "txfee": 100000,
-        "dust": 54600,
-        "required_confirmations": 7,
-        "mature_confirmations": 3600,
-        "avg_blocktime": 24,
-        "segwit": true,
-        "bech32_hrp": "via",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "VIA",
-        "mm2": 1,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/14'",
-        "trezor_coin": "Viacoin",
-        "links": {
-            "github": "https://github.com/viacoin",
-            "homepage": "https://viacoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5102"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "VITE-BEP20": {
         "coin": "VITE-BEP20",
         "type": "BEP-20",
@@ -36670,15 +27784,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -36689,53 +27794,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "VRM": {
-        "coin": "VRM",
-        "type": "UTXO",
-        "name": "Verium Reserve",
-        "coinpaprika_id": "vrm-veriumreserve",
-        "coingecko_id": "",
-        "livecoinwatch_id": "VRM",
-        "explorer_url": "https://explorer-vrm.vericonomy.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Verium Reserve",
-        "rpcport": 33987,
-        "pubtype": 70,
-        "p2shtype": 132,
-        "wiftype": 198,
-        "txfee": 100000,
-        "force_min_relay_fee": true,
-        "isPoS": 1,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 240,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrum01-vrm.vericonomy.com:50001",
-                "contact": [
-                    {
-                        "email": "dev@vericoin.info"
-                    },
-                    {
-                        "twitter": "vericonomy"
-                    },
-                    {
-                        "github": "VeriConomy"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "VRSC": {
@@ -36769,255 +27827,19 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "el0.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
+                "url": "el0.verus.io:17488",
+                "protocol": "WSS"
             },
             {
-                "url": "el1.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
+                "url": "el1.verus.io:17488",
+                "protocol": "WSS"
             },
             {
-                "url": "el2.verus.io:17485",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ]
-            },
-            {
-                "url": "el0.verus.io:17486",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ],
-                "disable_cert_verification": false,
-                "ws_url": "el0.verus.io:17488"
-            },
-            {
-                "url": "el1.verus.io:17486",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ],
-                "disable_cert_verification": false,
-                "ws_url": "el1.verus.io:17488"
-            },
-            {
-                "url": "el2.verus.io:17486",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "0x03-ctrlc@protonmail.com"
-                    },
-                    {
-                        "discord": "0x03#8822"
-                    },
-                    {
-                        "keybase": "bloodynora"
-                    }
-                ],
-                "disable_cert_verification": false,
-                "ws_url": "el2.verus.io:17488"
+                "url": "el2.verus.io:17488",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
-    },
-    "VPRM": {
-        "coin": "VPRM",
-        "type": "Smart Chain",
-        "name": "Vaporum",
-        "coinpaprika_id": "vprm-vaporum-coin",
-        "coingecko_id": "vaporum-coin",
-        "livecoinwatch_id": "VPRM",
-        "explorer_url": "http://explorer.vaporumcoin.us/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "VPRM",
-        "fname": "Vaporum",
-        "rpcport": 51609,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx2.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "VTC": {
-        "coin": "VTC",
-        "type": "UTXO",
-        "name": "Vertcoin",
-        "coinpaprika_id": "vtc-vertcoin",
-        "coingecko_id": "vertcoin",
-        "livecoinwatch_id": "VTC",
-        "explorer_url": "https://chainz.cryptoid.info/vtc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Vertcoin Signed Message:\n",
-        "fname": "Vertcoin",
-        "rpcport": 5888,
-        "pubtype": 71,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "vtc",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/28'",
-        "trezor_coin": "Vertcoin",
-        "links": {
-            "github": "https://github.com/vertcoin-project/vertcoin-core",
-            "homepage": "https://vertcoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5028"
-            },
-            {
-                "url": "electrumx-brn.webhop.me:55001"
-            },
-            {
-                "url": "electrumx.javerity.com:5885",
-                "ws_url": "electrumx.javerity.com:5887",
-                "contact": [
-                    {
-                        "discord": "cruelnovo#4936"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
-    },
-    "VTC-segwit": {
-        "coin": "VTC-segwit",
-        "type": "UTXO",
-        "name": "Vertcoin",
-        "coinpaprika_id": "vtc-vertcoin",
-        "coingecko_id": "vertcoin",
-        "livecoinwatch_id": "VTC",
-        "explorer_url": "https://chainz.cryptoid.info/vtc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Vertcoin Signed Message:\n",
-        "fname": "Vertcoin",
-        "rpcport": 5888,
-        "pubtype": 71,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 100000,
-        "segwit": true,
-        "bech32_hrp": "vtc",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "VTC",
-        "mm2": 1,
-        "required_confirmations": 4,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/28'",
-        "trezor_coin": "Vertcoin",
-        "links": {
-            "github": "https://github.com/vertcoin-project/vertcoin-core",
-            "homepage": "https://vertcoin.org"
-        },
-        "electrum": [
-            {
-                "url": "88.99.26.209:5028"
-            },
-            {
-                "url": "electrumx-brn.webhop.me:55001"
-            },
-            {
-                "url": "electrumx.javerity.com:5885",
-                "ws_url": "electrumx.javerity.com:5887",
-                "contact": [
-                    {
-                        "discord": "cruelnovo#4936"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "WAVES-BEP20": {
         "coin": "WAVES-BEP20",
@@ -37057,15 +27879,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -37123,24 +27936,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -37251,24 +28046,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -37327,24 +28104,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -37450,15 +28209,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -37606,24 +28356,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -37684,15 +28416,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -37703,73 +28426,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "XEP-segwit": {
-        "coin": "XEP-segwit",
-        "type": "UTXO",
-        "name": "Electra Protocol",
-        "coinpaprika_id": "",
-        "coingecko_id": "",
-        "livecoinwatch_id": "XEP",
-        "explorer_url": "https://electraprotocol.network/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Electra Protocol",
-        "rpcport": 16816,
-        "pubtype": 55,
-        "p2shtype": 137,
-        "wiftype": 162,
-        "txversion": 2,
-        "txfee": 100000,
-        "mm2": 1,
-        "segwit": true,
-        "signature_version": "witness_v0",
-        "bech32_hrp": "ep",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "XEP",
-        "required_confirmations": 4,
-        "avg_blocktime": 80,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/597'",
-        "electrum": [
-            {
-                "url": "electrumx1.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx1.electraprotocol.eu:50003"
-            },
-            {
-                "url": "electrumx2.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx2.electraprotocol.eu:50003"
-            },
-            {
-                "url": "electrumx3.electraprotocol.eu:50001",
-                "contact": [
-                    {
-                        "discord": "287952234317348865"
-                    }
-                ],
-                "ws_url": "electrumx3.electraprotocol.eu:50003"
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "XEP-BEP20": {
@@ -37810,15 +28466,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -37871,24 +28518,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -37999,15 +28628,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -38052,13 +28672,8 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
-            },
-            {
-                "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "url": "lenoir.ecoincore.com:10894",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38099,13 +28714,8 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
-                "url": "lenoir.ecoincore.com:10891",
-                "protocol": "TCP",
-                "ws_url": "lenoir.ecoincore.com:10894"
-            },
-            {
-                "url": "lenoir.ecoincore.com:10892",
-                "protocol": "SSL"
+                "url": "lenoir.ecoincore.com:10894",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -38146,140 +28756,16 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.neurai.top:50001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "alarm@neurai.org"
-                    },
-                    {
-                        "discord": "456566604809895947"
-                    }
-                ],
-                "ws_url": "electrumx1.neurai.top:50002"
+                "url": "electrumx1.neurai.top:50002",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx2.neurai.top:50001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "alarm@neurai.org"
-                    },
-                    {
-                        "discord": "456566604809895947"
-                    }
-                ],
-                "ws_url": "electrumx2.neurai.top:50002"
+                "url": "electrumx2.neurai.top:50002",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx3.neurai.top:50001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "alarm@neurai.org"
-                    },
-                    {
-                        "discord": "456566604809895947"
-                    }
-                ],
-                "ws_url": "electrumx3.neurai.top:50002"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XPM": {
-        "coin": "XPM",
-        "type": "UTXO",
-        "name": "Primecoin",
-        "coinpaprika_id": "xpm-primecoin",
-        "coingecko_id": "primecoin",
-        "livecoinwatch_id": "XPM",
-        "explorer_url": "https://www.blockseek.io/xpm/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": true,
-        "fname": "Primecoin",
-        "rpcport": 8332,
-        "pubtype": 23,
-        "p2shtype": 83,
-        "wiftype": 151,
-        "txfee": 0,
-        "dust": 1000000,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/24'",
-        "trezor_coin": "Primecoin",
-        "links": {
-            "github": "https://github.com/primecoin/primecoin",
-            "homepage": "https://primecoin.io"
-        },
-        "electrum": [
-            {
-                "url": "electrumx.mainnet.primecoin.org:50011"
-            },
-            {
-                "url": "electrumx.primecoin.org:50001"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XRG": {
-        "coin": "XRG",
-        "type": "UTXO",
-        "name": "Ergon",
-        "coinpaprika_id": "xrg-ergon",
-        "coingecko_id": "",
-        "livecoinwatch_id": "XRG",
-        "explorer_url": "https://explorer.ergon.network/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Ergon",
-        "rpcport": 2137,
-        "pubtype": 0,
-        "p2shtype": 5,
-        "wiftype": 128,
-        "txfee": 10,
-        "segwit": false,
-        "fork_id": "0x40",
-        "address_format": {
-            "format": "cashaddress",
-            "network": "ergon"
-        },
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/2137'",
-        "electrum": [
-            {
-                "url": "fulcrum.ergon.network:52138",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "la.ask.systems:52138",
-                "protocol": "SSL",
-                "disable_cert_verification": true
-            },
-            {
-                "url": "xrg_ful.googol.cash:52138",
-                "protocol": "SSL",
-                "disable_cert_verification": true
+                "url": "electrumx3.neurai.top:50002",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -38321,15 +28807,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -38382,24 +28859,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -38465,24 +28924,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -38594,15 +29035,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -38614,43 +29046,6 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
-    },
-    "XVC": {
-        "coin": "XVC",
-        "type": "UTXO",
-        "name": "VanillaCash",
-        "coinpaprika_id": "xvc-vcash",
-        "coingecko_id": "vcash",
-        "livecoinwatch_id": "XVC",
-        "explorer_url": "https://chainz.cryptoid.info/xvc/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "VanillaCash",
-        "isPoS": 1,
-        "rpcport": 48888,
-        "pubtype": 18,
-        "p2shtype": 30,
-        "wiftype": 181,
-        "txfee": 1000,
-        "dust": 10000,
-        "mm2": 1,
-        "required_confirmations": 7,
-        "avg_blocktime": 60,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrumx1.vanillacash.info:50011",
-                "ws_url": "electrumx1.vanillacash.info:50013"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "XVC-BEP20": {
         "coin": "XVC-BEP20",
@@ -38689,15 +29084,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -38753,118 +29139,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "XVG": {
-        "coin": "XVG",
-        "type": "UTXO",
-        "name": "Verge",
-        "coinpaprika_id": "xvg-verge",
-        "coingecko_id": "verge",
-        "livecoinwatch_id": "XVG",
-        "explorer_url": "https://xvgblockexplorer.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "VERGE Signed Message:\n",
-        "fname": "Verge",
-        "isPoS": 1,
-        "rpcport": 20102,
-        "pubtype": 30,
-        "p2shtype": 33,
-        "wiftype": 158,
-        "decimals": 6,
-        "segwit": true,
-        "bech32_hrp": "vg",
-        "txfee": 400000,
-        "dust": 400000,
-        "force_min_relay_fee": true,
-        "mm2": 1,
-        "required_confirmations": 10,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/77'",
-        "electrum": [
-            {
-                "url": "88.99.26.209:5036"
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -38906,15 +29190,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -39013,15 +29288,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -39077,24 +29343,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -39293,15 +29541,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -39357,24 +29596,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -39439,76 +29660,16 @@
         },
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10058",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30058"
+                "url": "electrum1.cipig.net:30058",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10058",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30058"
+                "url": "electrum2.cipig.net:30058",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10058",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30058"
-            },
-            {
-                "url": "electrum1.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20058",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30058",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -39548,76 +29709,16 @@
         "derivation_path": "m/44'/323'",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10065",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30065"
+                "url": "electrum1.cipig.net:30065",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10065",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30065"
+                "url": "electrum2.cipig.net:30065",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10065",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30065"
-            },
-            {
-                "url": "electrum1.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20065",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30065",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -39662,15 +29763,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -39682,46 +29774,6 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
-    },
-    "ZET": {
-        "coin": "ZET",
-        "type": "UTXO",
-        "name": "Zetacoin",
-        "coinpaprika_id": "zet-zetacoin",
-        "coingecko_id": "zetacoin",
-        "livecoinwatch_id": "ZET",
-        "explorer_url": "https://chainz.cryptoid.info/zet/",
-        "explorer_tx_url": "tx.dws?",
-        "explorer_address_url": "address.dws?",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Zetacoin Signed Message:\n",
-        "fname": "Zetacoin",
-        "isPoS": 1,
-        "rpcport": 22014,
-        "pubtype": 20,
-        "p2shtype": 85,
-        "wiftype": 153,
-        "txfee": 100000,
-        "dust": 100000,
-        "mm2": 1,
-        "mature_confirmations": 500,
-        "required_confirmations": 7,
-        "avg_blocktime": 45,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "207.180.252.200:50011",
-                "protocol": "TCP",
-                "ws_url": "207.180.252.200:50013"
-            }
-        ],
-        "explorer_block_url": "block.dws?"
     },
     "ZIL-BEP20": {
         "coin": "ZIL-BEP20",
@@ -39760,15 +29812,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -39871,24 +29914,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -40001,76 +30026,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40110,15 +30075,8 @@
         "derivation_path": "m/44'/19167'",
         "electrum": [
             {
-                "url": "electrumx2.runonflux.io:50001",
-                "protocol": "TCP",
-                "ws_url": "electrumx2.runonflux.io:50004"
-            },
-            {
-                "url": "electrumx.runonflux.io:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "ws_url": "electrumx.runonflux.io:50004"
+                "url": "electrumx.runonflux.io:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40161,24 +30119,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -40240,15 +30180,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -40303,76 +30234,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40419,76 +30290,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40535,76 +30346,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40651,76 +30402,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40767,76 +30458,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40883,76 +30514,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -40999,76 +30570,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -41115,76 +30626,16 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30050"
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30050"
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10050",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30050"
-            },
-            {
-                "url": "electrum1.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20050",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -41232,24 +30683,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41314,24 +30747,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41399,24 +30814,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41482,24 +30879,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41560,24 +30939,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41636,24 +30997,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41720,24 +31063,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41796,24 +31121,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -41881,24 +31188,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -41961,24 +31250,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42084,24 +31355,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42160,24 +31413,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42242,24 +31477,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42327,24 +31544,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42405,24 +31604,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42481,24 +31662,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42565,24 +31728,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42641,24 +31786,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42721,24 +31848,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
                 "url": "https://eth1.cipig.net:18555",
                 "contact": {
                     "email": "cipi@komodoplatform.com"
@@ -42799,15 +31908,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -42858,24 +31958,6 @@
             {
                 "url": "https://node.komodo.earth:8080/ethereum",
                 "gui_auth": true
-            },
-            {
-                "url": "http://eth1.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth2.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
-            },
-            {
-                "url": "http://eth3.cipig.net:8555",
-                "contact": {
-                    "email": "cipi@komodoplatform.com"
-                }
             },
             {
                 "url": "https://eth1.cipig.net:18555",
@@ -42938,15 +32020,6 @@
                 "gui_auth": true
             },
             {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
-            },
-            {
                 "url": "https://bsc1.cipig.net:18655"
             },
             {
@@ -42957,118 +32030,6 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
-        "explorer_block_url": "block/"
-    },
-    "tBCH": {
-        "coin": "tBCH",
-        "type": "UTXO",
-        "name": "Bitcoin Cash Testnet",
-        "coinpaprika_id": "",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://tbch.loping.net/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": true,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "bchd_urls": [
-            "https://bchd-testnet.greyh.at:18335"
-        ],
-        "other_types": [
-            "SLP"
-        ],
-        "fname": "Bitcoin Cash Testnet",
-        "pubtype": 111,
-        "p2shtype": 196,
-        "wiftype": 239,
-        "txfee": 0,
-        "estimate_fee_blocks": 2,
-        "segwit": false,
-        "fork_id": "0x40",
-        "address_format": {
-            "format": "cashaddress",
-            "network": "bchtest"
-        },
-        "mm2": 1,
-        "required_confirmations": 1,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "BCH",
-            "protocol_data": {
-                "slp_prefix": "slptest"
-            }
-        },
-        "allow_slp_unsafe_conf": false,
-        "slp_prefix": "slptest",
-        "electrum": [
-            {
-                "url": "tbch.loping.net:60002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "website": "https://1209k.com/bitcoin-eye/ele.php?chain=tbch"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "USBL": {
-        "coin": "USBL",
-        "type": "UTXO",
-        "name": "Balanced Dollar",
-        "coinpaprika_id": "",
-        "coingecko_id": "",
-        "livecoinwatch_id": "",
-        "explorer_url": "https://softbalanced.com:3001/insight/",
-        "explorer_tx_url": "tx/",
-        "explorer_address_url": "address/",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Balanced Dollar",
-        "confpath": "USERHOME/.bitdollar/bitdollar.conf",
-        "rpcport": 35573,
-        "pubtype": 65,
-        "p2shtype": 66,
-        "wiftype": 193,
-        "txfee": 0,
-        "mm2": 1,
-        "required_confirmations": 2,
-        "avg_blocktime": 150,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "swap.softbalanced.com:50001",
-                "contact": [
-                    {
-                        "email": "dev@softbalanced.com"
-                    },
-                    {
-                        "discord": "softbalanced#4045"
-                    }
-                ]
-            },
-            {
-                "url": "swap.softbalanced.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "dev@softbalanced.com"
-                    },
-                    {
-                        "discord": "softbalanced#4045"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "USDF": {
@@ -43102,196 +32063,6 @@
         "token_id": "bb309e48930671582bea508f9a1d9b491e49b69be3d6f372dc08da2ac6e90eb7",
         "parent_coin": "tSLP",
         "token_address_url": "token/",
-        "explorer_block_url": "block/"
-    },
-    "WHIVE": {
-        "coin": "WHIVE",
-        "type": "UTXO",
-        "name": "Whive",
-        "coinpaprika_id": "whive-the-whive-protocol",
-        "coingecko_id": "whive",
-        "livecoinwatch_id": "WHIVE",
-        "explorer_url": "https://whiveexplorer.cointest.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Whive",
-        "rpcport": 1867,
-        "pubtype": 73,
-        "p2shtype": 10,
-        "wiftype": 128,
-        "txfee": 0,
-        "dust": 1000,
-        "segwit": true,
-        "bech32_hrp": "wv",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "mature_confirmations": 100,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrumx1.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx1.cointest.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
-    "WHIVE-segwit": {
-        "coin": "WHIVE-segwit",
-        "type": "UTXO",
-        "name": "Whive",
-        "coinpaprika_id": "whive-the-whive-protocol",
-        "coingecko_id": "whive",
-        "livecoinwatch_id": "WHIVE",
-        "explorer_url": "https://whiveexplorer.cointest.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "fname": "Whive",
-        "rpcport": 1867,
-        "pubtype": 73,
-        "p2shtype": 10,
-        "wiftype": 128,
-        "txfee": 0,
-        "dust": 1000,
-        "segwit": true,
-        "bech32_hrp": "wv",
-        "address_format": {
-            "format": "segwit"
-        },
-        "orderbook_ticker": "WHIVE",
-        "mm2": 1,
-        "required_confirmations": 1,
-        "mature_confirmations": 100,
-        "avg_blocktime": 600,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "electrum": [
-            {
-                "url": "electrumx1.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50001",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx1.cointest.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.cointest.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "protocol@whive.io"
-                    },
-                    {
-                        "discord": "whiveio#9340"
-                    },
-                    {
-                        "twitter": "whiveio"
-                    }
-                ]
-            }
-        ],
         "explorer_block_url": "block/"
     },
     "XEC": {
@@ -43332,35 +32103,8 @@
         "derivation_path": "m/44'/1899'",
         "electrum": [
             {
-                "url": "ecash.stackwallet.com:59002",
-                "protocol": "SSL",
-                "ws_url": "ecash.stackwallet.com:59004"
-            },
-            {
-                "url": "electrum.bitcoinabc.org:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "joey@e.cash"
-                    },
-                    {
-                        "twitter": "bytesofman"
-                    }
-                ]
-            },
-            {
-                "url": "fulcrum.pepipierre.fr:50002",
-                "protocol": "SSL",
-                "disable_cert_verification": true,
-                "contact": [
-                    {
-                        "email": "contact@e.cash"
-                    },
-                    {
-                        "twitter": "ecashofficial"
-                    }
-                ]
+                "url": "ecash.stackwallet.com:59004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -43402,15 +32146,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -43457,76 +32192,16 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrum1.cipig.net:10002",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum1.cipig.net:30002"
+                "url": "electrum1.cipig.net:30002",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2.cipig.net:10002",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum2.cipig.net:30002"
+                "url": "electrum2.cipig.net:30002",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum3.cipig.net:10002",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ],
-                "ws_url": "electrum3.cipig.net:30002"
-            },
-            {
-                "url": "electrum1.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum2.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.cipig.net:20002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "cipi@komodoplatform.com"
-                    },
-                    {
-                        "discord": "cipi#4502"
-                    }
-                ]
+                "url": "electrum3.cipig.net:30002",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -43582,54 +32257,12 @@
         "required_confirmations": 3,
         "electrum": [
             {
-                "url": "zombie.dragonhound.info:10033",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30058"
+                "url": "zombie.dragonhound.info:30058",
+                "protocol": "WSS"
             },
             {
-                "url": "zombie.dragonhound.info:10133",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30059"
-            },
-            {
-                "url": "zombie.dragonhound.info:20033",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30058"
-            },
-            {
-                "url": "zombie.dragonhound.info:20133",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "smk@komodoplatform.com"
-                    },
-                    {
-                        "discord": "smk#7640"
-                    }
-                ],
-                "ws_url": "zombie.dragonhound.info:30059"
+                "url": "zombie.dragonhound.info:30059",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -43671,15 +32304,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -43727,41 +32351,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.runebase.io:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.runebase.io:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.runebase.io:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ],
-                "ws_url": "electrum3.runebase.io:50004"
+                "url": "electrum3.runebase.io:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -43799,40 +32390,12 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
-                "url": "electrumx1.actioncoin.com:10001",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
+                "url": "electrumx1.actioncoin.com:20001",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx2.actioncoin.com:10001",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx1.actioncoin.com:30001",
-                "ws_url": "electrumx1.actioncoin.com:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx2.actioncoin.com:30001",
-                "ws_url": "electrumx2.actioncoin.com:20001",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "support@actioncoin.com"
-                    }
-                ]
+                "url": "electrumx2.actioncoin.com:20001",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -43874,15 +32437,6 @@
             {
                 "url": "https://node.komodo.earth:8080/binance",
                 "gui_auth": true
-            },
-            {
-                "url": "http://bsc1.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc2.cipig.net:8655"
-            },
-            {
-                "url": "http://bsc3.cipig.net:8655"
             },
             {
                 "url": "https://bsc1.cipig.net:18655"
@@ -44087,46 +32641,16 @@
         },
         "electrum": [
             {
-                "url": "electrumx.mazanode.com:50001",
-                "contact": [
-                    {
-                        "email": "brian@mazacoin.org"
-                    }
-                ]
+                "url": "electrumx.mazanode.com:50005",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx2.mazacha.in:50001",
-                "contact": [
-                    {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
-                    }
-                ]
+                "url": "electrumx2.mazacha.in:50005",
+                "protocol": "WSS"
             },
             {
-                "url": "electrumx.mazanode.com:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "brian@mazacoin.org"
-                    }
-                ],
-                "ws_url": "electrumx.mazanode.com:50005"
-            },
-            {
-                "url": "electrumx2.mazacha.in:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "contact@mazacoin.org"
-                    },
-                    {
-                        "discord": "sherm77#5923"
-                    }
-                ],
-                "ws_url": "electrumx2.mazacha.in:50005"
+                "url": "electrum.seed.mazanode.com:50005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -44170,52 +32694,12 @@
         },
         "electrum": [
             {
-                "url": "coin.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
+                "url": "coin.crionic.org:50005",
+                "protocol": "WSS"
             },
             {
-                "url": "explorer.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "coin.crionic.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ],
-                "ws_url": "coin.crionic.org:50005"
-            },
-            {
-                "url": "explorer.crionic.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ],
-                "ws_url": "explorer.crionic.org:50005"
+                "url": "explorer.crionic.org:50005",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -44256,52 +32740,12 @@
         },
         "electrum": [
             {
-                "url": "electrum1-mainnet.evrmorecoin.org:50001",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ]
+                "url": "electrum1-mainnet.evrmorecoin.org:50004",
+                "protocol": "WSS"
             },
             {
-                "url": "electrum2-mainnet.evrmorecoin.org:50001",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1-mainnet.evrmorecoin.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ],
-                "ws_url": "electrum1-mainnet.evrmorecoin.org:50004"
-            },
-            {
-                "url": "electrum2-mainnet.evrmorecoin.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "hans_schm1dt@protonmail.com"
-                    },
-                    {
-                        "discord": "Hans_Schmidt#0745"
-                    }
-                ],
-                "ws_url": "electrum2-mainnet.evrmorecoin.org:50004"
+                "url": "electrum2-mainnet.evrmorecoin.org:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -537,6 +537,11 @@ def filter_tcp(coins_config, coins_config_ssl):
     coins_config_tcp = {}
     for coin in coins_config:
         coins_config_tcp.update({coin: coins_config[coin]})
+        # Omit gui_auth: true nodes - these are web only.
+        if 'nodes' in coins_config[coin]:
+            coins_config_tcp[coin]['nodes'] = [
+                i for i in coins_config[coin]["nodes"] if "gui_auth" not in i
+            ][:3]
         if "electrum" in coins_config[coin]:
             electrums = []
             # Prefer SSL
@@ -544,6 +549,9 @@ def filter_tcp(coins_config, coins_config_ssl):
                 if len(coins_config_ssl[coin]['electrum']) > 0:
                     electrums = coins_config_ssl[coin]['electrum']
             for i in coins_config[coin]["electrum"]:
+                if "gui_auth" in i:
+                    if i["gui_auth"] == True:
+                        continue
                 if item_exists(i, electrums) == False:
                     if 'protocol' in i:
                         # SSL is ok for legacy desktop so we allow them, else some coins with only SSL will be omited.

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -526,6 +526,13 @@ def filter_ssl(coins_config):
     return coins_config_ssl
 
 
+def item_exists(i, electrums):
+    for e in electrums:
+        if i['url'] == e['url']:
+            return True
+    return False
+
+
 def filter_tcp(coins_config, coins_config_ssl):
     coins_config_tcp = {}
     for coin in coins_config:
@@ -537,16 +544,18 @@ def filter_tcp(coins_config, coins_config_ssl):
                 if len(coins_config_ssl[coin]['electrum']) > 0:
                     electrums = coins_config_ssl[coin]['electrum']
             for i in coins_config[coin]["electrum"]:
-                if 'protocol' in i:
-                    # SSL is ok for legacy desktop so we allow them, else some coins with only SSL will be omited.
-                    if i['protocol'] != "WSS":
+                if item_exists(i, electrums) == False:
+                    if 'protocol' in i:
+                        # SSL is ok for legacy desktop so we allow them, else some coins with only SSL will be omited.
+                        if i['protocol'] != "WSS":
+                            electrums.append(i)
+                    else:
                         electrums.append(i)
-                else:
-                    electrums.append(i)
+     
             coins_config_tcp[coin]['electrum'] = electrums[:3]
             if len(coins_config_tcp[coin]['electrum']) == 0:
                 del coins_config_tcp[coin]
-        
+
     with open("coins_config_tcp.json", "w+") as f:
         json.dump(coins_config_tcp, f, indent=4)
     return coins_config_tcp

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -151,7 +151,11 @@ class CoinConfig:
                 # ZHTLC only
                 if "height" in protocol_data["check_point_block"]:
                     self.data[self.ticker].update({
-                        "check_point_block": protocol_data["check_point_block"]["height"]
+                        "checkpoint_height": protocol_data["check_point_block"]["height"]
+                    })
+                if "time" in protocol_data["check_point_block"]:
+                    self.data[self.ticker].update({
+                        "checkpoint_blocktime": protocol_data["check_point_block"]["time"]
                     })
 
             if "slp_prefix" in protocol_data:

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -3,6 +3,7 @@ import os
 import sys
 import time
 import json
+from copy import deepcopy
 import requests
 from scan_electrums import get_electrums_report
 
@@ -573,9 +574,9 @@ if __name__ == "__main__":
     coins_config, nodata = parse_coins_repo()
     with open("coins_config.json", "w+") as f:
         json.dump(coins_config, f, indent=4)
-    coins_config_tcp = filter_tcp(coins_config)
-    coins_config_ssl = filter_ssl(coins_config)
-    coins_config_wss = filter_wss(coins_config)
+    coins_config_tcp = filter_tcp(deepcopy(coins_config))
+    coins_config_ssl = filter_ssl(deepcopy(coins_config))
+    coins_config_wss = filter_wss(deepcopy(coins_config))
     for coin in coins_config:
         if coin in coins_config_ssl and coin in coins_config_ssl and coin in coins_config_ssl:
             color = "green"

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -504,11 +504,13 @@ if __name__ == "__main__":
         if "electrum" in coins_config[coin]:
             electrums = []
             for i in coins_config[coin]["electrum"]:
-                if 'ws_url' in i:
-                    electrums.append(i)
-                elif 'protocol' in i:
+                if 'protocol' in i:
                     if i['protocol'] == "SSL":
                         electrums.append(i)
+                    elif 'ws_url' in i:
+                        print(f"{coin} WSS URL found in non SSL electrum: {i}")
+                elif 'ws_url' in i:
+                    print(f"{coin} WSS URL found in non SSL electrum: {i}")
             coins_config_ssl[coin]['electrum'] = electrums
         if 'nodes' in coins_config[coin]:
             coins_config_ssl[coin]['nodes'] = [

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -494,3 +494,25 @@ if __name__ == "__main__":
     coins_config = parse_coins_repo()
     with open("coins_config.json", "w+") as f:
         json.dump(coins_config, f, indent=4)
+    coins_config_ssl = {}
+    for coin in coins_config:
+        coins_config_ssl.update({coin: coins_config[coin]})
+        if "electrum" in coins_config[coin]:
+            electrums = []
+            for i in coins_config[coin]["electrum"]:
+                if 'ws_url' in i:
+                    electrums.append(i)
+                elif 'protocol' in i:
+                    if i['protocol'] == "SSL":
+                        electrums.append(i)
+            coins_config_ssl[coin]['electrum'] = electrums
+        if 'nodes' in coins_config[coin]:
+            coins_config_ssl[coin]['nodes'] = [
+                i for i in coins_config[coin]["nodes"] if i['url'].startswith("https")
+            ]
+        if 'light_wallet_d_servers' in coins_config[coin]:
+            coins_config_ssl[coin]['light_wallet_d_servers'] = [
+                i for i in coins_config[coin]["light_wallet_d_servers"] if i.startswith("https")
+            ]
+    with open("coins_config_ssl.json", "w+") as f:
+        json.dump(coins_config_ssl, f, indent=4)

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -480,7 +480,7 @@ def parse_coins_repo():
             print(error)
     for coin in nodata:
         del coins_config[coin]
-    return coins_config
+    return coins_config, nodata
 
 
 def get_desktop_repo_coins_data():
@@ -494,10 +494,8 @@ def get_desktop_repo_coins_data():
     with open(f"../../atomicDEX-Desktop/assets/config/{coins_fn}", "r") as f:
         return json.load(f)
 
-if __name__ == "__main__":
-    coins_config = parse_coins_repo()
-    with open("coins_config.json", "w+") as f:
-        json.dump(coins_config, f, indent=4)
+
+def filter_ssl(coins_config):
     coins_config_ssl = {}
     for coin in coins_config:
         coins_config_ssl.update({coin: coins_config[coin]})
@@ -505,20 +503,87 @@ if __name__ == "__main__":
             electrums = []
             for i in coins_config[coin]["electrum"]:
                 if 'protocol' in i:
+                    # For web, we only want SSL. 
                     if i['protocol'] == "SSL":
                         electrums.append(i)
-                    elif 'ws_url' in i:
-                        print(f"{coin} WSS URL found in non SSL electrum: {i}")
-                elif 'ws_url' in i:
-                    print(f"{coin} WSS URL found in non SSL electrum: {i}")
-            coins_config_ssl[coin]['electrum'] = electrums
+            coins_config_ssl[coin]['electrum'] = electrums[:3]
+            if len(coins_config_ssl[coin]['electrum']) == 0:
+                del coins_config_ssl[coin]
+        
         if 'nodes' in coins_config[coin]:
             coins_config_ssl[coin]['nodes'] = [
                 i for i in coins_config[coin]["nodes"] if i['url'].startswith("https")
             ]
+        
         if 'light_wallet_d_servers' in coins_config[coin]:
             coins_config_ssl[coin]['light_wallet_d_servers'] = [
                 i for i in coins_config[coin]["light_wallet_d_servers"] if i.startswith("https")
             ]
+        
     with open("coins_config_ssl.json", "w+") as f:
         json.dump(coins_config_ssl, f, indent=4)
+    return coins_config_ssl
+
+
+def filter_tcp(coins_config):
+    coins_config_tcp = {}
+    for coin in coins_config:
+        coins_config_tcp.update({coin: coins_config[coin]})
+        if "electrum" in coins_config[coin]:
+            electrums = []
+            for i in coins_config[coin]["electrum"]:
+                if 'protocol' in i:
+                    # SSL is ok for legacy desktop so we allow them, else some coins with only SSL will be omited.
+                    if i['protocol'] != "WSS":
+                        electrums.append(i)
+            coins_config_tcp[coin]['electrum'] = electrums[:3]
+            if len(coins_config_tcp[coin]['electrum']) == 0:
+                del coins_config_tcp[coin]
+        
+    with open("coins_config_tcp.json", "w+") as f:
+        json.dump(coins_config_tcp, f, indent=4)
+    return coins_config_tcp
+
+
+def filter_wss(coins_config):
+    coins_config_wss = {}
+    for coin in coins_config:
+        coins_config_wss.update({coin: coins_config[coin]})
+        if "electrum" in coins_config[coin]:
+            electrums = []
+            for i in coins_config[coin]["electrum"]:
+                if "ws_url" in i:
+                    electrums.append({
+                        "url": i["ws_url"],
+                        "protocol": "WSS"
+                    })                        
+            coins_config_wss[coin]['electrum'] = electrums[:3]
+            if len(coins_config_wss[coin]['electrum']) == 0:
+                del coins_config_wss[coin]
+        
+    with open("coins_config_wss.json", "w+") as f:
+        json.dump(coins_config_wss, f, indent=4)
+    return coins_config_wss
+
+
+
+if __name__ == "__main__":
+    coins_config, nodata = parse_coins_repo()
+    with open("coins_config.json", "w+") as f:
+        json.dump(coins_config, f, indent=4)
+    coins_config_tcp = filter_tcp(coins_config)
+    coins_config_ssl = filter_ssl(coins_config)
+    coins_config_wss = filter_wss(coins_config)
+    for coin in coins_config:
+        if coin in coins_config_ssl and coin in coins_config_ssl and coin in coins_config_ssl:
+            color = "green"
+        else:
+            color = "blue"
+        print(colorize(f"{coin}: [SSL {coin in coins_config_ssl}] [TCP {coin in coins_config_tcp}] [WSS {coin in coins_config_wss}]", color))
+    for coin in nodata:
+        print(colorize(f"{coin}: [SSL False] [TCP False] [WSS False]", "red"))
+    print()
+    print(f"Total coins: {len(coins_config)}")
+    print(f"Total coins with SSL: {len(coins_config_ssl)}")
+    print(f"Total coins with TCP: {len(coins_config_tcp)}")
+    print(f"Total coins with WSS: {len(coins_config_wss)}")

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -536,6 +536,8 @@ def filter_tcp(coins_config):
                     # SSL is ok for legacy desktop so we allow them, else some coins with only SSL will be omited.
                     if i['protocol'] != "WSS":
                         electrums.append(i)
+                else:
+                    electrums.append(i)
             coins_config_tcp[coin]['electrum'] = electrums[:3]
             if len(coins_config_tcp[coin]['electrum']) == 0:
                 del coins_config_tcp[coin]

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -526,12 +526,16 @@ def filter_ssl(coins_config):
     return coins_config_ssl
 
 
-def filter_tcp(coins_config):
+def filter_tcp(coins_config, coins_config_ssl):
     coins_config_tcp = {}
     for coin in coins_config:
         coins_config_tcp.update({coin: coins_config[coin]})
         if "electrum" in coins_config[coin]:
             electrums = []
+            # Prefer SSL
+            if coin in coins_config_ssl:
+                if len(coins_config_ssl[coin]['electrum']) > 0:
+                    electrums = coins_config_ssl[coin]['electrum']
             for i in coins_config[coin]["electrum"]:
                 if 'protocol' in i:
                     # SSL is ok for legacy desktop so we allow them, else some coins with only SSL will be omited.
@@ -574,9 +578,9 @@ if __name__ == "__main__":
     coins_config, nodata = parse_coins_repo()
     with open("coins_config.json", "w+") as f:
         json.dump(coins_config, f, indent=4)
-    coins_config_tcp = filter_tcp(deepcopy(coins_config))
     coins_config_ssl = filter_ssl(deepcopy(coins_config))
     coins_config_wss = filter_wss(deepcopy(coins_config))
+    coins_config_tcp = filter_tcp(deepcopy(coins_config), coins_config_ssl)
     for coin in coins_config:
         if coin in coins_config_ssl and coin in coins_config_ssl and coin in coins_config_ssl:
             color = "green"


### PR DESCRIPTION
To avoid SSL warnings / errors in browser, I've tweaked the script  to exclude any nodes, electrums or lightwallets which are not using SSL, and add these to a new file called `coins_config_ssl.json`. Web based apps can use this file instead of the `coins_config.json` file which remains complete (excluding non responsive electrums)
