### PR TITLE
reduce dust for SUM - see notes

### DIFF
--- a/coins
+++ b/coins
@@ -10364,7 +10364,7 @@
     "wiftype": 187, 
     "decimals": 6, 
     "txfee": 0, 
-    "dust": 10000, 
+    "dust": 1000, 
     "segwit": false, 
     "bech32_hrp": "sum",
     "mm2": 1,


### PR DESCRIPTION
This PR:
dust for SUM was 10000 ... SUM has 6 decimals... so 10000 sats = 0.01 SUM... the min_trade_amount was 0.1 SUM which is too high.   Reducing to 1000 dust allows for smaller trades too occur which is more economical over time. 

Prior PR's:
addressed block confirmations which reduced average swap time from 8-15 mins down to 3-5 minutes. New URL for explorer helped visibility of tx info.