### PR TITLE
remove JEUR from forex

### DIFF
--- a/api_ids/forex_ids.json
+++ b/api_ids/forex_ids.json
@@ -16,8 +16,6 @@
     "JCHF-ERC20": "CHF",
     "JCHF-PLG20": "CHF",
     "JCNY-PLG20": "CNY",
-    "JEUR-ERC20": "EUR",
-    "JEUR-PLG20": "EUR",
     "JGBP-ERC20": "GBP",
     "JGBP-PLG20": "GBP",
     "JGOLD-PLG20": "XAU",


### PR DESCRIPTION
JEUR has de-pegged, see https://www.coingecko.com/en/categories/eur-stablecoin 