### PR TITLE
fix p2shtype for LCC-segwit

### DIFF
--- a/coins
+++ b/coins
@@ -7120,7 +7120,7 @@
     "sign_message_prefix": "Litecoin Signed Message:\n",
     "rpcport": 62457,
     "pubtype": 28,
-    "p2shtype": 5,
+    "p2shtype": 50,
     "wiftype": 176,
     "decimals": 7,
     "fork_id": "0x40",


### PR DESCRIPTION
same as for LCC
wallet code has
```
        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);
        base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1,50);
```
