### PR TITLE
set DOGE dust back to original

### DIFF
--- a/coins
+++ b/coins
@@ -3890,7 +3890,7 @@
     "wiftype": 158,
     "txfee": 0,
     "force_min_relay_fee": true,
-    "dust": 100000000,
+    "dust": 1000000,
     "mm2": 1,
     "required_confirmations": 2,
     "avg_blocktime": 60,


### PR DESCRIPTION
revert part of https://github.com/KomodoPlatform/coins/pull/870
keep the dynamic fee
set dust back to original setting to not waste txfees (using `harddustlimit=0.002` on the electrums now to filter out spam txes on the DOGE chain)