### PR TITLE
add script to determine coins added and removed between commits

### DIFF
--- a/utils/get_coins_diff.py
+++ b/utils/get_coins_diff.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+import argparse
+import requests
+
+'''
+Use this script to determine which coins were added or removed between two commits.
+To find the commit that matches app release dates, refer to
+https://github.com/KomodoPlatform/coins/commits/master/utils/coins_config.json
+
+You can use the full hash or the short hash (first 7 characters) of the commit.
+'''
+
+def get_coins_from_commit(commit: str, org: str = "komodoplatform", repo: str = "coins") -> set:
+    url = build_coins_config_url(commit, org="komodoplatform", repo="coins")
+    r = requests.get(url)
+    try:
+        return set(list(r.json().keys()))
+    except Exception as e:
+        print(f"{type(e)} error: {e}")
+        return set()
+
+
+def build_coins_config_url(commit, org="komodoplatform", repo="coins"):
+    return "https://raw.githubusercontent.com/" + org + "/" + repo + "/" + commit + "/utils/coins_config.json"
+
+
+def get_delisted_coins(old_coins, new_coins):
+    return list(old_coins - new_coins)
+
+def get_new_listed_coins(old_coins, new_coins):
+    return list(new_coins - old_coins)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Returns the add/remove list of coins between two commits.')
+    parser.add_argument('old_commit', type=str, help='Old commit hash')
+    parser.add_argument('new_commit', type=str, help='New commit hash')
+    # Parse the argument
+    args = parser.parse_args()
+    old_coins = get_coins_from_commit(args.old_commit)
+    new_coins = get_coins_from_commit(args.new_commit)
+
+    print(f"New coin listings: {get_new_listed_coins(old_coins, new_coins)}")
+    print(f"Delisted coins: {get_delisted_coins(old_coins, new_coins)}")


### PR DESCRIPTION
```
./get_coins_diff.py -h
usage: get_coins_diff.py [-h] old_commit new_commit

Returns the add/remove list of coins between two commits.

positional arguments:
  old_commit  Old commit hash
  new_commit  New commit hash

optional arguments:
  -h, --help  show this help message and exit
```

Example: `./get_coins_diff.py 33745cd2d87d275216d0d65dd725f0ffa45214a5 f956070bc4c33723f753ed6ecaf2dc32a6f44972`

Response:
```
27 new coin listings: ['EURE-PLG20', 'DFX-PLG20_OLD', 'KIIRO-BEP20', 'DIAC', 'ARPA-PLG20', 'AVA-BEP20_OLD', 'GLC', 'PYR-PLG20', 'GBX', 'MKR-PLG20', 'GAME-PLG20', 'SHIB-PLG20', 'AYA-BEP20', 'GMT-PLG20', 'GBX-BEP20', 'BLOCX', 'AVA-ERC20', 'PYR-ERC20', 'DOGEC', 'BORG-ERC20', 'GAME-ERC20', 'ILN', 'KIIRO', 'CHSB-ERC20_OLD', 'USDC-PLG20_OLD', 'EURE-ERC20', 'SUM']

10 delisted coins: ['AVA-BEP20', 'CHSB-ERC20', 'BKC', 'CLC', 'GRS-segwit', 'tQTUM-segwit', 'BSTY-segwit', 'VIA-segwit', 'QTUM-segwit', 'VRM']
```
