### PR TITLE
Change GH action script author to bot

### DIFF
--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: update coins json file
-          committer: GitHub <noreply@github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           branch: json-config-update
           delete-branch: true
           title: '[BOT] Update coins config json'

--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -29,9 +29,9 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: update coins json file
-          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          commit-message: Update coins json file
+          committer: github-actions[bot] github-actions[bot]@users.noreply.github.com
+          author: github-actions[bot] github-actions[bot]@users.noreply.github.com
           branch: json-config-update
           delete-branch: true
           title: '[BOT] Update coins config json'


### PR DESCRIPTION
Currently we are showing the commit author of the GH Action for generating the util configs as the GitHub user that triggered the schedule. For unverified commits, it is possible to impersonate any user. Changing this to show as being committed by the GH Action bot solves this issue.

An example of a commit generated by this script: https://github.com/KomodoPlatform/coins/commit/104105bc54ead229da56839646fa95f8027571e9

An example (from a different project) of how this will look:
![image](https://github.com/KomodoPlatform/coins/assets/77973576/9e513d39-147b-4fd6-b04b-31fb69bebf77)
