### PR TITLE
fix dust for GLC

### DIFF
--- a/coins
+++ b/coins
@@ -5354,6 +5354,7 @@
     "wiftype": 160,
     "segwit": false,
     "txfee": 100000,
+    "dust": 54600,
     "mm2": 1,
     "sign_message_prefix": "Goldcoin (GLC) Signed Message:\n",
     "required_confirmations": 3,


### PR DESCRIPTION
avoid: https://dexapi.cipig.net/public/error.php?uuid=e5bce68e-c587-41c5-8139-6453eaebab43
code: `src/test/transaction_tests.cpp:    BOOST_CHECK_EQUAL(nDustThreshold, 54600);`