### PR TITLE
fixed fee for GRS + dust for couple coins + some RPCs

### DIFF
--- a/coins
+++ b/coins
@@ -5203,6 +5203,7 @@
     "p2shtype": 5,
     "wiftype": 128,
     "txfee": 10000,
+    "dust": 10000,
     "segwit": true,
     "bech32_hrp": "grs",
     "mm2": 1,
@@ -5228,6 +5229,7 @@
     "p2shtype": 5,
     "wiftype": 128,
     "txfee": 10000,
+    "dust": 10000,
     "segwit": true,
     "bech32_hrp": "grs",
     "address_format": {

--- a/coins
+++ b/coins
@@ -11793,6 +11793,7 @@
     "p2shtype": 5,
     "wiftype": 128,
     "txfee": 100000,
+    "dust": 100000,
     "segwit": true,
     "bech32_hrp": "vtc",
     "mm2": 1,
@@ -11818,6 +11819,7 @@
     "p2shtype": 5,
     "wiftype": 128,
     "txfee": 100000,
+    "dust": 100000,
     "segwit": true,
     "bech32_hrp": "vtc",
     "address_format": {

--- a/coins
+++ b/coins
@@ -5202,7 +5202,7 @@
     "pubtype": 36,
     "p2shtype": 5,
     "wiftype": 128,
-    "txfee": 0,
+    "txfee": 10000,
     "segwit": true,
     "bech32_hrp": "grs",
     "mm2": 1,
@@ -5227,7 +5227,7 @@
     "pubtype": 36,
     "p2shtype": 5,
     "wiftype": 128,
-    "txfee": 0,
+    "txfee": 10000,
     "segwit": true,
     "bech32_hrp": "grs",
     "address_format": {

--- a/coins
+++ b/coins
@@ -9697,6 +9697,7 @@
     "wiftype": 128,
     "segwit": true,
     "txfee": 1000000,
+    "dust": 1000000,
     "mm2": 1,
     "required_confirmations": 3,
     "avg_blocktime": 60,

--- a/ethereum/AVAX
+++ b/ethereum/AVAX
@@ -8,6 +8,9 @@
     },
     {
       "url": "https://api.avax.network/ext/bc/C/rpc"
+    },
+    {
+      "url": "https://avalanche.blockpi.network/v1/rpc/public"
     }
   ]
 }

--- a/ethereum/FTM
+++ b/ethereum/FTM
@@ -8,6 +8,9 @@
     },
     {
       "url": "https://rpc.fantom.network"
+    },
+    {
+      "url": "https://rpc2.fantom.network"
     }
   ]
 }

--- a/ethereum/MATIC
+++ b/ethereum/MATIC
@@ -10,7 +10,7 @@
       "url": "https://polygon-rpc.com"
     },
     {
-      "url": "https://polygon.rpc.blxrbdn.com"
+      "url": "https://polygon.blockpi.network/v1/rpc/public"
     },
     {
       "url": "https://polygon.llamarpc.com"

--- a/ethereum/MOVR
+++ b/ethereum/MOVR
@@ -3,7 +3,7 @@
   "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
   "rpc_nodes": [
     {
-      "url": "https://rpc.moonriver.moonbeam.network"
+      "url": "https://moonriver.public.blastapi.io"
     },
     {
       "url": "https://rpc.api.moonriver.moonbeam.network"


### PR DESCRIPTION
make GRS use fixed fee to avoid failed swaps like this one: https://dexapi.cipig.net/public/error.php?uuid=2a12b4d4-146f-48f7-bf72-0a7ef27601e1
`the transaction was rejected by network rules.\\n\\nFee exceeds maximum configured by user (e.g. -maxtxfee, maxfeerate)`
the problem is that the electrums are showing a much higher fee then needed, and sometimes a higher one then accepted by the chain
this change also reduces miner fee payments for GRS in general

also set dust to same amount as txfee to prevent `"error" : "maker_swap:1110] !taker_coin.send_maker_spends_taker_payment: utxo_common:1537] HTLC spend fee 10000 is greater than transaction output 10000"`

set dust for VTC too, to avoid https://dexapi.cipig.net/public/error.php?uuid=c8d10d89-c87e-4b82-ac1e-583e3a5c2d65
`"maker_swap:1108] !taker_coin.send_maker_spends_taker_payment: utxo_common:1287] HTLC spend fee 66942 is greater than transaction output 33588"`

and it adds some more RPC nodes for EVM chains