### PR TITLE
fix PIVX dust

### DIFF
--- a/coins
+++ b/coins
@@ -9001,6 +9001,7 @@
     "p2shtype": 13,
     "wiftype": 212,
     "txfee": 100000,
+    "dust": 5460,
     "mm2": 1,
     "required_confirmations": 5,
     "avg_blocktime": 60,


### PR DESCRIPTION
fix for https://dexapi.cipig.net/public/error.php?uuid=cde6ea36-0829-42e2-82d2-8582170e474a

```
  "vout": [
    {
      "value": 0.00001987,
      "n": 0,
      "scriptPubKey": {
        "asm": "OP_DUP OP_HASH160 ca1e04745e8ca0c60d8c5881531d51bec470743f OP_EQUALVERIFY OP_CHECKSIG",
        "hex": "76a914ca1e04745e8ca0c60d8c5881531d51bec470743f88ac",
        "reqSigs": 1,
        "type": "pubkeyhash",
        "addresses": [
          "DPZnzesTGPD42AXY1qX8BQp78jLbmzpRT7"
        ]
      }
    },
```
```
src/test/transaction_tests.cpp:    BOOST_CHECK_EQUAL(nDustThreshold, 5460);
```

5460 > 1987
