### PR TITLE
Fix bot commenter syntax

### DIFF
--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -30,8 +30,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: Update coins json file
-          committer: github-actions[bot] github-actions[bot]@users.noreply.github.com
-          author: github-actions[bot] github-actions[bot]@users.noreply.github.com
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           branch: json-config-update
           delete-branch: true
           title: '[BOT] Update coins config json'


### PR DESCRIPTION
The required syntax in this context differs from the syntax of the place where this was taken from.

Example (not applicable here):
https://github.com/pypa/pipenv/issues/4328#issue-633926841
```diff
+        git config --local user.name 'github-actions[bot]'
+        git config --local user.email 'github-actions[bot]@users.noreply.github.com'
```

It should be in the format of:
`John <JohnDoe@users.noreply.github.com>`

Failed GH run:
https://github.com/KomodoPlatform/coins/actions/runs/9025141493/job/24800324104#step:5:47