### PR TITLE
FLUX has 8 decimals, not 18

### DIFF
--- a/coins
+++ b/coins
@@ -13175,7 +13175,7 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 1,
-    "decimals": 18,
+    "decimals": 8,
     "avg_blocktime": 15,
     "required_confirmations": 3,
     "protocol": {
@@ -13194,6 +13194,7 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 56,
+    "decimals": 8,
     "avg_blocktime": 3,
     "required_confirmations": 3,
     "protocol": {


### PR DESCRIPTION
https://etherscan.io/token/0x720CD16b011b987Da3518fbf38c3071d4F0D1495