### PR TITLE
fix GLC txfee and sign_message_prefix

### DIFF
--- a/coins
+++ b/coins
@@ -5182,18 +5182,18 @@
     },
     "derivation_path": "m/44'/714'"
   },
-{
+  {
     "coin": "GLC",
     "name": "goldcoin",
     "fname": "Goldcoin",
     "rpcport": 8122,
     "pubtype": 32,
-    "p2shtype": 50,
+    "p2shtype": 5,
     "wiftype": 160,
     "segwit": false,
-    "txfee": 1000,
+    "txfee": 100000,
     "mm2": 1,
-    "sign_message_prefix": "Goldcoin Signed Message:\n",
+    "sign_message_prefix": "Goldcoin (GLC) Signed Message:\n",
     "required_confirmations": 3,
     "avg_blocktime": 120,
     "protocol": {


### PR DESCRIPTION
https://dexapi.cipig.net/public/error.php?uuid=963f97c3-22a4-491e-be38-5a4519a1f77f
`src/wallet/wallet.h:static const CAmount DEFAULT_TRANSACTION_MINFEE = 100000;`
`src/validation.cpp:const std::string strMessageMagic = "Goldcoin (GLC) Signed Message:\n";'`