### PR TITLE
remove limited PLG20 RPC

### DIFF
--- a/ethereum/MATIC
+++ b/ethereum/MATIC
@@ -10,9 +10,6 @@
       "url": "https://polygon-rpc.com"
     },
     {
-      "url": "https://polygon.blockpi.network/v1/rpc/public"
-    },
-    {
       "url": "https://polygon.llamarpc.com"
     }
   ]


### PR DESCRIPTION
if swap takes too long to complete mm2 shows error
`
coins::eth:2077] ERROR Error getting spend events: eth:3878] RPC error: Error { code: InvalidParams, message: "eth_getLogs is limited to 1024 block range. Please check the parameter requirements at  https://docs.blockpi.io/documentations/api-reference", data: None }
`