### PR TITLE
fix DGB txfee

### DIFF
--- a/coins
+++ b/coins
@@ -3686,7 +3686,7 @@
     "pubtype": 30,
     "p2shtype": 63,
     "wiftype": 128,
-    "txfee": 100000,
+    "txfee": 10000000,
     "segwit": true,
     "bech32_hrp": "dgb",
     "mm2": 1,
@@ -3712,7 +3712,7 @@
     "pubtype": 30,
     "p2shtype": 63,
     "wiftype": 128,
-    "txfee": 100000,
+    "txfee": 10000000,
     "segwit": true,
     "bech32_hrp": "dgb",
     "address_format": {


### PR DESCRIPTION
https://github.com/DigiByte-Core/digibyte/releases: "Minimum Transaction Fee Increase: The minimum transaction fee has been increased from 0.001 DGB to 0.1 DGB per kilobyte."

`src/wallet/wallet.h:static const CAmount DEFAULT_TRANSACTION_MINFEE = 10000000;`