### PR TITLE
fix duplicate electrum for BITN

### DIFF
--- a/electrums/BITN
+++ b/electrums/BITN
@@ -12,7 +12,7 @@
     {
         "url": "bitchair.io:50001",
         "protocol": "TCP",
-        "ws_url": "bitexplorer.io:50004",
+        "ws_url": "bitchair.io:50004",
         "contact": [
             {
                 "discord": "c4pt#7855"


### PR DESCRIPTION
bitexplorer.io was duplicated in ws_url, while bitchair.io missing