### PR TITLE
remove bad FLUX electrum

### DIFF
--- a/electrums/FLUX
+++ b/electrums/FLUX
@@ -4,10 +4,5 @@
         "protocol": "SSL",
         "disable_cert_verification": true,
         "ws_url": "electrumx.runonflux.io:50004"  
-    },
-    {
-        "url": "electrumx2.runonflux.io:50001",
-        "protocol": "TCP",
-        "ws_url": "electrumx2.runonflux.io:50004"
     }
 ]

--- a/electrums/ZET
+++ b/electrums/ZET
@@ -2,8 +2,7 @@
     {
         "url": "zeta-seed-c.zetacoin.tech:50012",
         "protocol": "SSL",
-        "disable_cert_verification": false,
-        "ws_url": "207.180.252.200:50013"
+        "disable_cert_verification": false
     },
     {
         "url": "207.180.252.200:50011",


### PR DESCRIPTION
```
(echo '{ "id": 1, "method": "blockchain.headers.subscribe" }'; sleep 1) | ncat --ssl electrumx.runonflux.io 50002

{"jsonrpc": "2.0", "result": {"hex": "04000000e685f2609e10fd9f6fca3887e66689ebf28aa23c8db3512d1db05efc02000000fcb4cdc6b91a0d043d899dfc3b429df388b0f5fe9f4a48169fae6dab162278d6d9988e7adc9c6da15d12246eeb18623d1f8039f5ee6bcae29261e383248d7522aa211265de6a111d0fffd38e73000000000000000000000000000000000000000000000091e0d0b5340a62b2af0d1383398e839f6e530bf25c980e4b3af750b391fe53131e9eb7ccb73176ac47ee824d1658ba70660035a8f0f591ff45", "height": 1477346}, "id": 1}


(echo '{ "id": 1, "method": "blockchain.headers.subscribe" }'; sleep 1) | ncat --ssl electrumx2.runonflux.io 50002

{"jsonrpc": "2.0", "result": {"hex": "0400000051a797727050964f3a9619b2d1a5950b191d3c5604725d88a2f264f80800000092c287425a6f2e3b8775207b1fbb73c85edca99740f488e154e2e64ee6c63fc3d9988e7adc9c6da15d12246eeb18623d1f8039f5ee6bcae29261e383248d75226af0f0643889111d0565356200000000000000000000000000000000000000000000000017d3ba7c340550e82eb750a18da1b4fcc5ec559d7966131317bf47639f3b8a14ad50ec14775829f77aa6a72b2558d967ad86a727e912e97dbe", "height": 1459371}, "id": 1}
```

i talked to the people from FLUX 2 weeks ago or so... they first took down that bad electrum, but now it's back online and still stuck at height 1459371 (almost 20k blocks behind)... so now i remove it since it causes swaps to fail