### PR TITLE
fix FLUX avg_blocktime, fixed fee for LYNX

### DIFF
--- a/coins
+++ b/coins
@@ -13054,7 +13054,7 @@
     "txfee": 10000,
     "mm2": 1,
     "required_confirmations": 2,
-    "avg_blocktime": 60,
+    "avg_blocktime": 120,
     "protocol": {
       "type": "UTXO"
     },

--- a/coins
+++ b/coins
@@ -7443,7 +7443,7 @@
     "pubtype": 45,
     "p2shtype": 22,
     "wiftype": 173,
-    "txfee": 0,
+    "txfee": 100000,
     "dust": 54600,
     "segwit": false,
     "mm2": 1,


### PR DESCRIPTION
FLUX: https://miningpoolstats.stream/flux

LYNX: avoid `error: Response(electrum6.getlynx.io:50002, Object({\"code\": Number(1), \"message\": String(\"the transaction was rejected by network rules.\\n\\n256: absurdly-high-fee`