### PR TITLE
adds coins_config_unfiltered.json

### DIFF
--- a/utils/coins_config.json
+++ b/utils/coins_config.json
@@ -778,6 +778,24 @@
         },
         "electrum": [
             {
+                "url": "aby-ex-four.ewmci.online:50011",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "aby-ex-four.ewmci.online:50012",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "elec-seeder-one.artbytecoin.org:50012",
                 "protocol": "SSL",
                 "disable_cert_verification": true
@@ -789,6 +807,15 @@
             {
                 "url": "electrumx-three.artbyte.live:50012",
                 "protocol": "SSL"
+            },
+            {
+                "url": "aby-ex-four.ewmci.online:50013",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
             },
             {
                 "url": "elec-seeder-one.artbytecoin.org:50013",
@@ -5892,24 +5919,12 @@
         "derivation_path": "m/44'/664'",
         "electrum": [
             {
-                "url": "electrumserver01.globalboost.info:50011",
-                "protocol": "TCP"
-            },
-            {
                 "url": "electrumserver02.globalboost.info:50011",
                 "protocol": "TCP"
             },
             {
-                "url": "electrumserver01.globalboost.info:50014",
-                "protocol": "SSL"
-            },
-            {
                 "url": "electrumserver02.globalboost.info:50014",
                 "protocol": "SSL"
-            },
-            {
-                "url": "electrumserver01.globalboost.info:50013",
-                "protocol": "WSS"
             },
             {
                 "url": "electrumserver02.globalboost.info:50013",
@@ -8104,6 +8119,18 @@
             },
             {
                 "url": "electrum1.mooo.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.mooo.com:10007",
                 "contact": [
                     {
                         "email": "support@shorelinecrypto.com"
@@ -12523,7 +12550,17 @@
                 "disable_cert_verification": true
             },
             {
+                "url": "electrum3.egulden.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
                 "url": "electrum1.egulden.org:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "electrum3.egulden.org:50004",
                 "protocol": "WSS",
                 "disable_cert_verification": true
             }
@@ -18696,6 +18733,24 @@
         },
         "electrum": [
             {
+                "url": "il8p-ex-five.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "il8p-ex-five.ewmci.online:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "il8p.electrumx.transcenders.name:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -18736,6 +18791,15 @@
                     },
                     {
                         "github": "WikiMin3R"
+                    }
+                ]
+            },
+            {
+                "url": "il8p-ex-five.ewmci.online:50003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
                     }
                 ]
             },
@@ -26209,6 +26273,18 @@
                     }
                 ],
                 "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.mooo.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block/"
@@ -27983,6 +28059,10 @@
         "electrum": [
             {
                 "url": "pink-one.ewm-cx.net:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "pink-two.ewm-cx.net:50001",
                 "protocol": "TCP"
             }
         ],
@@ -30185,19 +30265,11 @@
                 "protocol": "SSL"
             },
             {
-                "url": "electrum03.reddcoin.com:50002",
-                "protocol": "SSL"
-            },
-            {
                 "url": "electrum01.reddcoin.com:50004",
                 "protocol": "WSS"
             },
             {
                 "url": "electrum02.reddcoin.com:50004",
-                "protocol": "WSS"
-            },
-            {
-                "url": "electrum03.reddcoin.com:50004",
                 "protocol": "WSS"
             }
         ],
@@ -31378,21 +31450,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.ridethebullcoin.com:10002",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "email": "rtbadmin@ridethebullcoin.com"
-                    },
-                    {
-                        "github": "RTBCoin"
-                    },
-                    {
-                        "discord": "rtbcoin"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx2.ridethebullcoin.com:10002",
                 "protocol": "TCP",
                 "contact": [
@@ -31408,38 +31465,8 @@
                 ]
             },
             {
-                "url": "electrumx1.ridethebullcoin.com:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "rtbadmin@ridethebullcoin.com"
-                    },
-                    {
-                        "github": "RTBCoin"
-                    },
-                    {
-                        "discord": "rtbcoin"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx2.ridethebullcoin.com:20053",
                 "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "rtbadmin@ridethebullcoin.com"
-                    },
-                    {
-                        "github": "RTBCoin"
-                    },
-                    {
-                        "discord": "rtbcoin"
-                    }
-                ]
-            },
-            {
-                "url": "electrumx1.ridethebullcoin.com:20052",
-                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "rtbadmin@ridethebullcoin.com"
@@ -35717,8 +35744,18 @@
         },
         "electrum": [
             {
+                "url": "failover.trc-uis.ewmcx.biz:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": false
+            },
+            {
                 "url": "uis-uno.ewmcx.net:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": false
+            },
+            {
+                "url": "failover.trc-uis.ewmcx.biz:50003",
+                "protocol": "WSS",
                 "disable_cert_verification": false
             },
             {
@@ -36222,8 +36259,18 @@
         },
         "electrum": [
             {
+                "url": "uno-bkp.coinmunity.gold:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
                 "url": "uno-main.coinmunity.gold:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "uno-bkp.coinmunity.gold:50003",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             },
             {
@@ -38330,57 +38377,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "VPRM": {
-        "coin": "VPRM",
-        "type": "Smart Chain",
-        "name": "Vaporum",
-        "coinpaprika_id": "vprm-vaporum-coin",
-        "coingecko_id": "vaporum-coin",
-        "livecoinwatch_id": "VPRM",
-        "explorer_url": "http://explorer.vaporumcoin.us/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "VPRM",
-        "fname": "Vaporum",
-        "rpcport": 51609,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx1.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ],
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx2.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ],
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "VTC": {
         "coin": "VTC",
         "type": "UTXO",
@@ -40107,6 +40103,24 @@
                 "protocol": "TCP"
             },
             {
+                "url": "xvc-ex-seven.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "xvc-ex-seven.ewmci.online:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx1.vanillacash.info:50013",
                 "protocol": "WSS"
             },
@@ -40354,18 +40368,6 @@
             {
                 "url": "88.99.26.209:5036",
                 "protocol": "TCP"
-            },
-            {
-                "url": "electrumx-verge.cloud:50001",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx-verge.cloud:50002",
-                "protocol": "SSL"
-            },
-            {
-                "url": "electrumx-verge.cloud:50004",
-                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/",
@@ -41234,10 +41236,6 @@
                 ]
             },
             {
-                "url": "zeta-seed-d.zetacoin.network:50012",
-                "protocol": "SSL"
-            },
-            {
                 "url": "zet-ex-three.ewmci.online:50013",
                 "protocol": "WSS",
                 "contact": [
@@ -41245,10 +41243,6 @@
                         "discord": "475820011634819072"
                     }
                 ]
-            },
-            {
-                "url": "zeta-seed-d.zetacoin.network:50013",
-                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -45144,6 +45138,18 @@
         },
         "electrum": [
             {
+                "url": "electrum2.runebase.io:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
                 "url": "electrum3.runebase.io:50001",
                 "protocol": "TCP",
                 "contact": [
@@ -45168,6 +45174,18 @@
                 ]
             },
             {
+                "url": "electrum2.runebase.io:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
                 "url": "electrum3.runebase.io:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -45182,6 +45200,18 @@
             {
                 "url": "electrum4.runebase.io:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.runebase.io:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "support@runebase.io"
@@ -45662,119 +45692,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "CRNC": {
-        "coin": "CRNC",
-        "type": "UTXO",
-        "name": "CrionicCoin",
-        "coinpaprika_id": "crnc-crionic",
-        "coingecko_id": "crionic",
-        "livecoinwatch_id": "CRNC",
-        "explorer_url": "https://explorer.crionic.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Crioniccoin Signed Message:\n",
-        "fname": "CrionicCoin",
-        "rpcport": 4466,
-        "pubtype": 28,
-        "p2shtype": 45,
-        "wiftype": 176,
-        "decimals": 8,
-        "signature_version": "base",
-        "txfee": 10000,
-        "segwit": true,
-        "bech32_hrp": "crnc",
-        "mm2": 1,
-        "required_confirmations": 3,
-        "avg_blocktime": 20,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "links": {
-            "github": "https://github.com/diabaths/Crionic-Coin",
-            "homepage": "https://coin.crionic.org"
-        },
-        "electrum": [
-            {
-                "url": "coin.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ],
-                "protocol": "TCP"
-            },
-            {
-                "url": "explorer.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ],
-                "protocol": "TCP"
-            },
-            {
-                "url": "coin.crionic.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "explorer.crionic.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "coin.crionic.org:50005",
-                "protocol": "WSS",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "explorer.crionic.org:50005",
-                "protocol": "WSS",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "EVR": {
         "coin": "EVR",
         "type": "UTXO",
@@ -45919,35 +45836,8 @@
         },
         "electrum": [
             {
-                "url": "electrum1.kiirocoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "1155906841625239684"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.kiirocoin.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.kiirocoin.org:50002",
                 "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.kiirocoin.org:50004",
-                "protocol": "WSS",
                 "contact": [
                     {
                         "github": "https://github.com/kiirocoin/electrum-kiiro/issues"

--- a/utils/coins_config_tcp.json
+++ b/utils/coins_config_tcp.json
@@ -742,16 +742,21 @@
         },
         "electrum": [
             {
+                "url": "aby-ex-four.ewmci.online:50012",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "elec-seeder-one.artbytecoin.org:50012",
                 "protocol": "SSL",
                 "disable_cert_verification": true
             },
             {
                 "url": "elec-seeder-two.artbytecoin.org:50012",
-                "protocol": "SSL"
-            },
-            {
-                "url": "electrumx-three.artbyte.live:50012",
                 "protocol": "SSL"
             }
         ],
@@ -5262,15 +5267,11 @@
         "derivation_path": "m/44'/664'",
         "electrum": [
             {
-                "url": "electrumserver01.globalboost.info:50014",
-                "protocol": "SSL"
-            },
-            {
                 "url": "electrumserver02.globalboost.info:50014",
                 "protocol": "SSL"
             },
             {
-                "url": "electrumserver01.globalboost.info:50011",
+                "url": "electrumserver02.globalboost.info:50011",
                 "protocol": "TCP"
             }
         ],
@@ -7082,6 +7083,18 @@
             },
             {
                 "url": "electrum1.mooo.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.mooo.com:10007",
                 "contact": [
                     {
                         "email": "support@shorelinecrypto.com"
@@ -10669,6 +10682,11 @@
         "electrum": [
             {
                 "url": "electrum1.egulden.org:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "electrum3.egulden.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true
             }
@@ -15530,6 +15548,15 @@
             "type": "UTXO"
         },
         "electrum": [
+            {
+                "url": "il8p-ex-five.ewmci.online:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
             {
                 "url": "il8p.electrumx.transcenders.name:50002",
                 "protocol": "SSL",
@@ -21920,6 +21947,18 @@
                     }
                 ],
                 "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.mooo.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block/"
@@ -23426,6 +23465,10 @@
         "electrum": [
             {
                 "url": "pink-one.ewm-cx.net:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "pink-two.ewm-cx.net:50001",
                 "protocol": "TCP"
             }
         ],
@@ -25196,10 +25239,6 @@
             {
                 "url": "electrum02.reddcoin.com:50002",
                 "protocol": "SSL"
-            },
-            {
-                "url": "electrum03.reddcoin.com:50002",
-                "protocol": "SSL"
             }
         ],
         "explorer_block_url": "block/"
@@ -26153,21 +26192,6 @@
         },
         "electrum": [
             {
-                "url": "electrumx1.ridethebullcoin.com:20053",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "rtbadmin@ridethebullcoin.com"
-                    },
-                    {
-                        "github": "RTBCoin"
-                    },
-                    {
-                        "discord": "rtbcoin"
-                    }
-                ]
-            },
-            {
                 "url": "electrumx2.ridethebullcoin.com:20053",
                 "protocol": "SSL",
                 "contact": [
@@ -26183,7 +26207,7 @@
                 ]
             },
             {
-                "url": "electrumx1.ridethebullcoin.com:10002",
+                "url": "electrumx2.ridethebullcoin.com:10002",
                 "protocol": "TCP",
                 "contact": [
                     {
@@ -29896,6 +29920,11 @@
         },
         "electrum": [
             {
+                "url": "failover.trc-uis.ewmcx.biz:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": false
+            },
+            {
                 "url": "uis-uno.ewmcx.net:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false
@@ -30371,6 +30400,11 @@
             "homepage": "https://unobtanium.uno"
         },
         "electrum": [
+            {
+                "url": "uno-bkp.coinmunity.gold:50002",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
             {
                 "url": "uno-main.coinmunity.gold:50002",
                 "protocol": "SSL",
@@ -32116,57 +32150,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "VPRM": {
-        "coin": "VPRM",
-        "type": "Smart Chain",
-        "name": "Vaporum",
-        "coinpaprika_id": "vprm-vaporum-coin",
-        "coingecko_id": "vaporum-coin",
-        "livecoinwatch_id": "VPRM",
-        "explorer_url": "http://explorer.vaporumcoin.us/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Komodo Signed Message:\n",
-        "asset": "VPRM",
-        "fname": "Vaporum",
-        "rpcport": 51609,
-        "txversion": 4,
-        "overwintered": 1,
-        "mm2": 1,
-        "required_confirmations": 5,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/141'",
-        "trezor_coin": "Komodo",
-        "electrum": [
-            {
-                "url": "electrumx1.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ],
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx2.vaporumcoin.us:50001",
-                "contact": [
-                    {
-                        "github": "VaporumCoin"
-                    }
-                ],
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "VTC": {
         "coin": "VTC",
         "type": "UTXO",
@@ -33714,6 +33697,15 @@
         },
         "electrum": [
             {
+                "url": "xvc-ex-seven.ewmci.online:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx1.vanillacash.info:50011",
                 "protocol": "TCP"
             },
@@ -33887,15 +33879,7 @@
         "derivation_path": "m/44'/77'",
         "electrum": [
             {
-                "url": "electrumx-verge.cloud:50002",
-                "protocol": "SSL"
-            },
-            {
                 "url": "88.99.26.209:5036",
-                "protocol": "TCP"
-            },
-            {
-                "url": "electrumx-verge.cloud:50001",
                 "protocol": "TCP"
             }
         ],
@@ -34588,12 +34572,17 @@
                 ]
             },
             {
-                "url": "zeta-seed-d.zetacoin.network:50012",
-                "protocol": "SSL"
-            },
-            {
                 "url": "207.180.252.200:50011",
                 "protocol": "TCP"
+            },
+            {
+                "url": "zet-ex-three.ewmci.online:50011",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -37603,6 +37592,18 @@
         },
         "electrum": [
             {
+                "url": "electrum2.runebase.io:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
                 "url": "electrum3.runebase.io:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -37617,18 +37618,6 @@
             {
                 "url": "electrum4.runebase.io:50002",
                 "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "support@runebase.io"
-                    },
-                    {
-                        "discord": "Bago#7842"
-                    }
-                ]
-            },
-            {
-                "url": "electrum3.runebase.io:50001",
-                "protocol": "TCP",
                 "contact": [
                     {
                         "email": "support@runebase.io"
@@ -38016,83 +38005,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "CRNC": {
-        "coin": "CRNC",
-        "type": "UTXO",
-        "name": "CrionicCoin",
-        "coinpaprika_id": "crnc-crionic",
-        "coingecko_id": "crionic",
-        "livecoinwatch_id": "CRNC",
-        "explorer_url": "https://explorer.crionic.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Crioniccoin Signed Message:\n",
-        "fname": "CrionicCoin",
-        "rpcport": 4466,
-        "pubtype": 28,
-        "p2shtype": 45,
-        "wiftype": 176,
-        "decimals": 8,
-        "signature_version": "base",
-        "txfee": 10000,
-        "segwit": true,
-        "bech32_hrp": "crnc",
-        "mm2": 1,
-        "required_confirmations": 3,
-        "avg_blocktime": 20,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "links": {
-            "github": "https://github.com/diabaths/Crionic-Coin",
-            "homepage": "https://coin.crionic.org"
-        },
-        "electrum": [
-            {
-                "url": "coin.crionic.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "explorer.crionic.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "coin.crionic.org:50001",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ],
-                "protocol": "TCP"
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "EVR": {
         "coin": "EVR",
         "type": "UTXO",
@@ -38201,29 +38113,11 @@
         },
         "electrum": [
             {
-                "url": "electrum1.kiirocoin.org:50002",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
-                    }
-                ]
-            },
-            {
                 "url": "electrum3.kiirocoin.org:50002",
                 "protocol": "SSL",
                 "contact": [
                     {
                         "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.kiirocoin.org:50001",
-                "protocol": "TCP",
-                "contact": [
-                    {
-                        "discord": "1155906841625239684"
                     }
                 ]
             }

--- a/utils/coins_config_unfiltered.json
+++ b/utils/coins_config_unfiltered.json
@@ -778,6 +778,15 @@
         },
         "electrum": [
             {
+                "url": "aby-ex-four.ewmci.online:50011",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "aby-ex-four.ewmci.online:50012",
                 "protocol": "SSL",
                 "contact": [
@@ -794,6 +803,32 @@
             {
                 "url": "elec-seeder-two.artbytecoin.org:50012",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrumx-three.artbyte.live:50012",
+                "protocol": "SSL"
+            },
+            {
+                "url": "aby-ex-four.ewmci.online:50013",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "elec-seeder-one.artbytecoin.org:50013",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "elec-seeder-two.artbytecoin.org:50013",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrumx-three.artbyte.live:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -1226,6 +1261,68 @@
         ],
         "explorer_block_url": "block/"
     },
+    "AIBC": {
+        "coin": "AIBC",
+        "type": "UTXO",
+        "name": "Aiblockchain",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "http://95.111.231.8:3001/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Aiblockchain",
+        "rpcport": 7772,
+        "pubtype": 23,
+        "p2shtype": 23,
+        "wiftype": 176,
+        "txfee": 0,
+        "dust": 5460,
+        "segwit": true,
+        "mm2": 1,
+        "required_confirmations": 11,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO",
+            "bip44": "m/44'/2'/0'/0/0"
+        },
+        "links": {
+            "github": "https://github.com/nickgsh/AiBlockChain",
+            "homepage": "https://aibc.space/"
+        },
+        "electrum": [
+            {
+                "url": "aibc.pro:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "electrum1_admin@aibc.pro"
+                    },
+                    {
+                        "github": "nickgsh"
+                    }
+                ]
+            },
+            {
+                "url": "aibc.pro:50002",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "electrum1_admin@aibc.pro"
+                    },
+                    {
+                        "github": "nickgsh"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "AIPG": {
         "coin": "AIPG",
         "type": "UTXO",
@@ -1274,6 +1371,24 @@
             {
                 "url": "electrumx2.aipowergrid.io:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "482101557383528448"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.aipowergrid.io:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "482101557383528448"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.aipowergrid.io:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "482101557383528448"
@@ -1872,6 +1987,42 @@
         "checkpoint_blocktime": 1652512363,
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10008",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10008",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10008",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20008",
                 "protocol": "SSL",
                 "contact": [
@@ -1898,6 +2049,42 @@
             {
                 "url": "electrum3.cipig.net:20008",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30008",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30008",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30008",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -2098,6 +2285,16 @@
             {
                 "url": "failover.aur.ewmcx.biz:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "electrumx.aur.ewmcx.info:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "failover.aur.ewmcx.biz:50003",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             }
         ],
@@ -2370,6 +2567,33 @@
         "derivation_path": "m/44'/921'",
         "electrum": [
             {
+                "url": "electrum-ca.avn.network:50001",
+                "contact": [
+                    {
+                        "email": "contact@avn.network"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum-eu.avn.network:50001",
+                "contact": [
+                    {
+                        "email": "contact@avn.network"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum-us.avn.network:50001",
+                "contact": [
+                    {
+                        "email": "contact@avn.network"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum-ca.avn.network:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -2390,6 +2614,33 @@
             {
                 "url": "electrum-us.avn.network:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "contact@avn.network"
+                    }
+                ]
+            },
+            {
+                "url": "electrum-ca.avn.network:50003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "contact@avn.network"
+                    }
+                ]
+            },
+            {
+                "url": "electrum-eu.avn.network:50003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "contact@avn.network"
+                    }
+                ]
+            },
+            {
+                "url": "electrum-us.avn.network:50003",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "contact@avn.network"
@@ -2546,6 +2797,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10057",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10057",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10057",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20057",
                 "protocol": "SSL",
                 "contact": [
@@ -2572,6 +2859,42 @@
             {
                 "url": "electrum3.cipig.net:20057",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30057",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30057",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30057",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -2691,6 +3014,45 @@
                 "contact": {
                     "email": "cipi@komodoplatform.com"
                 }
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "AYA": {
+        "coin": "AYA",
+        "type": "UTXO",
+        "name": "Aryacoin",
+        "coinpaprika_id": "aya-aryacoin",
+        "coingecko_id": "aryacoin",
+        "livecoinwatch_id": "AYA",
+        "explorer_url": "https://explorer.aryacoin.io/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Aryacoin Signed Message:\n",
+        "fname": "Aryacoin",
+        "rpcport": 9332,
+        "pubtype": 23,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 100000,
+        "dust": 54600,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/357'",
+        "electrum": [
+            {
+                "url": "88.99.26.209:5151",
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block/"
@@ -3556,6 +3918,18 @@
         "slp_prefix": "simpleledger",
         "electrum": [
             {
+                "url": "electrum3.cipig.net:10055",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "bch.imaginary.cash:50002",
                 "protocol": "SSL"
             },
@@ -3566,6 +3940,42 @@
             {
                 "url": "cashnode.bch.ninja:50002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum3.cipig.net:20055",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "bch.imaginary.cash:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "bch.soul-dev.com:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "cashnode.bch.ninja:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.cipig.net:30055",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/",
@@ -3954,6 +4364,50 @@
         "token_address_url": "token/",
         "explorer_block_url": "block/"
     },
+    "BBK": {
+        "coin": "BBK",
+        "type": "UTXO",
+        "name": "BitBlocks",
+        "coinpaprika_id": "bbk-bitblocks",
+        "coingecko_id": "",
+        "livecoinwatch_id": "BBK",
+        "explorer_url": "https://chainz.cryptoid.info/bbk/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": true,
+        "sign_message_prefix": "DarkNet Signed Message:\n",
+        "fname": "BitBlocks",
+        "rpcport": 59768,
+        "pubtype": 25,
+        "p2shtype": 85,
+        "wiftype": 107,
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "links": {
+            "github": "https://github.com/BitBlocksProject/BitBlocks",
+            "homepage": "https://bitblocksproject.com"
+        },
+        "electrum": [
+            {
+                "url": "bbk-one.ewm-cx.net:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "bbk-two.ewm-cx.net:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
     "BBK-BEP20": {
         "coin": "BBK-BEP20",
         "type": "BEP-20",
@@ -4255,6 +4709,58 @@
         "explorer_block_url": "block/",
         "forex_id": "IDR"
     },
+    "BITN": {
+        "coin": "BITN",
+        "type": "UTXO",
+        "name": "Bitnet",
+        "coinpaprika_id": "bit-bitnet",
+        "coingecko_id": "bitnet-io",
+        "livecoinwatch_id": "________BIT",
+        "explorer_url": "https://bitexplorer.io/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "address/",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Bitnet Signed Message:\n",
+        "fname": "Bitnet",
+        "rpcport": 9332,
+        "pubtype": 25,
+        "p2shtype": 22,
+        "wiftype": 158,
+        "txfee": 700000,
+        "segwit": true,
+        "bech32_hrp": "bit",
+        "mm2": 1,
+        "required_confirmations": 1,
+        "avg_blocktime": 600,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [
+            {
+                "url": "bitexplorer.io:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "c4pt#7855"
+                    }
+                ]
+            },
+            {
+                "url": "bitexplorer.io:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "c4pt#7855"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "BLK": {
         "coin": "BLK",
         "type": "UTXO",
@@ -4290,6 +4796,33 @@
         "derivation_path": "m/44'/10'",
         "electrum": [
             {
+                "url": "electrum1.blackcoin.nl:10001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.blackcoin.nl:20001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.blackcoin.nl:30001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.blackcoin.nl:10002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -4312,6 +4845,36 @@
             {
                 "url": "electrum3.blackcoin.nl:30002",
                 "protocol": "SSL",
+                "disable_cert_verification": false,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.blackcoin.nl:10004",
+                "protocol": "WSS",
+                "disable_cert_verification": false,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.blackcoin.nl:20004",
+                "protocol": "WSS",
+                "disable_cert_verification": false,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.blackcoin.nl:30004",
+                "protocol": "WSS",
                 "disable_cert_verification": false,
                 "contact": [
                     {
@@ -4402,6 +4965,33 @@
         },
         "electrum": [
             {
+                "url": "electrum1.blackcoin.nl:10011",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.blackcoin.nl:20011",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.blackcoin.nl:30011",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.blackcoin.nl:10012",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -4424,6 +5014,36 @@
             {
                 "url": "electrum3.blackcoin.nl:30012",
                 "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.blackcoin.nl:10014",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.blackcoin.nl:20014",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.blackcoin.nl:30014",
+                "protocol": "WSS",
                 "disable_cert_verification": true,
                 "contact": [
                     {
@@ -4469,12 +5089,28 @@
         },
         "electrum": [
             {
+                "url": "electrum1.blocx.live:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.blocx.live:50001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.blocx.live:50002",
                 "protocol": "SSL"
             },
             {
                 "url": "electrum2.blocx.live:50002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum1.blocx.live:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.blocx.live:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -4524,6 +5160,49 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/",
         "binance_id": "BNB"
+    },
+    "BOLI": {
+        "coin": "BOLI",
+        "type": "UTXO",
+        "name": "Bolivarcoin",
+        "coinpaprika_id": "boli-bolivarcoin",
+        "coingecko_id": "bolivarcoin",
+        "livecoinwatch_id": "BOLI",
+        "explorer_url": "https://chainz.cryptoid.info/boli/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "DarkCoin Signed Message:\n",
+        "fname": "Bolivarcoin",
+        "confpath": "USERHOME/.bolivarcoincore/bolivarcoin.conf",
+        "rpcport": 3563,
+        "pubtype": 85,
+        "p2shtype": 5,
+        "wiftype": 213,
+        "segwit": false,
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 3,
+        "avg_blocktime": 180,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/278'",
+        "links": {
+            "github": "https://github.com/BOLI-Project/BolivarCoin",
+            "homepage": "https://bolis.info"
+        },
+        "electrum": [
+            {
+                "url": "electrum2.bolivarcoin.tech:23001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
     },
     "BONE-ERC20": {
         "coin": "BONE-ERC20",
@@ -5240,8 +5919,16 @@
         "derivation_path": "m/44'/664'",
         "electrum": [
             {
+                "url": "electrumserver02.globalboost.info:50011",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrumserver02.globalboost.info:50014",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrumserver02.globalboost.info:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -5285,6 +5972,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10000",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10000",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10000",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20000",
                 "protocol": "SSL",
                 "contact": [
@@ -5311,6 +6034,42 @@
             {
                 "url": "electrum3.cipig.net:20000",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30000",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30000",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30000",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -5367,6 +6126,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10000",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10000",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10000",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20000",
                 "protocol": "SSL",
                 "contact": [
@@ -5393,6 +6188,42 @@
             {
                 "url": "electrum3.cipig.net:20000",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30000",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30000",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30000",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -5454,6 +6285,78 @@
         "explorer_block_url": "block/",
         "binance_id": "BTC"
     },
+    "BTCZ": {
+        "coin": "BTCZ",
+        "type": "UTXO",
+        "name": "BitcoinZ",
+        "coinpaprika_id": "btcz-bitcoinz",
+        "coingecko_id": "bitcoinz",
+        "livecoinwatch_id": "BTCZ",
+        "explorer_url": "https://explorer.btcz.rocks/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "address/",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "BitcoinZ Signed Message:\n",
+        "fname": "BitcoinZ",
+        "rpcport": 1979,
+        "taddr": 28,
+        "pubtype": 184,
+        "p2shtype": 189,
+        "wiftype": 128,
+        "txfee": 10000,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/177'",
+        "electrum": [
+            {
+                "url": "electrum1.btcz.rocks:50001",
+                "contact": [
+                    {
+                        "discord": "VandarGR#6065"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.btcz.rocks:50001",
+                "contact": [
+                    {
+                        "discord": "VandarGR#6065"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum1.btcz.rocks:50004",
+                "contact": [
+                    {
+                        "discord": "VandarGR#6065"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.btcz.rocks:50004",
+                "contact": [
+                    {
+                        "discord": "VandarGR#6065"
+                    }
+                ],
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "BTCZ-BEP20": {
         "coin": "BTCZ-BEP20",
         "type": "BEP-20",
@@ -5500,6 +6403,74 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "BTE": {
+        "coin": "BTE",
+        "type": "UTXO",
+        "name": "Bitweb",
+        "coinpaprika_id": "bte-bitweb",
+        "coingecko_id": "bitweb",
+        "livecoinwatch_id": "_BTE",
+        "explorer_url": "https://explorer.bitwebcore.net/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Bitweb",
+        "rpcport": 1605,
+        "pubtype": 33,
+        "p2shtype": 30,
+        "wiftype": 128,
+        "segwit": true,
+        "bech32_hrp": "web",
+        "txfee": 20000,
+        "mm2": 1,
+        "required_confirmations": 3,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
+        "explorer_block_url": "block/"
+    },
+    "BTE-segwit": {
+        "coin": "BTE-segwit",
+        "type": "UTXO",
+        "name": "Bitweb",
+        "coinpaprika_id": "bte-bitweb",
+        "coingecko_id": "bitweb",
+        "livecoinwatch_id": "_BTE",
+        "explorer_url": "https://explorer.bitwebcore.net/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Bitweb",
+        "rpcport": 1605,
+        "pubtype": 33,
+        "p2shtype": 30,
+        "wiftype": 128,
+        "segwit": true,
+        "bech32_hrp": "web",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "BTE",
+        "txfee": 20000,
+        "mm2": 1,
+        "required_confirmations": 3,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
         "explorer_block_url": "block/"
     },
     "BTT-BEP20": {
@@ -5758,6 +6729,16 @@
                         "discord": "[MadCatMining]#0677"
                     }
                 ]
+            },
+            {
+                "url": "btx-electrumx.coinsmunity.com:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "[MadCatMining]#0677"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -5805,6 +6786,16 @@
             {
                 "url": "btx-electrumx.coinsmunity.com:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "[MadCatMining]#0677"
+                    }
+                ]
+            },
+            {
+                "url": "btx-electrumx.coinsmunity.com:50003",
+                "protocol": "WSS",
                 "disable_cert_verification": true,
                 "contact": [
                     {
@@ -6405,6 +7396,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10029",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10029",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10029",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20029",
                 "protocol": "SSL",
                 "contact": [
@@ -6431,6 +7458,42 @@
             {
                 "url": "electrum3.cipig.net:20029",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30029",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30029",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30029",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -6490,6 +7553,41 @@
                 "url": "miami.ecoincore.com:34333",
                 "protocol": "SSL",
                 "disable_cert_verification": true
+            },
+            {
+                "url": "mumbai.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "oakland.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "woolloomooloo.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "holland.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "miami.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "mumbai.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "woolloomooloo.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -6544,6 +7642,41 @@
             {
                 "url": "miami.ecoincore.com:34333",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "mumbai.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "oakland.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "woolloomooloo.ecoincore.com:34333",
+                "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "holland.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "miami.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "mumbai.ecoincore.com:34335",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "woolloomooloo.ecoincore.com:34335",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             }
         ],
@@ -7011,6 +8144,74 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "CHTA": {
+        "coin": "CHTA",
+        "type": "UTXO",
+        "name": "Cheetahcoin",
+        "coinpaprika_id": "chta-cheetahcoin",
+        "coingecko_id": "cheetahcoin",
+        "livecoinwatch_id": "CHTA",
+        "explorer_url": "http://chtaexplorer.mooo.com:3002/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Cheetahcoin",
+        "rpcport": 8536,
+        "pubtype": 28,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 40000,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 120,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/682'",
+        "electrum": [
+            {
+                "url": "electrum.shorelinecrypto.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum1.mooo.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.mooo.com:10007",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "CHTA-BEP20": {
         "coin": "CHTA-BEP20",
         "type": "BEP-20",
@@ -7090,6 +8291,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10053",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10053",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10053",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20053",
                 "protocol": "SSL",
                 "contact": [
@@ -7116,6 +8353,42 @@
             {
                 "url": "electrum3.cipig.net:20053",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30053",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30053",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30053",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -7435,8 +8708,26 @@
         },
         "electrum": [
             {
+                "url": "clam-ex-one.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "clam-ex-one.ewmci.online:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "clam-ex-one.ewmci.online:50003",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "475820011634819072"
@@ -7445,6 +8736,52 @@
             }
         ],
         "explorer_block_url": "block.dws?"
+    },
+    "CLC": {
+        "coin": "CLC",
+        "type": "Smart Chain",
+        "name": "Collider Coin",
+        "coinpaprika_id": "clc-collider-coin",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://clc.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "CLC",
+        "fname": "Collider Coin",
+        "rpcport": 31034,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "requires_notarization": false,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "electrumx.cryptocollider.com:10001",
+                "contact": [
+                    {
+                        "email": "electrumx@cryptocollider.com"
+                    },
+                    {
+                        "discord": "collider#6160"
+                    }
+                ],
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
     },
     "CLP-BEP20": {
         "coin": "CLP-BEP20",
@@ -7492,6 +8829,34 @@
         ],
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
+    },
+    "COLX": {
+        "coin": "COLX",
+        "type": "UTXO",
+        "name": "ColossusXT",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://chainz.cryptoid.info/colx/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "ColossusXT",
+        "rpcport": 51473,
+        "pubtype": 30,
+        "p2shtype": 13,
+        "wiftype": 212,
+        "txfee": 1000000000,
+        "mm2": 1,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/1999'",
+        "explorer_block_url": "block.dws?"
     },
     "COMP-AVX20": {
         "coin": "COMP-AVX20",
@@ -7944,6 +9309,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -7970,6 +9371,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -8446,6 +9883,30 @@
                         "discord": "ruaxxx#3151"
                     }
                 ]
+            },
+            {
+                "url": "electrum02.cyberyen.work:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum03.cyberyen.work:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -8505,6 +9966,30 @@
             {
                 "url": "electrum03.cyberyen.work:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum02.cyberyen.work:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "ruaxxx@ruaxxx.com"
+                    },
+                    {
+                        "discord": "ruaxxx#3151"
+                    }
+                ]
+            },
+            {
+                "url": "electrum03.cyberyen.work:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "ruaxxx@ruaxxx.com"
@@ -8900,6 +10385,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10061",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10061",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10061",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20061",
                 "protocol": "SSL",
                 "contact": [
@@ -8926,6 +10447,42 @@
             {
                 "url": "electrum3.cipig.net:20061",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30061",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30061",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30061",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9261,6 +10818,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10059",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10059",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10059",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20059",
                 "protocol": "SSL",
                 "contact": [
@@ -9287,6 +10880,42 @@
             {
                 "url": "electrum3.cipig.net:20059",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30059",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9342,6 +10971,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10059",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10059",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10059",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20059",
                 "protocol": "SSL",
                 "contact": [
@@ -9368,6 +11033,42 @@
             {
                 "url": "electrum3.cipig.net:20059",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30059",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30059",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -9412,8 +11113,17 @@
         "derivation_path": "m/44'/18'",
         "electrum": [
             {
+                "url": "electrumx.dgc.ewmcx.org:50001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "failover.dgc.ewmcx.biz:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "failover.dgc.ewmcx.biz:50003",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             }
         ],
@@ -9601,6 +11311,51 @@
                         "github": "https://github.com/dpowcore-project/electrumx/issues"
                     }
                 ]
+            },
+            {
+                "url": "electrumxdpc.bitwebcore.net:22003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "mraksoll@gmail.com"
+                    },
+                    {
+                        "discord": "mraksoll"
+                    },
+                    {
+                        "github": "https://github.com/dpowcore-project/electrumx/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumxdpc1.bitwebcore.net:22003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "mraksoll@gmail.com"
+                    },
+                    {
+                        "discord": "mraksoll"
+                    },
+                    {
+                        "github": "https://github.com/dpowcore-project/electrumx/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumxdpc2.bitwebcore.net:22003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "mraksoll@gmail.com"
+                    },
+                    {
+                        "discord": "mraksoll"
+                    },
+                    {
+                        "github": "https://github.com/dpowcore-project/electrumx/issues"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -9663,9 +11418,83 @@
                         "discord": "cipi#4502"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.cipig.net:30072",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30072",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
+    },
+    "DIME": {
+        "coin": "DIME",
+        "type": "UTXO",
+        "name": "Dimecoin",
+        "coinpaprika_id": "dime-dimecoin",
+        "coingecko_id": "dimecoin",
+        "livecoinwatch_id": "DIME",
+        "explorer_url": "https://chainz.cryptoid.info/dime/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Dimecoin Signed Message:\n",
+        "fname": "Dimecoin",
+        "rpcport": 11931,
+        "pubtype": 15,
+        "p2shtype": 9,
+        "wiftype": 143,
+        "segwit": false,
+        "bech32_hrp": "vx",
+        "txfee": 1000,
+        "decimals": 5,
+        "mm2": 1,
+        "required_confirmations": 6,
+        "avg_blocktime": 64,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "links": {
+            "github": "https://github.com/dime-coin/dimecoin/"
+        },
+        "electrum": [
+            {
+                "url": "electrumx.dimecoinnetwork.com:50001",
+                "contact": [
+                    {
+                        "email": "developer@dimecoinnetwork.com"
+                    },
+                    {
+                        "discord": "dhop14#9359"
+                    }
+                ],
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
     },
     "DIMI": {
         "coin": "DIMI",
@@ -9723,6 +11552,38 @@
             {
                 "url": "electrumx2.diminutivecoin.com:50012",
                 "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "email": "support@diminutivecoin.com"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.diminutivecoin.com:50013",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "email": "support@diminutivecoin.com"
+                    },
+                    {
+                        "twitter": "coin_dimi"
+                    },
+                    {
+                        "reddit": "DiminutiveCoin_DIMI"
+                    },
+                    {
+                        "github": "MadCatMining"
+                    },
+                    {
+                        "discord": "[MadCatMining]#0677"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.diminutivecoin.com:50013",
+                "protocol": "WSS",
                 "disable_cert_verification": true,
                 "contact": [
                     {
@@ -9821,6 +11682,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -9847,6 +11744,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10048,6 +11981,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10060",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10060",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10060",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20060",
                 "protocol": "SSL",
                 "contact": [
@@ -10074,6 +12043,42 @@
             {
                 "url": "electrum3.cipig.net:20060",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30060",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30060",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30060",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10134,6 +12139,52 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/",
         "binance_id": "DOGE"
+    },
+    "DOGEC": {
+        "coin": "DOGEC",
+        "type": "UTXO",
+        "name": "DogeCash",
+        "coinpaprika_id": "dogec-dogecash",
+        "coingecko_id": "dogecash",
+        "livecoinwatch_id": "DOGEC",
+        "explorer_url": "https://explorer.dogecash.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "DarkNet Signed Message:\n",
+        "fname": "DogeCash",
+        "rpcport": 56750,
+        "pubtype": 30,
+        "p2shtype": 19,
+        "wiftype": 122,
+        "txfee": 10000,
+        "dust": 5460,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/385'",
+        "links": {
+            "github": "https://github.com/dogecash/dogecash",
+            "homepage": "https://dogecash.net"
+        },
+        "electrum": [
+            {
+                "url": "dogec-one.ewm-cx.com:50006",
+                "protocol": "TCP"
+            },
+            {
+                "url": "dogec-one.ewm-cx.com:50008",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block/"
     },
     "DOGEDASH-BEP20": {
         "coin": "DOGEDASH-BEP20",
@@ -10320,6 +12371,49 @@
         ],
         "explorer_block_url": "block/"
     },
+    "DP": {
+        "coin": "DP",
+        "type": "Smart Chain",
+        "name": "DigitalPrice",
+        "coinpaprika_id": "dp-digitalprice",
+        "coingecko_id": "digitalprice",
+        "livecoinwatch_id": "DP",
+        "explorer_url": "https://dp.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "DP",
+        "fname": "DigitalPrice",
+        "rpcport": 28388,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "requires_notarization": false,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "1.eu.dp.electrum.dexstats.info:10021",
+                "contact": [
+                    {
+                        "discord": "Zanzarismo#6500"
+                    }
+                ],
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "DOI": {
         "coin": "DOI",
         "type": "UTXO",
@@ -10352,6 +12446,16 @@
         },
         "electrum": [
             {
+                "url": "pink-deer-69.doi.works:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues",
+                        "twitter": "example_username"
+                    }
+                ]
+            },
+            {
                 "url": "big-parrot-60.doi.works:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -10383,8 +12487,51 @@
                     }
                 ],
                 "ws-url": "pink-deer-69.doi.works:50004"
+            },
+            {
+                "url": "ugly-bird-70.doi.works:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "github": "https://github.com/doichain/electrum-doi/issues",
+                        "twitter": "example_username"
+                    }
+                ],
+                "ws-url": "ugly-bird-70.doi.works:50004"
             }
         ],
+        "explorer_block_url": "block/"
+    },
+    "DUST": {
+        "coin": "DUST",
+        "type": "Smart Chain",
+        "name": "Dragonfairy",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "http://dragonfairy.gives/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "DRAGONFAIRY",
+        "fname": "Dragonfairy",
+        "rpcport": 62842,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 3,
+        "requires_notarization": false,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
         "explorer_block_url": "block/"
     },
     "ECA": {
@@ -10420,6 +12567,30 @@
         "derivation_path": "m/44'/249'",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10052",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10052",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20052",
                 "protocol": "SSL",
                 "contact": [
@@ -10434,6 +12605,30 @@
             {
                 "url": "electrum2.cipig.net:20052",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30052",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30052",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -10485,6 +12680,16 @@
             {
                 "url": "electrum3.egulden.org:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "electrum1.egulden.org:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "electrum3.egulden.org:50004",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             }
         ],
@@ -10742,6 +12947,42 @@
         "derivation_path": "m/44'/41'",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10062",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10062",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10062",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20062",
                 "protocol": "SSL",
                 "contact": [
@@ -10768,6 +13009,42 @@
             {
                 "url": "electrum3.cipig.net:20062",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30062",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30062",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30062",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -12261,6 +14538,125 @@
         ],
         "explorer_block_url": "block/"
     },
+    "FIRO": {
+        "coin": "FIRO",
+        "type": "UTXO",
+        "name": "Firo",
+        "coinpaprika_id": "firo-firo",
+        "coingecko_id": "zcoin",
+        "livecoinwatch_id": "FIRO",
+        "explorer_url": "https://explorer.firo.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Firo Signed Message:\n",
+        "fname": "Firo",
+        "rpcport": 8888,
+        "pubtype": 82,
+        "p2shtype": 7,
+        "wiftype": 210,
+        "txfee": 1000,
+        "mm2": 1,
+        "required_confirmations": 1,
+        "avg_blocktime": 300,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "trezor_coin": "Firo",
+        "links": {
+            "github": "https://github.com/firoorg/firo",
+            "homepage": "https://firo.org"
+        },
+        "electrum": [
+            {
+                "url": "electrumx.firo.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx01.firo.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx02.firo.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx03.firo.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx05.firo.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ]
+            },
+            {
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ],
+                "url": "electrumx.firo.org:50004"
+            },
+            {
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ],
+                "url": "electrumx01.firo.org:50004"
+            },
+            {
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ],
+                "url": "electrumx02.firo.org:50004"
+            },
+            {
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "github": "https://github.com/firoorg/electrumx-firo/issues"
+                    }
+                ],
+                "url": "electrumx03.firo.org:50004"
+            }
+        ],
+        "explorer_block_url": "block/",
+        "binance_id": "FIRO"
+    },
     "FIRO-BEP20": {
         "coin": "FIRO-BEP20",
         "type": "BEP-20",
@@ -12347,6 +14743,24 @@
         },
         "electrum": [
             {
+                "url": "electrumx1.fujicoin.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx1.fujicoin.org:50003",
                 "protocol": "SSL",
                 "contact": [
@@ -12358,6 +14772,24 @@
             {
                 "url": "electrumx2.fujicoin.org:50003",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.fujicoin.org:50005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50005",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "motty#8318"
@@ -12409,6 +14841,24 @@
         },
         "electrum": [
             {
+                "url": "electrumx1.fujicoin.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx1.fujicoin.org:50003",
                 "protocol": "SSL",
                 "contact": [
@@ -12420,6 +14870,24 @@
             {
                 "url": "electrumx2.fujicoin.org:50003",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx1.fujicoin.org:50005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "motty#8318"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.fujicoin.org:50005",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "motty#8318"
@@ -12630,6 +15098,38 @@
         ],
         "explorer_block_url": "block/"
     },
+    "FLO": {
+        "coin": "FLO",
+        "type": "UTXO",
+        "name": "Florincoin",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Florincoin",
+        "rpcport": 7313,
+        "pubtype": 35,
+        "p2shtype": 8,
+        "wiftype": 176,
+        "txfee": 100000,
+        "mm2": 1,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/216'",
+        "trezor_coin": "Flo",
+        "links": {
+            "github": "https://github.com/floblockchain/flo",
+            "homepage": "https://flo.cash"
+        }
+    },
     "FLOW-BEP20": {
         "coin": "FLOW-BEP20",
         "type": "BEP-20",
@@ -12716,6 +15216,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10054",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10054",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10054",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20054",
                 "protocol": "SSL",
                 "contact": [
@@ -12742,6 +15278,42 @@
             {
                 "url": "electrum3.cipig.net:20054",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30054",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30054",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30054",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -12796,6 +15368,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10054",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10054",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10054",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20054",
                 "protocol": "SSL",
                 "contact": [
@@ -12822,6 +15430,42 @@
             {
                 "url": "electrum3.cipig.net:20054",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30054",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30054",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30054",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -13544,6 +16188,49 @@
         ],
         "explorer_block_url": "block/"
     },
+    "GBX": {
+        "coin": "GBX",
+        "type": "UTXO",
+        "name": "GoByte",
+        "coinpaprika_id": "gbx-gobyte",
+        "coingecko_id": "gobyte",
+        "livecoinwatch_id": "GBX",
+        "explorer_url": "https://insight.gobyte.network/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "DarkCoin Signed Message:\n",
+        "fname": "GoByte",
+        "confpath": "USERHOME/.gobytecore/gobyte.conf",
+        "rpcport": 12454,
+        "pubtype": 38,
+        "p2shtype": 10,
+        "wiftype": 198,
+        "segwit": false,
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 3,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/176'",
+        "links": {
+            "github": "https://github.com/gobytecoin/gobyte",
+            "homepage": "https://gobyte.network"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5128",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "GBX-BEP20": {
         "coin": "GBX-BEP20",
         "type": "BEP-20",
@@ -13676,12 +16363,28 @@
         },
         "electrum": [
             {
+                "url": "electrum1.netseed.net:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.netseed.net:50001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.netseed.net:50002",
                 "protocol": "SSL"
             },
             {
                 "url": "electrum2.netseed.net:50002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum1.netseed.net:50003",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.netseed.net:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -13718,6 +16421,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10022",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:10022",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:10022",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
                 "url": "electrum1.cipig.net:20022",
                 "protocol": "SSL",
                 "contact": [
@@ -13744,6 +16483,42 @@
             {
                 "url": "electrum3.cipig.net:20022",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30022",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30022",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30022",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -14261,6 +17036,24 @@
         "derivation_path": "m/44'/69420'",
         "electrum": [
             {
+                "url": "electrum.maxpuig.com:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "mecs#4770"
+                    }
+                ]
+            },
+            {
+                "url": "electrum.niftybakes.com:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "405566674448810005"
+                    }
+                ]
+            },
+            {
                 "url": "electrum.maxpuig.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -14273,6 +17066,15 @@
                 "url": "uk.garlium.crapules.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "orpheas#1503"
+                    }
+                ]
+            },
+            {
+                "url": "electrum.maxpuig.com:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "orpheas#1503"
@@ -14429,6 +17231,354 @@
         },
         "electrum": [
             {
+                "url": "electrum1.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum12.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum13.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum14.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum15.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum16.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum17.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum18.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum19.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum20.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum21.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum22.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum23.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum24.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum25.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum26.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum27.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum28.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum31.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum32.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum33.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum34.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum35.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum36.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum37.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum38.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum39.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum40.groestlcoin.org:50001",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum11.groestlcoin.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false,
@@ -14440,6 +17590,367 @@
                         "discord": "jackielove4u#0412"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum11.groestlcoin.org:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": false,
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ]
+            },
+            {
+                "url": "electrum12.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum13.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum14.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum15.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum16.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum17.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum18.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum19.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum20.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum21.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum22.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum23.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum24.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum25.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum26.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum27.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum28.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum31.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum32.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum33.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum34.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum35.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum36.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum37.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum38.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum39.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum40.groestlcoin.org:50004",
+                "contact": [
+                    {
+                        "email": "jackielove4u@hotmail.com"
+                    },
+                    {
+                        "discord": "jackielove4u#0412"
+                    }
+                ],
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -15382,6 +18893,15 @@
         },
         "electrum": [
             {
+                "url": "il8p-ex-five.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "il8p-ex-five.ewmci.online:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -15433,9 +18953,98 @@
                         "github": "WikiMin3R"
                     }
                 ]
+            },
+            {
+                "url": "il8p-ex-five.ewmci.online:50003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "il8p.electrumx.transcenders.name:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "email": "coins@ewmci.com"
+                    },
+                    {
+                        "discord": "[CryptoStan]#9341"
+                    },
+                    {
+                        "twitter": "EwmciL"
+                    },
+                    {
+                        "reddit": "InfiniLooP"
+                    },
+                    {
+                        "github": "WikiMin3R"
+                    }
+                ]
+            },
+            {
+                "url": "il9p.electrumx.transcenders.name:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "email": "coins@ewmci.com"
+                    },
+                    {
+                        "discord": "[CryptoStan]#9341"
+                    },
+                    {
+                        "twitter": "EwmciL"
+                    },
+                    {
+                        "reddit": "InfiniLooP"
+                    },
+                    {
+                        "github": "WikiMin3R"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block.dws?"
+    },
+    "ILN": {
+        "coin": "ILN",
+        "type": "Smart Chain",
+        "name": "Ilien",
+        "coinpaprika_id": "iln-ilien9195",
+        "coingecko_id": "",
+        "livecoinwatch_id": "ILN",
+        "explorer_url": "https://explorer.ilien.io/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "ILN",
+        "fname": "Ilien",
+        "rpcport": 12986,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "p2p": 12985,
+        "magic": "feb4cb23",
+        "nSPV": "5.9.102.210, 5.9.253.195, 5.9.253.196, 5.9.253.197, 5.9.253.198, 5.9.253.199, 5.9.253.200, 5.9.253.201, 5.9.253.202, 5.9.253.203",
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [],
+        "explorer_block_url": "block/"
     },
     "ILN-BEP20": {
         "coin": "ILN-BEP20",
@@ -17790,6 +21399,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10014",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10014",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10014",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20014",
                 "protocol": "SSL",
                 "contact": [
@@ -17816,6 +21461,42 @@
             {
                 "url": "electrum3.cipig.net:20014",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30014",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30014",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30014",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -17859,6 +21540,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10015",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10015",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10015",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20015",
                 "protocol": "SSL",
                 "contact": [
@@ -17885,6 +21602,42 @@
             {
                 "url": "electrum3.cipig.net:20015",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30015",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30015",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30015",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -17928,6 +21681,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10016",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10016",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10016",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20016",
                 "protocol": "SSL",
                 "contact": [
@@ -17954,6 +21743,42 @@
             {
                 "url": "electrum3.cipig.net:20016",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30016",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30016",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30016",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -18005,6 +21830,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10001",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10001",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10001",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20001",
                 "protocol": "SSL",
                 "contact": [
@@ -18031,6 +21892,42 @@
             {
                 "url": "electrum3.cipig.net:20001",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30001",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30001",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30001",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -18336,6 +22233,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10024",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10024",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10024",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20024",
                 "protocol": "SSL",
                 "contact": [
@@ -18362,6 +22295,42 @@
             {
                 "url": "electrum3.cipig.net:20024",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30024",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30024",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30024",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -18453,6 +22422,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10019",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10019",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10019",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20019",
                 "protocol": "SSL",
                 "contact": [
@@ -18479,6 +22484,42 @@
             {
                 "url": "electrum3.cipig.net:20019",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30019",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30019",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30019",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -18524,6 +22565,18 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10067",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10067",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10067",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
                 "protocol": "SSL"
@@ -18537,6 +22590,21 @@
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum1.cipig.net:30067",
+                "disable_cert_verification": false,
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.cipig.net:30067",
+                "disable_cert_verification": false,
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.cipig.net:30067",
+                "disable_cert_verification": false,
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -18578,6 +22646,18 @@
         "derivation_path": "m/44'/140'",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10067",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10067",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10067",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20067",
                 "disable_cert_verification": false,
                 "protocol": "SSL"
@@ -18591,6 +22671,21 @@
                 "url": "electrum3.cipig.net:20067",
                 "disable_cert_verification": false,
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum1.cipig.net:30067",
+                "disable_cert_verification": false,
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum2.cipig.net:30067",
+                "disable_cert_verification": false,
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.cipig.net:30067",
+                "disable_cert_verification": false,
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -18631,8 +22726,30 @@
         "derivation_path": "m/44'/192'",
         "electrum": [
             {
+                "url": "88.99.26.209:5140",
+                "protocol": "TCP"
+            },
+            {
+                "url": "lcc-ex-one.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "lcc-ex-one.ewmci.online:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "lcc-ex-one.ewmci.online:50003",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "475820011634819072"
@@ -18682,8 +22799,30 @@
         "derivation_path": "m/44'/192'",
         "electrum": [
             {
+                "url": "88.99.26.209:5140",
+                "protocol": "TCP"
+            },
+            {
+                "url": "lcc-ex-one.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "lcc-ex-one.ewmci.online:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "lcc-ex-one.ewmci.online:50003",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "475820011634819072"
@@ -18802,6 +22941,40 @@
                 "url": "https://electrum3.cipig.net:18755"
             }
         ],
+        "explorer_block_url": "block/"
+    },
+    "LNC": {
+        "coin": "LNC",
+        "type": "UTXO",
+        "name": "LightningCash",
+        "coinpaprika_id": "ltncg-lightningcash-gold",
+        "coingecko_id": "lightningcash-gold",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://explorer.lightningcash-coin.com/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "LightningCash",
+        "rpcport": 9110,
+        "pubtype": 28,
+        "p2shtype": 50,
+        "wiftype": 176,
+        "decimals": 8,
+        "signature_version": "base",
+        "txfee": 10000,
+        "segwit": true,
+        "bech32_hrp": "lnc",
+        "mm2": 1,
+        "required_confirmations": 6,
+        "avg_blocktime": 5,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
         "explorer_block_url": "block/"
     },
     "LEO-ERC20": {
@@ -19472,6 +23645,94 @@
         ],
         "explorer_block_url": "block/"
     },
+    "WCN": {
+        "coin": "WCN",
+        "type": "UTXO",
+        "name": "Widecoin",
+        "coinpaprika_id": "wcn-widecoin",
+        "coingecko_id": "widecoin",
+        "livecoinwatch_id": "WCN",
+        "explorer_url": "https://explorer.widecoin.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Widecoin",
+        "rpcport": 8552,
+        "pubtype": 73,
+        "p2shtype": 33,
+        "wiftype": 153,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "wc",
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/613'",
+        "electrum": [
+            {
+                "url": "electrumx.widecoin.org:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.widecoin.org:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "WCN-segwit": {
+        "coin": "WCN-segwit",
+        "type": "UTXO",
+        "name": "Widecoin",
+        "coinpaprika_id": "wcn-widecoin",
+        "coingecko_id": "widecoin",
+        "livecoinwatch_id": "WCN",
+        "explorer_url": "https://explorer.widecoin.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Widecoin",
+        "rpcport": 8552,
+        "pubtype": 73,
+        "p2shtype": 33,
+        "wiftype": 153,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "wc",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "WCN",
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/613'",
+        "electrum": [
+            {
+                "url": "electrumx.widecoin.org:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.widecoin.org:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "LEASH-ERC20": {
         "coin": "LEASH-ERC20",
         "type": "ERC-20",
@@ -19731,6 +23992,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10063",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10063",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10063",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20063",
                 "protocol": "SSL",
                 "contact": [
@@ -19757,6 +24054,42 @@
             {
                 "url": "electrum3.cipig.net:20063",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30063",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30063",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30063",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -19813,6 +24146,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10063",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10063",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10063",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20063",
                 "protocol": "SSL",
                 "contact": [
@@ -19839,6 +24208,42 @@
             {
                 "url": "electrum3.cipig.net:20063",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30063",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30063",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30063",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -19895,6 +24300,34 @@
             {
                 "url": "electrum7.getlynx.io:50002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum8.getlynx.io:50002",
+                "protocol": "SSL"
+            },
+            {
+                "url": "electrum9.getlynx.io:50002",
+                "protocol": "SSL"
+            },
+            {
+                "url": "electrum5.getlynx.io:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum6.getlynx.io:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum7.getlynx.io:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum8.getlynx.io:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum9.getlynx.io:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -20696,6 +25129,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10023",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10023",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10023",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20023",
                 "protocol": "SSL",
                 "contact": [
@@ -20722,6 +25191,42 @@
             {
                 "url": "electrum3.cipig.net:20023",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30023",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30023",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30023",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -20830,6 +25335,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10069",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10069",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10069",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20069",
                 "protocol": "SSL",
                 "contact": [
@@ -20856,6 +25397,42 @@
             {
                 "url": "electrum3.cipig.net:20069",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30069",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30069",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30069",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -21533,6 +26110,116 @@
         ],
         "explorer_block_url": "block/"
     },
+    "MONA": {
+        "coin": "MONA",
+        "type": "UTXO",
+        "name": "MonaCoin",
+        "coinpaprika_id": "mona-monacoin",
+        "coingecko_id": "monacoin",
+        "livecoinwatch_id": "MONA",
+        "explorer_url": "https://blockbook.electrum-mona.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Monacoin Signed Message:\n",
+        "fname": "MonaCoin",
+        "rpcport": 9402,
+        "pubtype": 50,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 100000,
+        "dust": 100000,
+        "segwit": true,
+        "bech32_hrp": "mona",
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 90,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/22'",
+        "trezor_coin": "Monacoin",
+        "links": {
+            "github": "https://github.com/monacoinproject/monacoin",
+            "homepage": "https://monacoin.org"
+        },
+        "electrum": [
+            {
+                "url": "133.167.67.203:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.tamami-foundation.org:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx1.monacoin.ninja:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "MONA-segwit": {
+        "coin": "MONA-segwit",
+        "type": "UTXO",
+        "name": "MonaCoin",
+        "coinpaprika_id": "mona-monacoin",
+        "coingecko_id": "monacoin",
+        "livecoinwatch_id": "MONA",
+        "explorer_url": "https://blockbook.electrum-mona.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Monacoin Signed Message:\n",
+        "fname": "MonaCoin",
+        "rpcport": 9402,
+        "pubtype": 50,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 100000,
+        "dust": 100000,
+        "segwit": true,
+        "bech32_hrp": "mona",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "MONA",
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 90,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/22'",
+        "trezor_coin": "Monacoin",
+        "links": {
+            "github": "https://github.com/monacoinproject/monacoin",
+            "homepage": "https://monacoin.org"
+        },
+        "electrum": [
+            {
+                "url": "133.167.67.203:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.tamami-foundation.org:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx1.monacoin.ninja:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "MOVR": {
         "coin": "MOVR",
         "type": "Moonriver",
@@ -21657,6 +26344,14 @@
             {
                 "url": "electrum3.nav.community:40002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum2.nav.community:40004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum3.nav.community:40004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -21754,6 +26449,74 @@
             }
         ],
         "token_address_url": "tokentxns?a=",
+        "explorer_block_url": "block/"
+    },
+    "NENG": {
+        "coin": "NENG",
+        "type": "UTXO",
+        "name": "Nengcoin",
+        "coinpaprika_id": "neng-nengcoin",
+        "coingecko_id": "nengcoin",
+        "livecoinwatch_id": "NENG",
+        "explorer_url": "http://nengexplorer.mooo.com:3001/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Nengcoin",
+        "rpcport": 6376,
+        "pubtype": 53,
+        "p2shtype": 5,
+        "wiftype": 176,
+        "txfee": 200000,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/681'",
+        "electrum": [
+            {
+                "url": "electrum.shorelinecrypto.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum1.mooo.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.mooo.com:10001",
+                "contact": [
+                    {
+                        "email": "support@shorelinecrypto.com"
+                    },
+                    {
+                        "discord": "honglu69#5911"
+                    }
+                ],
+                "protocol": "TCP"
+            }
+        ],
         "explorer_block_url": "block/"
     },
     "NENG-BEP20": {
@@ -21995,6 +26758,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10036",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10036",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10036",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20036",
                 "protocol": "SSL",
                 "contact": [
@@ -22070,6 +26869,46 @@
         },
         "electrum": [
             {
+                "url": "electrumx1.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx3.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx4.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "nmc2.bitcoins.sk:57001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrumx1.nmc.dotbit.zone:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -22095,6 +26934,20 @@
                         "github": "https://github.com/namecoin/electrum-nmc/issues"
                     }
                 ]
+            },
+            {
+                "url": "electrumx4.nmc.dotbit.zone:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "nmc2.bitcoins.sk:57002",
+                "protocol": "SSL",
+                "disable_cert_verification": true
             }
         ],
         "explorer_block_url": "block/"
@@ -22140,6 +26993,46 @@
         },
         "electrum": [
             {
+                "url": "electrumx1.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx3.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx4.nmc.dotbit.zone:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "nmc2.bitcoins.sk:57001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrumx1.nmc.dotbit.zone:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -22165,6 +27058,20 @@
                         "github": "https://github.com/namecoin/electrum-nmc/issues"
                     }
                 ]
+            },
+            {
+                "url": "electrumx4.nmc.dotbit.zone:50002",
+                "protocol": "SSL",
+                "contact": [
+                    {
+                        "github": "https://github.com/namecoin/electrum-nmc/issues"
+                    }
+                ]
+            },
+            {
+                "url": "nmc2.bitcoins.sk:57002",
+                "protocol": "SSL",
+                "disable_cert_verification": true
             }
         ],
         "explorer_block_url": "block/"
@@ -22338,6 +27245,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -22364,6 +27307,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -22488,6 +27467,38 @@
         ],
         "explorer_block_url": "block/",
         "forex_id": "NZD"
+    },
+    "NYAN": {
+        "coin": "NYAN",
+        "type": "UTXO",
+        "name": "Nyancoin",
+        "coinpaprika_id": "nyan-nyancoin",
+        "coingecko_id": "nyancoin",
+        "livecoinwatch_id": "__NYAN",
+        "explorer_url": "https://www.nyanchain.com/",
+        "explorer_tx_url": "tx.nyan?",
+        "explorer_address_url": "ad.nyan?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Nyancoin",
+        "rpcport": 33700,
+        "pubtype": 45,
+        "p2shtype": 5,
+        "wiftype": 173,
+        "txfee": 100000,
+        "segwit": false,
+        "bech32_hrp": "ny",
+        "mm2": 1,
+        "required_confirmations": 10,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
+        "explorer_block_url": "block/"
     },
     "NYC-BEP20": {
         "coin": "NYC-BEP20",
@@ -23273,6 +28284,149 @@
         ],
         "explorer_block_url": "block/"
     },
+    "PINK": {
+        "coin": "PINK",
+        "type": "UTXO",
+        "name": "Pinkcoin",
+        "coinpaprika_id": "pink-pinkcoin",
+        "coingecko_id": "pinkcoin",
+        "livecoinwatch_id": "PINK",
+        "explorer_url": "https://chainz.cryptoid.info/pink/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": true,
+        "sign_message_prefix": "Pinkcoin Signed Message:\n",
+        "fname": "Pinkcoin",
+        "rpcport": 9135,
+        "isPoS": 1,
+        "pubtype": 3,
+        "p2shtype": 28,
+        "wiftype": 131,
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/117'",
+        "links": {
+            "github": "https://github.com/Pink2Dev/Pink2",
+            "homepage": "https://getstarted.with.pink"
+        },
+        "electrum": [
+            {
+                "url": "pink-one.ewm-cx.net:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "pink-two.ewm-cx.net:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
+    "PIVX": {
+        "coin": "PIVX",
+        "type": "UTXO",
+        "name": "PIVX",
+        "coinpaprika_id": "pivx-pivx",
+        "coingecko_id": "pivx",
+        "livecoinwatch_id": "PIVX",
+        "explorer_url": "https://chainz.cryptoid.info/pivx/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "PIVX",
+        "rpcport": 51473,
+        "pubtype": 30,
+        "p2shtype": 13,
+        "wiftype": 212,
+        "txfee": 100000,
+        "dust": 5460,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/119'",
+        "electrum": [
+            {
+                "url": "electrum01.chainster.org:50001",
+                "contact": [
+                    {
+                        "discord": "312541186793406465"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum01.chainster.org:50003",
+                "contact": [
+                    {
+                        "discord": "312541186793406465"
+                    }
+                ],
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?",
+        "binance_id": "PIVX"
+    },
+    "PND": {
+        "coin": "PND",
+        "type": "UTXO",
+        "name": "Pandacoin",
+        "coinpaprika_id": "pnd-pandacoin",
+        "coingecko_id": "pandacoin",
+        "livecoinwatch_id": "PND",
+        "explorer_url": "https://chainz.cryptoid.info/pnd/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Pandacoin",
+        "isPoS": 1,
+        "rpcport": 22444,
+        "pubtype": 55,
+        "p2shtype": 22,
+        "wiftype": 183,
+        "decimals": 6,
+        "txfee": 10000000,
+        "dust": 1000000,
+        "segwit": true,
+        "bech32_hrp": "pn",
+        "mm2": 1,
+        "required_confirmations": 1,
+        "avg_blocktime": 600,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/37'",
+        "electrum": [
+            {
+                "url": "electrum.thepandacoin.net:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum.thepandacoin.net:443",
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
     "POT": {
         "coin": "POT",
         "type": "UTXO",
@@ -23314,6 +28468,14 @@
             {
                 "url": "pot-uno.ewmcx.net:50002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "pot-duo.ewmcx.net:50013",
+                "protocol": "WSS"
+            },
+            {
+                "url": "pot-uno.ewmcx.net:50003",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -23592,6 +28754,16 @@
                 "url": "electrum.peercoinexplorer.net:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false
+            },
+            {
+                "url": "allingas.peercoinexplorer.net:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": false
+            },
+            {
+                "url": "electrum.peercoinexplorer.net:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": false
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -23705,6 +28877,36 @@
                 "url": "https://electrum3.cipig.net:18755"
             }
         ],
+        "explorer_block_url": "block/"
+    },
+    "PRCY": {
+        "coin": "PRCY",
+        "type": "UTXO",
+        "name": "PRivaCY Coin",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "PRCY",
+        "explorer_url": "https://explorer.prcycoin.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "PRivaCY Coin",
+        "rpcport": 59683,
+        "pubtype": 55,
+        "p2shtype": 61,
+        "wiftype": 28,
+        "txfee": 0,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/853'",
         "explorer_block_url": "block/"
     },
     "PRCY-BEP20": {
@@ -23896,6 +29098,24 @@
         },
         "electrum": [
             {
+                "url": "electrumx.live:50010",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
+            },
+            {
+                "url": "txserver.live:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx.live:50012",
                 "protocol": "SSL",
                 "contact": [
@@ -23907,6 +29127,24 @@
             {
                 "url": "txserver.live:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx.live:30010",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "PRUX-Coin#1668"
+                    }
+                ]
+            },
+            {
+                "url": "txserver.live:30001",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "PRUX-Coin#1668"
@@ -24273,6 +29511,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -24299,6 +29573,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24352,6 +29662,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -24378,6 +29724,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24431,6 +29813,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -24457,6 +29875,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24726,8 +30180,32 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
+                "url": "electrum3.cipig.net:10071",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30071",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24783,6 +30261,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -24809,6 +30323,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24921,8 +30471,32 @@
         "fallback_swap_contract": "0xba8b71f3544b93e2f681f996da519a98ace0107a",
         "electrum": [
             {
+                "url": "electrum3.cipig.net:10071",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum3.cipig.net:20071",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30071",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -24981,6 +30555,14 @@
             {
                 "url": "electrum02.reddcoin.com:50002",
                 "protocol": "SSL"
+            },
+            {
+                "url": "electrum01.reddcoin.com:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrum02.reddcoin.com:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -25300,6 +30882,15 @@
         "derivation_path": "m/44'/143'",
         "electrum": [
             {
+                "url": "ric-ex-two.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "electrum3.cipig.net:20074",
                 "protocol": "SSL",
                 "contact": [
@@ -25314,6 +30905,27 @@
             {
                 "url": "ric-ex-two.ewmci.online:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30074",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "ric-ex-two.ewmci.online:50003",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "475820011634819072"
@@ -25359,6 +30971,15 @@
         "derivation_path": "m/44'/143'",
         "electrum": [
             {
+                "url": "ric-ex-two.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "electrum3.cipig.net:20074",
                 "protocol": "SSL",
                 "contact": [
@@ -25373,6 +30994,27 @@
             {
                 "url": "ric-ex-two.ewmci.online:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30074",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "ric-ex-two.ewmci.online:50003",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "475820011634819072"
@@ -25462,6 +31104,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10020",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10020",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10020",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20020",
                 "protocol": "SSL",
                 "contact": [
@@ -25488,6 +31166,42 @@
             {
                 "url": "electrum3.cipig.net:20020",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30020",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30020",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30020",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -25532,6 +31246,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10021",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10021",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10021",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20021",
                 "protocol": "SSL",
                 "contact": [
@@ -25558,6 +31308,42 @@
             {
                 "url": "electrum3.cipig.net:20021",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30021",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30021",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30021",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -25956,6 +31742,21 @@
         },
         "electrum": [
             {
+                "url": "electrumx2.ridethebullcoin.com:10002",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "rtbadmin@ridethebullcoin.com"
+                    },
+                    {
+                        "github": "RTBCoin"
+                    },
+                    {
+                        "discord": "rtbcoin"
+                    }
+                ]
+            },
+            {
                 "url": "electrumx2.ridethebullcoin.com:20053",
                 "protocol": "SSL",
                 "contact": [
@@ -25969,6 +31770,70 @@
                         "discord": "rtbcoin"
                     }
                 ]
+            },
+            {
+                "url": "electrumx2.ridethebullcoin.com:20052",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "rtbadmin@ridethebullcoin.com"
+                    },
+                    {
+                        "github": "RTBCoin"
+                    },
+                    {
+                        "discord": "rtbcoin"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "RTM": {
+        "coin": "RTM",
+        "type": "UTXO",
+        "name": "Raptoreum",
+        "coinpaprika_id": "rtm-raptoreum",
+        "coingecko_id": "raptoreum",
+        "livecoinwatch_id": "RTM",
+        "explorer_url": "https://explorer.raptoreum.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Raptoreum",
+        "rpcport": 9998,
+        "pubtype": 60,
+        "p2shtype": 16,
+        "wiftype": 128,
+        "txfee": 1000,
+        "mm2": 1,
+        "confpath": "USERHOME/.raptoreumcore/raptoreum.conf",
+        "required_confirmations": 3,
+        "avg_blocktime": 120,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/10226'",
+        "electrum": [
+            {
+                "url": "x1.raptoreum.com:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "x2.raptoreum.com:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "x1.raptoreum.com:50004",
+                "protocol": "WSS"
+            },
+            {
+                "url": "x2.raptoreum.com:50004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -26059,6 +31924,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10051",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10051",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10051",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20051",
                 "protocol": "SSL",
                 "contact": [
@@ -26085,6 +31986,42 @@
             {
                 "url": "electrum3.cipig.net:20051",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30051",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30051",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30051",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -26846,6 +32783,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10011",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10011",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10011",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20011",
                 "protocol": "SSL",
                 "contact": [
@@ -26872,6 +32845,42 @@
             {
                 "url": "electrum3.cipig.net:20011",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30011",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30011",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30011",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -27238,6 +33247,16 @@
                 "url": "sumpos2.electrum-sum.org:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false
+            },
+            {
+                "url": "sumpos.electrum-sum.org:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": false
+            },
+            {
+                "url": "sumpos2.electrum-sum.org:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": false
             }
         ],
         "explorer_block_url": "block/"
@@ -27274,6 +33293,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10005",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10005",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10005",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20005",
                 "protocol": "SSL",
                 "contact": [
@@ -27300,6 +33355,42 @@
             {
                 "url": "electrum3.cipig.net:20005",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30005",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -27895,6 +33986,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10064",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10064",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10064",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20064",
                 "protocol": "SSL",
                 "contact": [
@@ -27921,6 +34048,42 @@
             {
                 "url": "electrum3.cipig.net:20064",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30064",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30064",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30064",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -27977,6 +34140,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10064",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10064",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10064",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20064",
                 "protocol": "SSL",
                 "contact": [
@@ -28011,10 +34210,77 @@
                         "discord": "cipi#4502"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.cipig.net:30064",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30064",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30064",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block.dws?",
         "binance_id": "SYS"
+    },
+    "SCA": {
+        "coin": "SCA",
+        "type": "UTXO",
+        "name": "Scalaris",
+        "coinpaprika_id": "sca-scalaris",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://explorer.scalaris.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Scalaris",
+        "rpcport": 42510,
+        "txversion": 1,
+        "pubtype": 63,
+        "p2shtype": 23,
+        "wiftype": 154,
+        "txfee": 200000,
+        "required_confirmations": 3,
+        "avg_blocktime": 60,
+        "mm2": 1,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
+        "explorer_block_url": "block/"
     },
     "TAMA-ERC20": {
         "coin": "TAMA-ERC20",
@@ -28266,8 +34532,36 @@
         },
         "electrum": [
             {
+                "url": "electrum3.cipig.net:10068",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "testnet.aranguren.org:51001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum3.cipig.net:20068",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30068",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28315,8 +34609,36 @@
         },
         "electrum": [
             {
+                "url": "electrum3.cipig.net:10068",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "testnet.aranguren.org:51001",
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum3.cipig.net:20068",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30068",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -28532,6 +34854,58 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "THC": {
+        "coin": "THC",
+        "type": "Smart Chain",
+        "name": "HempCoin",
+        "coinpaprika_id": "thc-hempcoin",
+        "coingecko_id": "hempcoin-thc",
+        "livecoinwatch_id": "THC",
+        "explorer_url": "https://thc.explorer.dexstats.info/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "THC",
+        "fname": "HempCoin",
+        "rpcport": 36790,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "requires_notarization": true,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [
+            {
+                "url": "1.eu.thc.electrum.dexstats.info:10020",
+                "contact": [
+                    {
+                        "discord": "CHMEX#0686"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "2.eu.thc.electrum.dexstats.info:10020",
+                "contact": [
+                    {
+                        "discord": "CHMEX#0686"
+                    }
+                ],
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "THC-BEP20": {
         "coin": "THC-BEP20",
         "type": "BEP-20",
@@ -28612,8 +34986,32 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "1.eu.tokel.electrum.dexstats.info:10077",
+                "contact": [
+                    {
+                        "email": "chmex@dexstats.info"
+                    },
+                    {
+                        "discord": "chmex#0686"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "1.eu.tokel.electrum.dexstats.info:11077",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "chmex@dexstats.info"
+                    },
+                    {
+                        "discord": "chmex#0686"
+                    }
+                ]
+            },
+            {
+                "url": "1.eu.tokel.electrum.dexstats.info:9077",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "chmex@dexstats.info"
@@ -28768,6 +35166,11 @@
             {
                 "url": "failover.trc-uis.ewmcx.biz:50006",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "failover.trc-uis.ewmcx.biz:50007",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             }
         ],
@@ -29672,6 +36075,16 @@
                 "url": "uis-uno.ewmcx.net:50002",
                 "protocol": "SSL",
                 "disable_cert_verification": false
+            },
+            {
+                "url": "failover.trc-uis.ewmcx.biz:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": false
+            },
+            {
+                "url": "uis-uno.ewmcx.net:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": false
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -30176,6 +36589,16 @@
             {
                 "url": "uno-main.coinmunity.gold:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "uno-bkp.coinmunity.gold:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
+            {
+                "url": "uno-main.coinmunity.gold:50003",
+                "protocol": "WSS",
                 "disable_cert_verification": true
             }
         ],
@@ -31348,6 +37771,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10009",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10009",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10009",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20009",
                 "protocol": "SSL",
                 "contact": [
@@ -31374,6 +37833,42 @@
             {
                 "url": "electrum3.cipig.net:20009",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30009",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30009",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30009",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31419,6 +37914,33 @@
         },
         "electrum": [
             {
+                "url": "e1.validitytech.com:11001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "e2.validitytech.com:11001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "e3.validitytech.com:11001",
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "e1.validitytech.com:11002",
                 "protocol": "SSL",
                 "disable_cert_verification": true,
@@ -31441,6 +37963,36 @@
             {
                 "url": "e3.validitytech.com:11002",
                 "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "e1.validitytech.com:11004",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "e2.validitytech.com:11004",
+                "protocol": "WSS",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "discord": "michelvankessel#7656"
+                    }
+                ]
+            },
+            {
+                "url": "e3.validitytech.com:11004",
+                "protocol": "WSS",
                 "disable_cert_verification": true,
                 "contact": [
                     {
@@ -31718,6 +38270,18 @@
                         "discord": "cipi#4502"
                     }
                 ]
+            },
+            {
+                "url": "electrum3.cipig.net:30073",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -31768,6 +38332,18 @@
             {
                 "url": "electrum3.cipig.net:20073",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30073",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -31827,6 +38403,38 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "VRM": {
+        "coin": "VRM",
+        "type": "UTXO",
+        "name": "Verium Reserve",
+        "coinpaprika_id": "vrm-veriumreserve",
+        "coingecko_id": "veriumreserve",
+        "livecoinwatch_id": "VRM",
+        "explorer_url": "https://explorer-vrm.vericonomy.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Verium Reserve",
+        "rpcport": 33987,
+        "pubtype": 70,
+        "p2shtype": 132,
+        "wiftype": 198,
+        "txfee": 100000,
+        "force_min_relay_fee": true,
+        "isPoS": 1,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 240,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
+        "explorer_block_url": "block/"
+    },
     "VRSC": {
         "coin": "VRSC",
         "type": "Smart Chain",
@@ -31857,6 +38465,51 @@
         "derivation_path": "m/44'/141'",
         "trezor_coin": "Komodo",
         "electrum": [
+            {
+                "url": "el0.verus.io:17485",
+                "contact": [
+                    {
+                        "email": "0x03-ctrlc@protonmail.com"
+                    },
+                    {
+                        "discord": "0x03#8822"
+                    },
+                    {
+                        "keybase": "bloodynora"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "el1.verus.io:17485",
+                "contact": [
+                    {
+                        "email": "0x03-ctrlc@protonmail.com"
+                    },
+                    {
+                        "discord": "0x03#8822"
+                    },
+                    {
+                        "keybase": "bloodynora"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "el2.verus.io:17485",
+                "contact": [
+                    {
+                        "email": "0x03-ctrlc@protonmail.com"
+                    },
+                    {
+                        "discord": "0x03#8822"
+                    },
+                    {
+                        "keybase": "bloodynora"
+                    }
+                ],
+                "protocol": "TCP"
+            },
             {
                 "url": "el0.verus.io:17486",
                 "protocol": "SSL",
@@ -31904,6 +38557,54 @@
                     }
                 ],
                 "disable_cert_verification": false
+            },
+            {
+                "url": "el0.verus.io:17488",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "0x03-ctrlc@protonmail.com"
+                    },
+                    {
+                        "discord": "0x03#8822"
+                    },
+                    {
+                        "keybase": "bloodynora"
+                    }
+                ],
+                "disable_cert_verification": false
+            },
+            {
+                "url": "el1.verus.io:17488",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "0x03-ctrlc@protonmail.com"
+                    },
+                    {
+                        "discord": "0x03#8822"
+                    },
+                    {
+                        "keybase": "bloodynora"
+                    }
+                ],
+                "disable_cert_verification": false
+            },
+            {
+                "url": "el2.verus.io:17488",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "0x03-ctrlc@protonmail.com"
+                    },
+                    {
+                        "discord": "0x03#8822"
+                    },
+                    {
+                        "keybase": "bloodynora"
+                    }
+                ],
+                "disable_cert_verification": false
             }
         ],
         "explorer_block_url": "block/"
@@ -31939,6 +38640,36 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.grms.pw:17485",
+                "contact": [
+                    {
+                        "email": "contact@grms.pw"
+                    },
+                    {
+                        "discord": "miner113#7864"
+                    },
+                    {
+                        "github": "Miner113"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.grms.pw:17485",
+                "contact": [
+                    {
+                        "email": "contact@grms.pw"
+                    },
+                    {
+                        "discord": "miner113#7864"
+                    },
+                    {
+                        "github": "Miner113"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.grms.pw:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -31967,9 +38698,201 @@
                         "github": "Miner113"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.grms.pw:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "contact@grms.pw"
+                    },
+                    {
+                        "discord": "miner113#7864"
+                    },
+                    {
+                        "github": "Miner113"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.grms.pw:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "contact@grms.pw"
+                    },
+                    {
+                        "discord": "miner113#7864"
+                    },
+                    {
+                        "github": "Miner113"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
+    },
+    "VPRM": {
+        "coin": "VPRM",
+        "type": "Smart Chain",
+        "name": "Vaporum",
+        "coinpaprika_id": "vprm-vaporum-coin",
+        "coingecko_id": "vaporum-coin",
+        "livecoinwatch_id": "VPRM",
+        "explorer_url": "http://explorer.vaporumcoin.us/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Komodo Signed Message:\n",
+        "asset": "VPRM",
+        "fname": "Vaporum",
+        "rpcport": 51609,
+        "txversion": 4,
+        "overwintered": 1,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/141'",
+        "trezor_coin": "Komodo",
+        "electrum": [],
+        "explorer_block_url": "block/"
+    },
+    "VTC": {
+        "coin": "VTC",
+        "type": "UTXO",
+        "name": "Vertcoin",
+        "coinpaprika_id": "vtc-vertcoin",
+        "coingecko_id": "vertcoin",
+        "livecoinwatch_id": "VTC",
+        "explorer_url": "https://chainz.cryptoid.info/vtc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Vertcoin Signed Message:\n",
+        "fname": "Vertcoin",
+        "rpcport": 5888,
+        "pubtype": 71,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 100000,
+        "dust": 100000,
+        "segwit": true,
+        "bech32_hrp": "vtc",
+        "mm2": 1,
+        "required_confirmations": 4,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/28'",
+        "trezor_coin": "Vertcoin",
+        "links": {
+            "github": "https://github.com/vertcoin-project/vertcoin-core",
+            "homepage": "https://vertcoin.org"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5028",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.javerity.com:5885",
+                "contact": [
+                    {
+                        "discord": "cruelnovo#4936"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.javerity.com:5887",
+                "contact": [
+                    {
+                        "discord": "cruelnovo#4936"
+                    }
+                ],
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
+    },
+    "VTC-segwit": {
+        "coin": "VTC-segwit",
+        "type": "UTXO",
+        "name": "Vertcoin",
+        "coinpaprika_id": "vtc-vertcoin",
+        "coingecko_id": "vertcoin",
+        "livecoinwatch_id": "VTC",
+        "explorer_url": "https://chainz.cryptoid.info/vtc/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Vertcoin Signed Message:\n",
+        "fname": "Vertcoin",
+        "rpcport": 5888,
+        "pubtype": 71,
+        "p2shtype": 5,
+        "wiftype": 128,
+        "txfee": 100000,
+        "dust": 100000,
+        "segwit": true,
+        "bech32_hrp": "vtc",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "VTC",
+        "mm2": 1,
+        "required_confirmations": 4,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/28'",
+        "trezor_coin": "Vertcoin",
+        "links": {
+            "github": "https://github.com/vertcoin-project/vertcoin-core",
+            "homepage": "https://vertcoin.org"
+        },
+        "electrum": [
+            {
+                "url": "88.99.26.209:5028",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.javerity.com:5885",
+                "contact": [
+                    {
+                        "discord": "cruelnovo#4936"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.javerity.com:5887",
+                "contact": [
+                    {
+                        "discord": "cruelnovo#4936"
+                    }
+                ],
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block.dws?"
     },
     "WAF": {
         "coin": "WAF",
@@ -32008,6 +38931,15 @@
             {
                 "url": "waifu-explorer.io:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "376197863346274307"
+                    }
+                ]
+            },
+            {
+                "url": "waifu-explorer.io:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "376197863346274307"
@@ -32604,6 +39536,101 @@
         "token_address_url": "tokentxns?a=",
         "explorer_block_url": "block/"
     },
+    "XEP-segwit": {
+        "coin": "XEP-segwit",
+        "type": "UTXO",
+        "name": "Electra Protocol",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "XEP",
+        "explorer_url": "https://electraprotocol.network/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Electra Protocol",
+        "rpcport": 16816,
+        "pubtype": 55,
+        "p2shtype": 137,
+        "wiftype": 162,
+        "txversion": 2,
+        "txfee": 100000,
+        "dust": 100000,
+        "mm2": 1,
+        "segwit": true,
+        "signature_version": "witness_v0",
+        "bech32_hrp": "ep",
+        "address_format": {
+            "format": "segwit"
+        },
+        "orderbook_ticker": "XEP",
+        "required_confirmations": 4,
+        "avg_blocktime": 80,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/597'",
+        "electrum": [
+            {
+                "url": "electrumx1.electraprotocol.eu:50001",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.electraprotocol.eu:50001",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx3.electraprotocol.eu:50001",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx1.electraprotocol.eu:50003",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrumx2.electraprotocol.eu:50003",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrumx3.electraprotocol.eu:50003",
+                "contact": [
+                    {
+                        "discord": "287952234317348865"
+                    }
+                ],
+                "protocol": "WSS"
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
     "XEP-BEP20": {
         "coin": "XEP-BEP20",
         "type": "BEP-20",
@@ -32843,8 +39870,16 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
+                "url": "lenoir.ecoincore.com:10891",
+                "protocol": "TCP"
+            },
+            {
                 "url": "lenoir.ecoincore.com:10892",
                 "protocol": "SSL"
+            },
+            {
+                "url": "lenoir.ecoincore.com:10894",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32885,8 +39920,16 @@
         "derivation_path": "m/44'/90'",
         "electrum": [
             {
+                "url": "lenoir.ecoincore.com:10891",
+                "protocol": "TCP"
+            },
+            {
                 "url": "lenoir.ecoincore.com:10892",
                 "protocol": "SSL"
+            },
+            {
+                "url": "lenoir.ecoincore.com:10894",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -32961,6 +40004,92 @@
                         "discord": "456566604809895947"
                     }
                 ]
+            },
+            {
+                "url": "electrumx1.neurai.top:50002",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "alarm@neurai.org"
+                    },
+                    {
+                        "discord": "456566604809895947"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.neurai.top:50002",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "alarm@neurai.org"
+                    },
+                    {
+                        "discord": "456566604809895947"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx3.neurai.top:50002",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "alarm@neurai.org"
+                    },
+                    {
+                        "discord": "456566604809895947"
+                    }
+                ]
+            }
+        ],
+        "explorer_block_url": "block/"
+    },
+    "XPM": {
+        "coin": "XPM",
+        "type": "UTXO",
+        "name": "Primecoin",
+        "coinpaprika_id": "xpm-primecoin",
+        "coingecko_id": "primecoin",
+        "livecoinwatch_id": "XPM",
+        "explorer_url": "https://www.blockseek.io/xpm/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": true,
+        "fname": "Primecoin",
+        "rpcport": 8332,
+        "pubtype": 23,
+        "p2shtype": 83,
+        "wiftype": 151,
+        "txfee": 0,
+        "dust": 1000000,
+        "mm2": 1,
+        "required_confirmations": 5,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/24'",
+        "trezor_coin": "Primecoin",
+        "links": {
+            "github": "https://github.com/primecoin/primecoin",
+            "homepage": "https://primecoin.io"
+        },
+        "electrum": [
+            {
+                "url": "electrumx.gemmer.primecoin.org:50011",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.mainnet.primecoin.org:50011",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.primecoin.org:50001",
+                "protocol": "TCP"
             }
         ],
         "explorer_block_url": "block/"
@@ -33025,6 +40154,27 @@
                 "url": "xrg_ful.googol.cash:52138",
                 "protocol": "SSL",
                 "disable_cert_verification": true
+            },
+            {
+                "url": "fulcrum.ergon.network:52140",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "licho@ergon.moe"
+                    },
+                    {
+                        "telegram": "licho92karol"
+                    }
+                ]
+            },
+            {
+                "url": "la.ask.systems:52140",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "telegram": "@fsmv0"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -33332,6 +40482,23 @@
         },
         "electrum": [
             {
+                "url": "electrumx1.vanillacash.info:50011",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.vanillacash.info:50011",
+                "protocol": "TCP"
+            },
+            {
+                "url": "xvc-ex-seven.ewmci.online:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "xvc-ex-seven.ewmci.online:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -33339,6 +40506,14 @@
                         "discord": "475820011634819072"
                     }
                 ]
+            },
+            {
+                "url": "electrumx1.vanillacash.info:50013",
+                "protocol": "WSS"
+            },
+            {
+                "url": "electrumx2.vanillacash.info:50013",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -33431,6 +40606,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -33465,9 +40676,89 @@
                         "discord": "cipi#4502"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
+    },
+    "XVG": {
+        "coin": "XVG",
+        "type": "UTXO",
+        "name": "Verge",
+        "coinpaprika_id": "xvg-verge",
+        "coingecko_id": "verge",
+        "livecoinwatch_id": "XVG",
+        "explorer_url": "https://xvgblockexplorer.com/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "VERGE Signed Message:\n",
+        "fname": "Verge",
+        "isPoS": 1,
+        "rpcport": 20102,
+        "pubtype": 30,
+        "p2shtype": 33,
+        "wiftype": 158,
+        "decimals": 6,
+        "segwit": true,
+        "bech32_hrp": "vg",
+        "txfee": 400000,
+        "dust": 400000,
+        "force_min_relay_fee": true,
+        "mm2": 1,
+        "required_confirmations": 10,
+        "avg_blocktime": 30,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/77'",
+        "electrum": [
+            {
+                "url": "88.99.26.209:5036",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/",
+        "binance_id": "XVG"
     },
     "XVS-BEP20": {
         "coin": "XVS-BEP20",
@@ -33973,6 +41264,42 @@
         },
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10058",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10058",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10058",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20058",
                 "protocol": "SSL",
                 "contact": [
@@ -33999,6 +41326,42 @@
             {
                 "url": "electrum3.cipig.net:20058",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30058",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30058",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30058",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -34047,6 +41410,42 @@
         "derivation_path": "m/44'/323'",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10065",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10065",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10065",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20065",
                 "protocol": "SSL",
                 "contact": [
@@ -34073,6 +41472,42 @@
             {
                 "url": "electrum3.cipig.net:20065",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30065",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30065",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30065",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -34166,8 +41601,30 @@
         },
         "electrum": [
             {
+                "url": "207.180.252.200:50011",
+                "protocol": "TCP"
+            },
+            {
+                "url": "zet-ex-three.ewmci.online:50011",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "zet-ex-three.ewmci.online:50012",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
+                "url": "zet-ex-three.ewmci.online:50013",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "discord": "475820011634819072"
@@ -34430,6 +41887,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -34464,9 +41957,91 @@
                         "discord": "cipi#4502"
                     }
                 ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
+    },
+    "FLUX": {
+        "coin": "FLUX",
+        "type": "UTXO",
+        "name": "Flux",
+        "coinpaprika_id": "zel-zelcash",
+        "coingecko_id": "zelcash",
+        "livecoinwatch_id": "_FLUX",
+        "explorer_url": "https://explorer.runonflux.io/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Flux",
+        "rpcport": 16124,
+        "taddr": 28,
+        "pubtype": 184,
+        "p2shtype": 189,
+        "wiftype": 128,
+        "txversion": 4,
+        "overwintered": 1,
+        "version_group_id": "0x892f2085",
+        "consensus_branch_id": "0x76b809bb",
+        "txfee": 10000,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 120,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/19167'",
+        "electrum": [
+            {
+                "url": "electrumx.runonflux.io:50001",
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.runonflux.io:50001",
+                "protocol": "TCP"
+            }
+        ],
+        "explorer_block_url": "block/",
+        "binance_id": "FLUX"
     },
     "FLUX-ERC20": {
         "coin": "FLUX-ERC20",
@@ -34620,6 +42195,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -34646,6 +42257,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -34700,6 +42347,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -34726,6 +42409,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -34780,6 +42499,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -34806,6 +42561,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -34860,6 +42651,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -34886,6 +42713,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -34940,6 +42803,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -34966,6 +42865,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -35020,6 +42955,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -35046,6 +43017,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -35100,6 +43107,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -35126,6 +43169,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -35180,6 +43259,42 @@
         "fallback_swap_contract": "0x2f754733acd6d753731c00fee32cb484551cc15d",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10050",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20050",
                 "protocol": "SSL",
                 "contact": [
@@ -35206,6 +43321,42 @@
             {
                 "url": "electrum3.cipig.net:20050",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30050",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30050",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -36677,6 +44828,75 @@
         ],
         "explorer_block_url": "block/"
     },
+    "UFO": {
+        "coin": "UFO",
+        "type": "UTXO",
+        "name": "Uniform Fiscal Object",
+        "coinpaprika_id": "ufo-uniform-fiscal-object",
+        "coingecko_id": "ufocoin",
+        "livecoinwatch_id": "UFO",
+        "explorer_url": "https://chainz.cryptoid.info/ufo/",
+        "explorer_tx_url": "tx.dws?",
+        "explorer_address_url": "address.dws?",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "UFO Signed Message:\n",
+        "fname": "Uniform Fiscal Object",
+        "rpcport": 8087,
+        "pubtype": 27,
+        "p2shtype": 68,
+        "wiftype": 155,
+        "txfee": 100000,
+        "segwit": true,
+        "bech32_hrp": "uf",
+        "mm2": 1,
+        "required_confirmations": 6,
+        "avg_blocktime": 1.5,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/202'",
+        "links": {
+            "github": "https://github.com/fiscalobject/ufo",
+            "homepage": "https://ufobject.com"
+        },
+        "electrum": [],
+        "explorer_block_url": "block.dws?"
+    },
+    "USBL": {
+        "coin": "USBL",
+        "type": "UTXO",
+        "name": "Balanced Dollar",
+        "coinpaprika_id": "",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://softbalanced.com:3001/insight/",
+        "explorer_tx_url": "tx/",
+        "explorer_address_url": "address/",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "fname": "Balanced Dollar",
+        "confpath": "USERHOME/.bitdollar/bitdollar.conf",
+        "rpcport": 35573,
+        "pubtype": 65,
+        "p2shtype": 66,
+        "wiftype": 193,
+        "txfee": 0,
+        "mm2": 1,
+        "required_confirmations": 2,
+        "avg_blocktime": 150,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "electrum": [],
+        "explorer_block_url": "block/"
+    },
     "USDF": {
         "coin": "USDF",
         "type": "SLP",
@@ -36742,6 +44962,36 @@
             "type": "UTXO"
         },
         "electrum": [
+            {
+                "url": "electrumx1.cointest.com:50001",
+                "contact": [
+                    {
+                        "email": "protocol@whive.io"
+                    },
+                    {
+                        "discord": "whiveio#9340"
+                    },
+                    {
+                        "twitter": "whiveio"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.cointest.com:50001",
+                "contact": [
+                    {
+                        "email": "protocol@whive.io"
+                    },
+                    {
+                        "discord": "whiveio#9340"
+                    },
+                    {
+                        "twitter": "whiveio"
+                    }
+                ],
+                "protocol": "TCP"
+            },
             {
                 "url": "electrumx1.cointest.com:50002",
                 "protocol": "SSL",
@@ -36811,6 +45061,36 @@
             "type": "UTXO"
         },
         "electrum": [
+            {
+                "url": "electrumx1.cointest.com:50001",
+                "contact": [
+                    {
+                        "email": "protocol@whive.io"
+                    },
+                    {
+                        "discord": "whiveio#9340"
+                    },
+                    {
+                        "twitter": "whiveio"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.cointest.com:50001",
+                "contact": [
+                    {
+                        "email": "protocol@whive.io"
+                    },
+                    {
+                        "discord": "whiveio#9340"
+                    },
+                    {
+                        "twitter": "whiveio"
+                    }
+                ],
+                "protocol": "TCP"
+            },
             {
                 "url": "electrumx1.cointest.com:50002",
                 "protocol": "SSL",
@@ -36910,6 +45190,10 @@
                         "twitter": "ecashofficial"
                     }
                 ]
+            },
+            {
+                "url": "ecash.stackwallet.com:59004",
+                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/",
@@ -36994,6 +45278,42 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrum1.cipig.net:10002",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2.cipig.net:10002",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum3.cipig.net:10002",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1.cipig.net:20002",
                 "protocol": "SSL",
                 "contact": [
@@ -37020,6 +45340,42 @@
             {
                 "url": "electrum3.cipig.net:20002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum1.cipig.net:30002",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.cipig.net:30002",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "cipi@komodoplatform.com"
+                    },
+                    {
+                        "discord": "cipi#4502"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.cipig.net:30002",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "cipi@komodoplatform.com"
@@ -37084,6 +45440,30 @@
         "required_confirmations": 3,
         "electrum": [
             {
+                "url": "zombie.dragonhound.info:10033",
+                "contact": [
+                    {
+                        "email": "smk@komodoplatform.com"
+                    },
+                    {
+                        "discord": "smk#7640"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "zombie.dragonhound.info:10133",
+                "contact": [
+                    {
+                        "email": "smk@komodoplatform.com"
+                    },
+                    {
+                        "discord": "smk#7640"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "zombie.dragonhound.info:20033",
                 "protocol": "SSL",
                 "contact": [
@@ -37098,6 +45478,30 @@
             {
                 "url": "zombie.dragonhound.info:20133",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "smk@komodoplatform.com"
+                    },
+                    {
+                        "discord": "smk#7640"
+                    }
+                ]
+            },
+            {
+                "url": "zombie.dragonhound.info:30058",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "smk@komodoplatform.com"
+                    },
+                    {
+                        "discord": "smk#7640"
+                    }
+                ]
+            },
+            {
+                "url": "zombie.dragonhound.info:30059",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "smk@komodoplatform.com"
@@ -37190,6 +45594,42 @@
         },
         "electrum": [
             {
+                "url": "electrum2.runebase.io:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.runebase.io:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
+                "url": "electrum4.runebase.io:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
                 "url": "electrum2.runebase.io:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -37216,6 +45656,42 @@
             {
                 "url": "electrum4.runebase.io:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2.runebase.io:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.runebase.io:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
+                "url": "electrum4.runebase.io:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "support@runebase.io"
@@ -37261,8 +45737,26 @@
         "trezor_coin": "Komodo",
         "electrum": [
             {
+                "url": "electrumx2.actioncoin.com:10001",
+                "contact": [
+                    {
+                        "email": "support@actioncoin.com"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrumx2.actioncoin.com:30001",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "email": "support@actioncoin.com"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.actioncoin.com:20001",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "email": "support@actioncoin.com"
@@ -37562,6 +46056,36 @@
         },
         "electrum": [
             {
+                "url": "electrum.seed.mazanode.com:50001",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx.mazanode.com:50001",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrumx2.mazacha.in:50001",
+                "contact": [
+                    {
+                        "email": "contact@mazacoin.org"
+                    },
+                    {
+                        "discord": "sherm77#5923"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum.seed.mazanode.com:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -37590,8 +46114,78 @@
                         "discord": "sherm77#5923"
                     }
                 ]
+            },
+            {
+                "url": "electrum.seed.mazanode.com:50005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx.mazanode.com:50005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "brian@mazacoin.org"
+                    }
+                ]
+            },
+            {
+                "url": "electrumx2.mazacha.in:50005",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "contact@mazacoin.org"
+                    },
+                    {
+                        "discord": "sherm77#5923"
+                    }
+                ]
             }
         ],
+        "explorer_block_url": "block/"
+    },
+    "CRNC": {
+        "coin": "CRNC",
+        "type": "UTXO",
+        "name": "CrionicCoin",
+        "coinpaprika_id": "crnc-crionic",
+        "coingecko_id": "crionic",
+        "livecoinwatch_id": "CRNC",
+        "explorer_url": "https://explorer.crionic.org/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Crioniccoin Signed Message:\n",
+        "fname": "CrionicCoin",
+        "rpcport": 4466,
+        "pubtype": 28,
+        "p2shtype": 45,
+        "wiftype": 176,
+        "decimals": 8,
+        "signature_version": "base",
+        "txfee": 10000,
+        "segwit": true,
+        "bech32_hrp": "crnc",
+        "mm2": 1,
+        "required_confirmations": 3,
+        "avg_blocktime": 20,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/192'",
+        "links": {
+            "github": "https://github.com/diabaths/Crionic-Coin",
+            "homepage": "https://coin.crionic.org"
+        },
+        "electrum": [],
         "explorer_block_url": "block/"
     },
     "EVR": {
@@ -37630,6 +46224,30 @@
         },
         "electrum": [
             {
+                "url": "electrum1-mainnet.evrmorecoin.org:50001",
+                "contact": [
+                    {
+                        "email": "hans_schm1dt@protonmail.com"
+                    },
+                    {
+                        "discord": "Hans_Schmidt#0745"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
+                "url": "electrum2-mainnet.evrmorecoin.org:50001",
+                "contact": [
+                    {
+                        "email": "hans_schm1dt@protonmail.com"
+                    },
+                    {
+                        "discord": "Hans_Schmidt#0745"
+                    }
+                ],
+                "protocol": "TCP"
+            },
+            {
                 "url": "electrum1-mainnet.evrmorecoin.org:50002",
                 "protocol": "SSL",
                 "contact": [
@@ -37652,8 +46270,70 @@
                         "discord": "Hans_Schmidt#0745"
                     }
                 ]
+            },
+            {
+                "url": "electrum1-mainnet.evrmorecoin.org:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "hans_schm1dt@protonmail.com"
+                    },
+                    {
+                        "discord": "Hans_Schmidt#0745"
+                    }
+                ]
+            },
+            {
+                "url": "electrum2-mainnet.evrmorecoin.org:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "hans_schm1dt@protonmail.com"
+                    },
+                    {
+                        "discord": "Hans_Schmidt#0745"
+                    }
+                ]
             }
         ],
+        "explorer_block_url": "block/"
+    },
+    "BKC": {
+        "coin": "BKC",
+        "type": "UTXO",
+        "name": "Bunkercoin",
+        "coinpaprika_id": "bkc-bunkercoin",
+        "coingecko_id": "",
+        "livecoinwatch_id": "",
+        "explorer_url": "https://bkcexplorer.bunker.mt/",
+        "explorer_tx_url": "",
+        "explorer_address_url": "",
+        "supported": [],
+        "active": false,
+        "is_testnet": false,
+        "currently_enabled": false,
+        "wallet_only": false,
+        "sign_message_prefix": "Bunkercoin Signed Message:\n",
+        "fname": "Bunkercoin",
+        "rpcport": 22555,
+        "pubtype": 25,
+        "p2shtype": 22,
+        "wiftype": 158,
+        "txfee": 1000000,
+        "force_min_relay_fee": true,
+        "dust": 1000000,
+        "mm2": 1,
+        "required_confirmations": 10,
+        "avg_blocktime": 60,
+        "protocol": {
+            "type": "UTXO"
+        },
+        "derivation_path": "m/44'/3'",
+        "links": {
+            "github": "https://github.com/bunkercoin/bunkercoin",
+            "homepage": "https://bunkercoin.org"
+        },
+        "electrum": [],
         "explorer_block_url": "block/"
     },
     "KIIRO": {
@@ -37692,6 +46372,15 @@
             {
                 "url": "electrum3.kiirocoin.org:50002",
                 "protocol": "SSL",
+                "contact": [
+                    {
+                        "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrum3.kiirocoin.org:50004",
+                "protocol": "WSS",
                 "contact": [
                     {
                         "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
@@ -37801,6 +46490,24 @@
                         "discord": "Meowmancer#2099"
                     }
                 ]
+            },
+            {
+                "url": "meowcoinelectrum.xyz:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "Meowmancer#2099"
+                    }
+                ]
+            },
+            {
+                "url": "meowelectrum.xyz:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "Meowmancer#2099"
+                    }
+                ]
             }
         ],
         "explorer_block_url": "block/"
@@ -37842,8 +46549,27 @@
         },
         "electrum": [
             {
+                "url": "electrum.zoincommunity.com:50001",
+                "protocol": "TCP",
+                "contact": [
+                    {
+                        "github": "https://github.com/seopub/electrumx_zoin/issues"
+                    }
+                ]
+            },
+            {
                 "url": "electrum.zoincommunity.com:50002",
                 "protocol": "SSL",
+                "disable_cert_verification": true,
+                "contact": [
+                    {
+                        "github": "https://github.com/seopub/electrumx_zoin/issues"
+                    }
+                ]
+            },
+            {
+                "url": "electrum.zoincommunity.com:50004",
+                "protocol": "WSS",
                 "disable_cert_verification": true,
                 "contact": [
                     {

--- a/utils/coins_config_wss.json
+++ b/utils/coins_config_wss.json
@@ -778,16 +778,21 @@
         },
         "electrum": [
             {
+                "url": "aby-ex-four.ewmci.online:50013",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
+            {
                 "url": "elec-seeder-one.artbytecoin.org:50013",
                 "protocol": "WSS",
                 "disable_cert_verification": true
             },
             {
                 "url": "elec-seeder-two.artbytecoin.org:50013",
-                "protocol": "WSS"
-            },
-            {
-                "url": "electrumx-three.artbyte.live:50013",
                 "protocol": "WSS"
             }
         ],
@@ -5327,10 +5332,6 @@
         },
         "derivation_path": "m/44'/664'",
         "electrum": [
-            {
-                "url": "electrumserver01.globalboost.info:50013",
-                "protocol": "WSS"
-            },
             {
                 "url": "electrumserver02.globalboost.info:50013",
                 "protocol": "WSS"
@@ -10602,6 +10603,11 @@
                 "url": "electrum1.egulden.org:50004",
                 "protocol": "WSS",
                 "disable_cert_verification": true
+            },
+            {
+                "url": "electrum3.egulden.org:50004",
+                "protocol": "WSS",
+                "disable_cert_verification": true
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -15576,6 +15582,15 @@
             "type": "UTXO"
         },
         "electrum": [
+            {
+                "url": "il8p-ex-five.ewmci.online:50003",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "discord": "475820011634819072"
+                    }
+                ]
+            },
             {
                 "url": "il8p.electrumx.transcenders.name:50003",
                 "protocol": "WSS",
@@ -24964,10 +24979,6 @@
             {
                 "url": "electrum02.reddcoin.com:50004",
                 "protocol": "WSS"
-            },
-            {
-                "url": "electrum03.reddcoin.com:50004",
-                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block/"
@@ -25942,21 +25953,6 @@
             "homepage": "https://ridethebullcoin.com"
         },
         "electrum": [
-            {
-                "url": "electrumx1.ridethebullcoin.com:20052",
-                "protocol": "WSS",
-                "contact": [
-                    {
-                        "email": "rtbadmin@ridethebullcoin.com"
-                    },
-                    {
-                        "github": "RTBCoin"
-                    },
-                    {
-                        "discord": "rtbcoin"
-                    }
-                ]
-            },
             {
                 "url": "electrumx2.ridethebullcoin.com:20052",
                 "protocol": "WSS",
@@ -29707,6 +29703,11 @@
         },
         "electrum": [
             {
+                "url": "failover.trc-uis.ewmcx.biz:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": false
+            },
+            {
                 "url": "uis-uno.ewmcx.net:50003",
                 "protocol": "WSS",
                 "disable_cert_verification": false
@@ -30206,6 +30207,11 @@
             "homepage": "https://unobtanium.uno"
         },
         "electrum": [
+            {
+                "url": "uno-bkp.coinmunity.gold:50003",
+                "protocol": "WSS",
+                "disable_cert_verification": true
+            },
             {
                 "url": "uno-main.coinmunity.gold:50003",
                 "protocol": "WSS",
@@ -33668,50 +33674,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "XVG": {
-        "coin": "XVG",
-        "type": "UTXO",
-        "name": "Verge",
-        "coinpaprika_id": "xvg-verge",
-        "coingecko_id": "verge",
-        "livecoinwatch_id": "XVG",
-        "explorer_url": "https://xvgblockexplorer.com/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "VERGE Signed Message:\n",
-        "fname": "Verge",
-        "isPoS": 1,
-        "rpcport": 20102,
-        "pubtype": 30,
-        "p2shtype": 33,
-        "wiftype": 158,
-        "decimals": 6,
-        "segwit": true,
-        "bech32_hrp": "vg",
-        "txfee": 400000,
-        "dust": 400000,
-        "force_min_relay_fee": true,
-        "mm2": 1,
-        "required_confirmations": 10,
-        "avg_blocktime": 30,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/77'",
-        "electrum": [
-            {
-                "url": "electrumx-verge.cloud:50004",
-                "protocol": "WSS"
-            }
-        ],
-        "explorer_block_url": "block/",
-        "binance_id": "XVG"
-    },
     "XVS-BEP20": {
         "coin": "XVS-BEP20",
         "type": "BEP-20",
@@ -34416,10 +34378,6 @@
                         "discord": "475820011634819072"
                     }
                 ]
-            },
-            {
-                "url": "zeta-seed-d.zetacoin.network:50013",
-                "protocol": "WSS"
             }
         ],
         "explorer_block_url": "block.dws?"
@@ -37202,6 +37160,18 @@
         },
         "electrum": [
             {
+                "url": "electrum2.runebase.io:50004",
+                "protocol": "WSS",
+                "contact": [
+                    {
+                        "email": "support@runebase.io"
+                    },
+                    {
+                        "discord": "Bago#7842"
+                    }
+                ]
+            },
+            {
                 "url": "electrum3.runebase.io:50004",
                 "protocol": "WSS",
                 "contact": [
@@ -37594,71 +37564,6 @@
         ],
         "explorer_block_url": "block/"
     },
-    "CRNC": {
-        "coin": "CRNC",
-        "type": "UTXO",
-        "name": "CrionicCoin",
-        "coinpaprika_id": "crnc-crionic",
-        "coingecko_id": "crionic",
-        "livecoinwatch_id": "CRNC",
-        "explorer_url": "https://explorer.crionic.org/",
-        "explorer_tx_url": "",
-        "explorer_address_url": "",
-        "supported": [],
-        "active": false,
-        "is_testnet": false,
-        "currently_enabled": false,
-        "wallet_only": false,
-        "sign_message_prefix": "Crioniccoin Signed Message:\n",
-        "fname": "CrionicCoin",
-        "rpcport": 4466,
-        "pubtype": 28,
-        "p2shtype": 45,
-        "wiftype": 176,
-        "decimals": 8,
-        "signature_version": "base",
-        "txfee": 10000,
-        "segwit": true,
-        "bech32_hrp": "crnc",
-        "mm2": 1,
-        "required_confirmations": 3,
-        "avg_blocktime": 20,
-        "protocol": {
-            "type": "UTXO"
-        },
-        "derivation_path": "m/44'/192'",
-        "links": {
-            "github": "https://github.com/diabaths/Crionic-Coin",
-            "homepage": "https://coin.crionic.org"
-        },
-        "electrum": [
-            {
-                "url": "coin.crionic.org:50005",
-                "protocol": "WSS",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            },
-            {
-                "url": "explorer.crionic.org:50005",
-                "protocol": "WSS",
-                "contact": [
-                    {
-                        "email": "diabatiis@gmail.com"
-                    },
-                    {
-                        "discord": "Diabaths#1919"
-                    }
-                ]
-            }
-        ],
-        "explorer_block_url": "block/"
-    },
     "EVR": {
         "coin": "EVR",
         "type": "UTXO",
@@ -37754,15 +37659,6 @@
             "homepage": "https://kiirocoin.org"
         },
         "electrum": [
-            {
-                "url": "electrum1.kiirocoin.org:50004",
-                "protocol": "WSS",
-                "contact": [
-                    {
-                        "github": "https://github.com/kiirocoin/electrum-kiiro/issues"
-                    }
-                ]
-            },
             {
                 "url": "electrum3.kiirocoin.org:50004",
                 "protocol": "WSS",

--- a/utils/electrum_scan_report.json
+++ b/utils/electrum_scan_report.json
@@ -1,35 +1,35 @@
 {
     "ABY": {
         "electrums_total_all": 11,
-        "electrums_working_all": 6,
+        "electrums_working_all": 9,
         "electrums_total_tcp": 1,
-        "electrums_working_tcp": 0,
+        "electrums_working_tcp": 1,
         "electrums_total_ssl": 5,
-        "electrums_working_ssl": 3,
+        "electrums_working_ssl": 4,
         "electrums_total_wss": 5,
-        "electrums_working_wss": 3,
+        "electrums_working_wss": 4,
         "tcp": {
             "aby-ex-four.ewmci.online:50011": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "ssl": {
+            "aby-ex-four.ewmci.online:50012": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "elec-seeder-one.artbytecoin.org:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "elec-seeder-two.artbytecoin.org:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx-three.artbyte.live:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "aby-ex-four.ewmci.online:50012": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
             },
             "electrumx-four.artbyte.live:50012": {
                 "last_connection": 0,
@@ -37,21 +37,21 @@
             }
         },
         "wss": {
+            "aby-ex-four.ewmci.online:50013": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "elec-seeder-one.artbytecoin.org:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "elec-seeder-two.artbytecoin.org:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx-three.artbyte.live:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "aby-ex-four.ewmci.online:50013": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('23.158.200.73', 50013)"
             },
             "electrumx-four.artbyte.live:50013": {
                 "last_connection": 0,
@@ -60,42 +60,38 @@
         }
     },
     "ACTN": {
-        "electrums_total_all": 6,
+        "electrums_total_all": 5,
         "electrums_working_all": 3,
         "electrums_total_tcp": 2,
         "electrums_working_tcp": 1,
         "electrums_total_ssl": 2,
         "electrums_working_ssl": 1,
-        "electrums_total_wss": 2,
+        "electrums_total_wss": 1,
         "electrums_working_wss": 1,
         "tcp": {
             "electrumx2.actioncoin.com:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.actioncoin.com:10001": {
                 "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "result": "timed out"
             }
         },
         "ssl": {
             "electrumx2.actioncoin.com:30001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.actioncoin.com:30001": {
                 "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "result": "timed out"
             }
         },
         "wss": {
             "electrumx2.actioncoin.com:20001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "electrumx1.actioncoin.com:20001": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('157.230.70.123', 20001)"
             }
         }
     },
@@ -110,7 +106,7 @@
         "electrums_working_wss": 1,
         "tcp": {
             "aibc.pro:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "aibcelectrum.com:50001": {
@@ -121,7 +117,7 @@
         "ssl": {},
         "wss": {
             "aibc.pro:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "aibcelectrum.com:50002": {
@@ -142,21 +138,21 @@
         "tcp": {},
         "ssl": {
             "electrumx1.aipowergrid.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.aipowergrid.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrumx1.aipowergrid.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.aipowergrid.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -172,43 +168,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -225,11 +221,11 @@
         "tcp": {},
         "ssl": {
             "electrumx.aur.ewmcx.info:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "failover.aur.ewmcx.biz:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "lenoir.ecoincore.com:12343": {
@@ -239,11 +235,11 @@
         },
         "wss": {
             "electrumx.aur.ewmcx.info:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "failover.aur.ewmcx.biz:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -259,43 +255,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum-ca.avn.network:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum-eu.avn.network:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum-us.avn.network:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum-ca.avn.network:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum-eu.avn.network:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum-us.avn.network:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum-ca.avn.network:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum-eu.avn.network:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum-us.avn.network:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -311,59 +307,59 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30057": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "AYA": {
-        "electrums_total_all": 7,
+        "electrums_total_all": 6,
         "electrums_working_all": 1,
         "electrums_total_tcp": 3,
         "electrums_working_tcp": 1,
         "electrums_total_ssl": 2,
         "electrums_working_ssl": 0,
-        "electrums_total_wss": 2,
+        "electrums_total_wss": 1,
         "electrums_working_wss": 0,
         "tcp": {
             "88.99.26.209:5151": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum1.aryacoin.io:2052": {
@@ -386,10 +382,6 @@
             }
         },
         "wss": {
-            "electrum1.aryacoin.io:2051": {
-                "last_connection": 0,
-                "result": ""
-            },
             "electrum2.aryacoin.io:2051": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connect call failed ('162.254.32.140', 2051)"
@@ -407,11 +399,11 @@
         "electrums_working_wss": 0,
         "tcp": {
             "bbk-one.ewm-cx.net:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "bbk-two.ewm-cx.net:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -429,59 +421,59 @@
         "electrums_working_wss": 4,
         "tcp": {
             "electrum3.cipig.net:10055": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "bch.imaginary.cash:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "bch.soul-dev.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "cashnode.bch.ninja:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20055": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "bch.imaginary.cash:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "bch.soul-dev.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "cashnode.bch.ninja:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30055": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "BITN": {
-        "electrums_total_all": 4,
+        "electrums_total_all": 3,
         "electrums_working_all": 2,
         "electrums_total_tcp": 2,
         "electrums_working_tcp": 1,
         "electrums_total_ssl": 0,
         "electrums_working_ssl": 0,
-        "electrums_total_wss": 2,
+        "electrums_total_wss": 1,
         "electrums_working_wss": 1,
         "tcp": {
             "bitexplorer.io:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "bitchair.io:50001": {
@@ -492,12 +484,8 @@
         "ssl": {},
         "wss": {
             "bitexplorer.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "bitchair.io:50004": {
-                "last_connection": 0,
-                "result": ""
             }
         }
     },
@@ -513,7 +501,7 @@
         "tcp": {
             "bunkerelectrum.bunker.mt:50001": {
                 "last_connection": 0,
-                "result": "timed out"
+                "result": "[Errno 113] No route to host"
             }
         },
         "ssl": {},
@@ -530,43 +518,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.blackcoin.nl:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blackcoin.nl:20001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blackcoin.nl:30001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.blackcoin.nl:10002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blackcoin.nl:20002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blackcoin.nl:30002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.blackcoin.nl:10004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blackcoin.nl:20004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blackcoin.nl:30004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -582,11 +570,11 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrum1.blocx.live:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blocx.live:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blocx.live:50001": {
@@ -596,11 +584,11 @@
         },
         "ssl": {
             "electrum1.blocx.live:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blocx.live:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blocx.live:50002": {
@@ -610,11 +598,11 @@
         },
         "wss": {
             "electrum1.blocx.live:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blocx.live:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blocx.live:50004": {
@@ -634,7 +622,7 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrum2.bolivarcoin.tech:23001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -643,41 +631,41 @@
     },
     "BSTY": {
         "electrums_total_all": 6,
-        "electrums_working_all": 6,
+        "electrums_working_all": 3,
         "electrums_total_tcp": 2,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 1,
         "electrums_total_ssl": 2,
-        "electrums_working_ssl": 2,
+        "electrums_working_ssl": 1,
         "electrums_total_wss": 2,
-        "electrums_working_wss": 2,
+        "electrums_working_wss": 1,
         "tcp": {
-            "electrumserver01.globalboost.info:50011": {
-                "last_connection": 1716048185,
+            "electrumserver02.globalboost.info:50011": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrumserver02.globalboost.info:50011": {
+            "electrumserver01.globalboost.info:50011": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {
-            "electrumserver01.globalboost.info:50014": {
-                "last_connection": 1716048185,
+            "electrumserver02.globalboost.info:50014": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrumserver02.globalboost.info:50014": {
+            "electrumserver01.globalboost.info:50014": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
-            "electrumserver01.globalboost.info:50013": {
-                "last_connection": 1716048185,
+            "electrumserver02.globalboost.info:50013": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrumserver02.globalboost.info:50013": {
+            "electrumserver01.globalboost.info:50013": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connect call failed ('142.54.191.210', 50013)"
             }
         }
     },
@@ -692,43 +680,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30000": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -744,34 +732,34 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrum1.btcz.rocks:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.btcz.rocks:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "electrum1.btcz.rocks:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.btcz.rocks:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "BTE": {
-        "electrums_total_all": 6,
+        "electrums_total_all": 3,
         "electrums_working_all": 0,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 3,
         "electrums_working_ssl": 0,
-        "electrums_total_wss": 3,
+        "electrums_total_wss": 0,
         "electrums_working_wss": 0,
         "tcp": {},
         "ssl": {
@@ -788,20 +776,7 @@
                 "result": "timed out"
             }
         },
-        "wss": {
-            "electrumx.bitwebcore.net:20003": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrumx1.bitwebcore.net:20003": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrumx2.bitwebcore.net:20003": {
-                "last_connection": 0,
-                "result": ""
-            }
-        }
+        "wss": {}
     },
     "BTX": {
         "electrums_total_all": 2,
@@ -815,13 +790,13 @@
         "tcp": {},
         "ssl": {
             "btx-electrumx.coinsmunity.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "btx-electrumx.coinsmunity.com:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -837,80 +812,80 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30029": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "CDN": {
-        "electrums_total_all": 13,
+        "electrums_total_all": 12,
         "electrums_working_all": 10,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 8,
         "electrums_working_ssl": 6,
-        "electrums_total_wss": 5,
+        "electrums_total_wss": 4,
         "electrums_working_wss": 4,
         "tcp": {},
         "ssl": {
             "chicago.ecoincore.com:34333": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "holland.ecoincore.com:34333": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "miami.ecoincore.com:34333": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "mumbai.ecoincore.com:34333": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "oakland.ecoincore.com:34333": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "woolloomooloo.ecoincore.com:34333": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "lenoir.ecoincore.com:34333": {
@@ -924,24 +899,20 @@
         },
         "wss": {
             "holland.ecoincore.com:34335": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "miami.ecoincore.com:34335": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "mumbai.ecoincore.com:34335": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "woolloomooloo.ecoincore.com:34335": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "lenoir.ecoincore.com:34335": {
-                "last_connection": 0,
-                "result": ""
             }
         }
     },
@@ -956,68 +927,68 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30053": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "CHTA": {
         "electrums_total_all": 3,
-        "electrums_working_all": 2,
+        "electrums_working_all": 3,
         "electrums_total_tcp": 3,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 3,
         "electrums_total_ssl": 0,
         "electrums_working_ssl": 0,
         "electrums_total_wss": 0,
         "electrums_working_wss": 0,
         "tcp": {
             "electrum.shorelinecrypto.com:10007": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum1.mooo.com:10007": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.mooo.com:10007": {
-                "last_connection": 0,
-                "result": "timed out"
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "ssl": {},
@@ -1034,19 +1005,19 @@
         "electrums_working_wss": 1,
         "tcp": {
             "clam-ex-one.ewmci.online:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "clam-ex-one.ewmci.online:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "clam-ex-one.ewmci.online:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1062,7 +1033,7 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx.cryptocollider.com:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -1071,41 +1042,41 @@
     },
     "CRNC": {
         "electrums_total_all": 6,
-        "electrums_working_all": 6,
+        "electrums_working_all": 0,
         "electrums_total_tcp": 2,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 0,
         "electrums_total_ssl": 2,
-        "electrums_working_ssl": 2,
+        "electrums_working_ssl": 0,
         "electrums_total_wss": 2,
-        "electrums_working_wss": 2,
+        "electrums_working_wss": 0,
         "tcp": {
             "coin.crionic.org:50001": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             },
             "explorer.crionic.org:50001": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {
             "coin.crionic.org:50002": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             },
             "explorer.crionic.org:50002": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
             "coin.crionic.org:50005": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connect call failed ('194.163.132.161', 50005)"
             },
             "explorer.crionic.org:50005": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connect call failed ('158.220.97.200', 50005)"
             }
         }
     },
@@ -1121,11 +1092,11 @@
         "tcp": {},
         "ssl": {
             "electrum02.cyberyen.work:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum03.cyberyen.work:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum01.cyberyen.work:50002": {
@@ -1135,11 +1106,11 @@
         },
         "wss": {
             "electrum02.cyberyen.work:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum03.cyberyen.work:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum01.cyberyen.work:50004": {
@@ -1159,43 +1130,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30061": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1211,72 +1182,68 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "DGC": {
-        "electrums_total_all": 4,
+        "electrums_total_all": 3,
         "electrums_working_all": 3,
         "electrums_total_tcp": 1,
         "electrums_working_tcp": 1,
         "electrums_total_ssl": 1,
         "electrums_working_ssl": 1,
-        "electrums_total_wss": 2,
+        "electrums_total_wss": 1,
         "electrums_working_wss": 1,
         "tcp": {
             "electrumx.dgc.ewmcx.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "failover.dgc.ewmcx.biz:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "failover.dgc.ewmcx.biz:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "electrumx.dgc.ewmcx.org:50003": {
-                "last_connection": 0,
-                "result": ""
             }
         }
     },
@@ -1301,21 +1268,21 @@
         },
         "ssl": {
             "electrum1.cipig.net:20072": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20072": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30072": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30072": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1331,7 +1298,7 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx.dimecoinnetwork.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -1350,21 +1317,21 @@
         "tcp": {},
         "ssl": {
             "electrumx1.diminutivecoin.com:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.diminutivecoin.com:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrumx1.diminutivecoin.com:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.diminutivecoin.com:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1380,43 +1347,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1432,43 +1399,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30060": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1484,14 +1451,14 @@
         "electrums_working_wss": 1,
         "tcp": {
             "dogec-one.ewm-cx.com:50006": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "dogec-one.ewm-cx.com:50008": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1507,25 +1474,25 @@
         "electrums_working_wss": 0,
         "tcp": {
             "pink-deer-69.doi.works:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "big-parrot-60.doi.works:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "itchy-jellyfish-89.doi.works:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "pink-deer-69.doi.works:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "ugly-bird-70.doi.works:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -1542,7 +1509,7 @@
         "electrums_working_wss": 0,
         "tcp": {
             "1.eu.dp.electrum.dexstats.info:10021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -1561,29 +1528,29 @@
         "tcp": {},
         "ssl": {
             "electrumxdpc.bitwebcore.net:22002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumxdpc1.bitwebcore.net:22002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumxdpc2.bitwebcore.net:22002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrumxdpc.bitwebcore.net:22003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumxdpc1.bitwebcore.net:22003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumxdpc2.bitwebcore.net:22003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1599,55 +1566,55 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrum1.cipig.net:10052": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10052": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20052": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20052": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30052": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30052": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "EFL": {
-        "electrums_total_all": 12,
-        "electrums_working_all": 2,
+        "electrums_total_all": 9,
+        "electrums_working_all": 4,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 6,
-        "electrums_working_ssl": 1,
-        "electrums_total_wss": 6,
-        "electrums_working_wss": 1,
+        "electrums_working_ssl": 2,
+        "electrums_total_wss": 3,
+        "electrums_working_wss": 2,
         "tcp": {},
         "ssl": {
             "electrum1.egulden.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
+            "electrum3.egulden.org:50002": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.egulden.org:50002": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
-            },
-            "electrum3.egulden.org:50002": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connection refused"
             },
@@ -1666,28 +1633,16 @@
         },
         "wss": {
             "electrum1.egulden.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
+            "electrum3.egulden.org:50004": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.egulden.org:50004": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connect call failed ('136.144.199.124', 50004)"
-            },
-            "electrum3.egulden.org:50004": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('81.169.167.87', 50004)"
-            },
-            "electrum5.egulden.org:11019": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "holland.ecoincore.com:11019": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "lenoir.ecoincore.com:11019": {
-                "last_connection": 0,
-                "result": ""
             }
         }
     },
@@ -1702,43 +1657,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30062": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1754,31 +1709,31 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrum1-mainnet.evrmorecoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2-mainnet.evrmorecoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1-mainnet.evrmorecoin.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2-mainnet.evrmorecoin.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1-mainnet.evrmorecoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2-mainnet.evrmorecoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1794,42 +1749,42 @@
         "electrums_working_wss": 4,
         "tcp": {
             "electrumx.firo.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx01.firo.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx02.firo.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx03.firo.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx05.firo.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "electrumx.firo.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx01.firo.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx02.firo.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx03.firo.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1845,31 +1800,31 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrumx1.fujicoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.fujicoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrumx1.fujicoin.org:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.fujicoin.org:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrumx1.fujicoin.org:50005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.fujicoin.org:50005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1885,11 +1840,11 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx.runonflux.io:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.runonflux.io:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -1897,11 +1852,11 @@
         "wss": {
             "electrumx.runonflux.io:50004": {
                 "last_connection": 0,
-                "result": "Multiple exceptions: [Errno 111] Connect call failed ('95.217.0.178', 50004), [Errno 101] Network is unreachable"
+                "result": "Multiple exceptions: [Errno 111] Connect call failed ('95.217.0.178', 50004), [Errno 101] Connect call failed ('2a01:4f9:c012:853e::', 50004, 0, 0)"
             },
             "electrumx2.runonflux.io:50004": {
                 "last_connection": 0,
-                "result": "Multiple exceptions: [Errno 111] Connect call failed ('135.181.29.202', 50004), [Errno 101] Network is unreachable"
+                "result": "Multiple exceptions: [Errno 111] Connect call failed ('135.181.29.202', 50004), [Errno 101] Connect call failed ('2a01:4f9:c010:db66::', 50004, 0, 0)"
             }
         }
     },
@@ -1916,43 +1871,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30054": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -1968,7 +1923,7 @@
         "electrums_working_wss": 0,
         "tcp": {
             "88.99.26.209:5128": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -1986,31 +1941,31 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrum1.netseed.net:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.netseed.net:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.netseed.net:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.netseed.net:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.netseed.net:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.netseed.net:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2026,43 +1981,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30022": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2078,21 +2033,21 @@
         "electrums_working_wss": 1,
         "tcp": {
             "electrum.maxpuig.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.niftybakes.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum.maxpuig.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "uk.garlium.crapules.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "au.garlium.crapules.org:50002": {
@@ -2114,27 +2069,27 @@
         },
         "wss": {
             "electrum.maxpuig.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "GRMS": {
-        "electrums_total_all": 12,
+        "electrums_total_all": 10,
         "electrums_working_all": 6,
         "electrums_total_tcp": 4,
         "electrums_working_tcp": 2,
         "electrums_total_ssl": 4,
         "electrums_working_ssl": 2,
-        "electrums_total_wss": 4,
+        "electrums_total_wss": 2,
         "electrums_working_wss": 2,
         "tcp": {
             "electrum1.grms.pw:17485": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.grms.pw:17485": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.grms.pw:17485": {
@@ -2148,11 +2103,11 @@
         },
         "ssl": {
             "electrum1.grms.pw:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.grms.pw:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.grms.pw:50002": {
@@ -2166,147 +2121,139 @@
         },
         "wss": {
             "electrum1.grms.pw:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.grms.pw:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "electrum.grms.pw:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrum2.grms.pw:50004": {
-                "last_connection": 0,
-                "result": ""
             }
         }
     },
     "GRS": {
-        "electrums_total_all": 78,
+        "electrums_total_all": 72,
         "electrums_working_all": 60,
         "electrums_total_tcp": 38,
         "electrums_working_tcp": 29,
         "electrums_total_ssl": 1,
         "electrums_working_ssl": 1,
-        "electrums_total_wss": 39,
+        "electrums_total_wss": 33,
         "electrums_working_wss": 30,
         "tcp": {
             "electrum1.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum12.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum13.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum14.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum15.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum16.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum17.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum18.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum19.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum20.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum21.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum22.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum23.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum24.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum25.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum26.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum27.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum28.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum31.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum32.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum33.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum34.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum35.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum36.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum37.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum38.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum39.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum40.groestlcoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum29.groestlcoin.org:50001": {
@@ -2343,215 +2290,191 @@
             },
             "electrum9.groestlcoin.org:50001": {
                 "last_connection": 0,
-                "result": "timed out"
+                "result": "[Errno 113] No route to host"
             }
         },
         "ssl": {
             "electrum11.groestlcoin.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum11.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum12.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum13.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum14.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum15.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum16.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum17.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum18.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum19.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum20.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum21.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum22.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum23.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum24.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum25.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum26.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum27.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum28.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum31.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum32.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum33.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum34.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum35.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum36.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum37.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum38.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum39.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum40.groestlcoin.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum29.groestlcoin.org:50004": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connect call failed ('45.63.25.237', 50004)"
             },
-            "electrum3.groestlcoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
             "electrum30.groestlcoin.org:50004": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connect call failed ('45.32.33.53', 50004)"
             },
-            "electrum4.groestlcoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrum5.groestlcoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrum6.groestlcoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrum7.groestlcoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
-            "electrum8.groestlcoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
-            },
             "electrum9.groestlcoin.org:50004": {
                 "last_connection": 0,
-                "result": ""
+                "result": "[Errno 113] Connect call failed ('128.199.255.51', 50004)"
             }
         }
     },
     "IL8P": {
         "electrums_total_all": 7,
-        "electrums_working_all": 4,
+        "electrums_working_all": 7,
         "electrums_total_tcp": 1,
-        "electrums_working_tcp": 0,
+        "electrums_working_tcp": 1,
         "electrums_total_ssl": 3,
-        "electrums_working_ssl": 2,
+        "electrums_working_ssl": 3,
         "electrums_total_wss": 3,
-        "electrums_working_wss": 2,
+        "electrums_working_wss": 3,
         "tcp": {
             "il8p-ex-five.ewmci.online:50001": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "ssl": {
+            "il8p-ex-five.ewmci.online:50002": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "il8p.electrumx.transcenders.name:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "il9p.electrumx.transcenders.name:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "il8p-ex-five.ewmci.online:50002": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
+            "il8p-ex-five.ewmci.online:50003": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "il8p.electrumx.transcenders.name:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "il9p.electrumx.transcenders.name:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "il8p-ex-five.ewmci.online:50003": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('38.114.120.228', 50003)"
             }
         }
     },
@@ -2587,28 +2510,28 @@
         }
     },
     "KIIRO": {
-        "electrums_total_all": 7,
-        "electrums_working_all": 5,
+        "electrums_total_all": 6,
+        "electrums_working_all": 2,
         "electrums_total_tcp": 1,
-        "electrums_working_tcp": 1,
+        "electrums_working_tcp": 0,
         "electrums_total_ssl": 3,
-        "electrums_working_ssl": 2,
-        "electrums_total_wss": 3,
-        "electrums_working_wss": 2,
+        "electrums_working_ssl": 1,
+        "electrums_total_wss": 2,
+        "electrums_working_wss": 1,
         "tcp": {
             "electrum1.kiirocoin.org:50001": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {
-            "electrum1.kiirocoin.org:50002": {
-                "last_connection": 1716048185,
+            "electrum3.kiirocoin.org:50002": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrum3.kiirocoin.org:50002": {
+            "electrum1.kiirocoin.org:50002": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             },
             "electrum2.kiirocoin.org:50002": {
                 "last_connection": 0,
@@ -2616,17 +2539,13 @@
             }
         },
         "wss": {
+            "electrum3.kiirocoin.org:50004": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "electrum1.kiirocoin.org:50004": {
                 "last_connection": 1716048185,
-                "result": "Passed"
-            },
-            "electrum3.kiirocoin.org:50004": {
-                "last_connection": 1716048185,
-                "result": "Passed"
-            },
-            "electrum2.kiirocoin.org:50004": {
-                "last_connection": 0,
-                "result": ""
+                "result": "[Errno 111] Connect call failed ('5.78.105.104', 50004)"
             }
         }
     },
@@ -2641,43 +2560,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2693,43 +2612,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30015": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2745,43 +2664,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30016": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2797,43 +2716,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2849,43 +2768,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30024": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2901,39 +2820,39 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum2.cipig.net:30019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30019": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -2949,43 +2868,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30067": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3001,11 +2920,11 @@
         "electrums_working_wss": 1,
         "tcp": {
             "88.99.26.209:5140": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "lcc-ex-one.ewmci.online:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "188.166.117.139:50001": {
@@ -3015,13 +2934,13 @@
         },
         "ssl": {
             "lcc-ex-one.ewmci.online:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "lcc-ex-one.ewmci.online:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3059,43 +2978,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30063": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3112,45 +3031,45 @@
         "tcp": {},
         "ssl": {
             "electrum5.getlynx.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum6.getlynx.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum7.getlynx.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum8.getlynx.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum9.getlynx.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum5.getlynx.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum6.getlynx.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum7.getlynx.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum8.getlynx.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum9.getlynx.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3166,43 +3085,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30021": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3218,15 +3137,15 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum.seed.mazanode.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.mazanode.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.mazacha.in:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.mazacha.in:50001": {
@@ -3236,15 +3155,15 @@
         },
         "ssl": {
             "electrum.seed.mazanode.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.mazanode.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.mazacha.in:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.mazacha.in:50002": {
@@ -3254,15 +3173,15 @@
         },
         "wss": {
             "electrum.seed.mazanode.com:50005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.mazanode.com:50005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.mazacha.in:50005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.mazacha.in:50005": {
@@ -3282,43 +3201,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30023": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3335,21 +3254,21 @@
         "tcp": {},
         "ssl": {
             "meowcoinelectrum.xyz:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "meowelectrum.xyz:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "meowcoinelectrum.xyz:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "meowelectrum.xyz:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3365,43 +3284,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30069": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3417,15 +3336,15 @@
         "electrums_working_wss": 0,
         "tcp": {
             "133.167.67.203:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.tamami-foundation.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.monacoin.ninja:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.monacoin.nl:50001": {
@@ -3437,22 +3356,22 @@
         "wss": {}
     },
     "NAV": {
-        "electrums_total_all": 6,
+        "electrums_total_all": 5,
         "electrums_working_all": 4,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 3,
         "electrums_working_ssl": 2,
-        "electrums_total_wss": 3,
+        "electrums_total_wss": 2,
         "electrums_working_wss": 2,
         "tcp": {},
         "ssl": {
             "electrum2.nav.community:40002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.nav.community:40002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum4.nav.community:40002": {
@@ -3462,35 +3381,35 @@
         },
         "wss": {
             "electrum2.nav.community:40004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.nav.community:40004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "electrum4.nav.community:40004": {
-                "last_connection": 0,
-                "result": ""
             }
         }
     },
     "NENG": {
-        "electrums_total_all": 2,
-        "electrums_working_all": 2,
-        "electrums_total_tcp": 2,
-        "electrums_working_tcp": 2,
+        "electrums_total_all": 3,
+        "electrums_working_all": 3,
+        "electrums_total_tcp": 3,
+        "electrums_working_tcp": 3,
         "electrums_total_ssl": 0,
         "electrums_working_ssl": 0,
         "electrums_total_wss": 0,
         "electrums_working_wss": 0,
         "tcp": {
             "electrum.shorelinecrypto.com:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum1.mooo.com:10001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
+            "electrum2.mooo.com:10001": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -3508,29 +3427,29 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrum1.cipig.net:10036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -3547,23 +3466,23 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx1.nmc.dotbit.zone:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.nmc.dotbit.zone:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.nmc.dotbit.zone:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx4.nmc.dotbit.zone:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "nmc2.bitcoins.sk:57001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx1.nmc.dotbit.zone:50004": {
@@ -3585,23 +3504,23 @@
         },
         "ssl": {
             "electrumx1.nmc.dotbit.zone:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.nmc.dotbit.zone:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.nmc.dotbit.zone:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx4.nmc.dotbit.zone:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "nmc2.bitcoins.sk:57002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -3619,11 +3538,11 @@
         "tcp": {},
         "ssl": {
             "electrumx.nvc.ewmcx.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "failover.nvc.ewmcx.biz:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -3662,21 +3581,21 @@
     },
     "PINK": {
         "electrums_total_all": 2,
-        "electrums_working_all": 1,
+        "electrums_working_all": 2,
         "electrums_total_tcp": 2,
-        "electrums_working_tcp": 1,
+        "electrums_working_tcp": 2,
         "electrums_total_ssl": 0,
         "electrums_working_ssl": 0,
         "electrums_total_wss": 0,
         "electrums_working_wss": 0,
         "tcp": {
             "pink-one.ewm-cx.net:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "pink-two.ewm-cx.net:50001": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "ssl": {},
@@ -3693,7 +3612,7 @@
         "electrums_working_wss": 1,
         "tcp": {
             "electrum01.chainster.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum02.chainster.org:50001": {
@@ -3704,7 +3623,7 @@
         "ssl": {},
         "wss": {
             "electrum01.chainster.org:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum02.chainster.org:50003": {
@@ -3724,14 +3643,14 @@
         "electrums_working_wss": 1,
         "tcp": {
             "electrum.thepandacoin.net:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "electrum.thepandacoin.net:443": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3748,21 +3667,21 @@
         "tcp": {},
         "ssl": {
             "pot-duo.ewmcx.net:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "pot-uno.ewmcx.net:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "pot-duo.ewmcx.net:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "pot-uno.ewmcx.net:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3779,21 +3698,21 @@
         "tcp": {},
         "ssl": {
             "allingas.peercoinexplorer.net:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.peercoinexplorer.net:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "allingas.peercoinexplorer.net:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.peercoinexplorer.net:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3809,31 +3728,31 @@
         "electrums_working_wss": 2,
         "tcp": {
             "electrumx.live:50010": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "txserver.live:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrumx.live:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "txserver.live:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrumx.live:30010": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "txserver.live:30001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -3849,83 +3768,83 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30050": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "RDD": {
         "electrums_total_all": 6,
-        "electrums_working_all": 6,
+        "electrums_working_all": 4,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 3,
-        "electrums_working_ssl": 3,
+        "electrums_working_ssl": 2,
         "electrums_total_wss": 3,
-        "electrums_working_wss": 3,
+        "electrums_working_wss": 2,
         "tcp": {},
         "ssl": {
             "electrum01.reddcoin.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum02.reddcoin.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum03.reddcoin.com:50002": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
             "electrum01.reddcoin.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum02.reddcoin.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum03.reddcoin.com:50004": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connect call failed ('198.211.121.69', 50004)"
             }
         }
     },
@@ -3940,68 +3859,68 @@
         "electrums_working_wss": 2,
         "tcp": {
             "ric-ex-two.ewmci.online:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum3.cipig.net:20074": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "ric-ex-two.ewmci.online:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum3.cipig.net:30074": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "ric-ex-two.ewmci.online:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "RTB": {
         "electrums_total_all": 6,
-        "electrums_working_all": 6,
+        "electrums_working_all": 3,
         "electrums_total_tcp": 2,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 1,
         "electrums_total_ssl": 2,
-        "electrums_working_ssl": 2,
+        "electrums_working_ssl": 1,
         "electrums_total_wss": 2,
-        "electrums_working_wss": 2,
+        "electrums_working_wss": 1,
         "tcp": {
-            "electrumx1.ridethebullcoin.com:10002": {
-                "last_connection": 1716048185,
+            "electrumx2.ridethebullcoin.com:10002": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrumx2.ridethebullcoin.com:10002": {
+            "electrumx1.ridethebullcoin.com:10002": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {
-            "electrumx1.ridethebullcoin.com:20053": {
-                "last_connection": 1716048185,
+            "electrumx2.ridethebullcoin.com:20053": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrumx2.ridethebullcoin.com:20053": {
+            "electrumx1.ridethebullcoin.com:20053": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
-            "electrumx1.ridethebullcoin.com:20052": {
-                "last_connection": 1716048185,
+            "electrumx2.ridethebullcoin.com:20052": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "electrumx2.ridethebullcoin.com:20052": {
+            "electrumx1.ridethebullcoin.com:20052": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connect call failed ('107.172.44.227', 20052)"
             }
         }
     },
@@ -4016,79 +3935,79 @@
         "electrums_working_wss": 2,
         "tcp": {
             "x1.raptoreum.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "x2.raptoreum.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "x1.raptoreum.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "x2.raptoreum.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "RUNES": {
         "electrums_total_all": 10,
-        "electrums_working_all": 6,
+        "electrums_working_all": 9,
         "electrums_total_tcp": 4,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 3,
         "electrums_total_ssl": 3,
-        "electrums_working_ssl": 2,
+        "electrums_working_ssl": 3,
         "electrums_total_wss": 3,
-        "electrums_working_wss": 2,
+        "electrums_working_wss": 3,
         "tcp": {
+            "electrum2.runebase.io:50001": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "electrum3.runebase.io:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum4.runebase.io:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum1.runebase.io:50001": {
                 "last_connection": 0,
                 "result": "timed out"
-            },
-            "electrum2.runebase.io:50001": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {
+            "electrum2.runebase.io:50002": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "electrum3.runebase.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum4.runebase.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "electrum2.runebase.io:50002": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
+            "electrum2.runebase.io:50004": {
+                "last_connection": 1716885371,
+                "result": "Passed"
+            },
             "electrum3.runebase.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum4.runebase.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
-            },
-            "electrum2.runebase.io:50004": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('207.180.215.180', 50004)"
             }
         }
     },
@@ -4103,43 +4022,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30051": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4181,43 +4100,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4234,21 +4153,21 @@
         "tcp": {},
         "ssl": {
             "sumpos.electrum-sum.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "sumpos2.electrum-sum.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "sumpos.electrum-sum.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "sumpos2.electrum-sum.org:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4264,43 +4183,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30005": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4316,43 +4235,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30064": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4368,23 +4287,23 @@
         "electrums_working_wss": 1,
         "tcp": {
             "electrum3.cipig.net:10068": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "testnet.aranguren.org:51001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum3.cipig.net:20068": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum3.cipig.net:30068": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4400,11 +4319,11 @@
         "electrums_working_wss": 0,
         "tcp": {
             "1.eu.thc.electrum.dexstats.info:10020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "2.eu.thc.electrum.dexstats.info:10020": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -4422,7 +4341,7 @@
         "electrums_working_wss": 1,
         "tcp": {
             "1.eu.tokel.electrum.dexstats.info:10077": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "2.eu.tokel.electrum.dexstats.info:10077": {
@@ -4432,7 +4351,7 @@
         },
         "ssl": {
             "1.eu.tokel.electrum.dexstats.info:11077": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "2.eu.tokel.electrum.dexstats.info:11077": {
@@ -4442,7 +4361,7 @@
         },
         "wss": {
             "1.eu.tokel.electrum.dexstats.info:9077": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "2.eu.tokel.electrum.dexstats.info:9077": {
@@ -4472,18 +4391,18 @@
         },
         "ssl": {
             "failover.trc-uis.ewmcx.biz:50006": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "failover.trc-uis.ewmcx.biz:50007": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.southofheaven.ca:50004": {
                 "last_connection": 0,
-                "result": "Multiple exceptions: [Errno 111] Connect call failed ('172.104.225.34', 50004), [Errno 101] Network is unreachable"
+                "result": "Multiple exceptions: [Errno 111] Connect call failed ('172.104.225.34', 50004), [Errno 101] Connect call failed ('2a01:7e01::f03c:91ff:fed1:88b3', 50004, 0, 0)"
             },
             "electrum.terracoin.io:50004": {
                 "last_connection": 0,
@@ -4539,63 +4458,63 @@
     },
     "UIS": {
         "electrums_total_all": 4,
-        "electrums_working_all": 2,
+        "electrums_working_all": 4,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 2,
-        "electrums_working_ssl": 1,
+        "electrums_working_ssl": 2,
         "electrums_total_wss": 2,
-        "electrums_working_wss": 1,
+        "electrums_working_wss": 2,
         "tcp": {},
         "ssl": {
-            "uis-uno.ewmcx.net:50002": {
-                "last_connection": 1716048185,
+            "failover.trc-uis.ewmcx.biz:50002": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "failover.trc-uis.ewmcx.biz:50002": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+            "uis-uno.ewmcx.net:50002": {
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "wss": {
-            "uis-uno.ewmcx.net:50003": {
-                "last_connection": 1716048185,
+            "failover.trc-uis.ewmcx.biz:50003": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "failover.trc-uis.ewmcx.biz:50003": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('164.68.110.226', 50003)"
+            "uis-uno.ewmcx.net:50003": {
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         }
     },
     "UNO": {
         "electrums_total_all": 4,
-        "electrums_working_all": 2,
+        "electrums_working_all": 4,
         "electrums_total_tcp": 0,
         "electrums_working_tcp": 0,
         "electrums_total_ssl": 2,
-        "electrums_working_ssl": 1,
+        "electrums_working_ssl": 2,
         "electrums_total_wss": 2,
-        "electrums_working_wss": 1,
+        "electrums_working_wss": 2,
         "tcp": {},
         "ssl": {
-            "uno-main.coinmunity.gold:50002": {
-                "last_connection": 1716048185,
+            "uno-bkp.coinmunity.gold:50002": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "uno-bkp.coinmunity.gold:50002": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+            "uno-main.coinmunity.gold:50002": {
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "wss": {
-            "uno-main.coinmunity.gold:50003": {
-                "last_connection": 1716048185,
+            "uno-bkp.coinmunity.gold:50003": {
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
-            "uno-bkp.coinmunity.gold:50003": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connect call failed ('194.163.144.75', 50003)"
+            "uno-main.coinmunity.gold:50003": {
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         }
     },
@@ -4611,13 +4530,13 @@
         "tcp": {
             "swap.softbalanced.com:50001": {
                 "last_connection": 0,
-                "result": "timed out"
+                "result": "[Errno 113] No route to host"
             }
         },
         "ssl": {
             "swap.softbalanced.com:50002": {
                 "last_connection": 0,
-                "result": "timed out"
+                "result": "[Errno 113] No route to host"
             }
         },
         "wss": {}
@@ -4633,43 +4552,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "e1.validitytech.com:11001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "e2.validitytech.com:11001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "e3.validitytech.com:11001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "e1.validitytech.com:11002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "e2.validitytech.com:11002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "e3.validitytech.com:11002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "e1.validitytech.com:11004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "e2.validitytech.com:11004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "e3.validitytech.com:11004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4686,13 +4605,13 @@
         "tcp": {},
         "ssl": {
             "electrum3.cipig.net:20073": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum3.cipig.net:30073": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4708,52 +4627,52 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "VPRM": {
         "electrums_total_all": 2,
-        "electrums_working_all": 2,
+        "electrums_working_all": 0,
         "electrums_total_tcp": 2,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 0,
         "electrums_total_ssl": 0,
         "electrums_working_ssl": 0,
         "electrums_total_wss": 0,
@@ -4761,11 +4680,11 @@
         "tcp": {
             "electrumx1.vaporumcoin.us:50001": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             },
             "electrumx2.vaporumcoin.us:50001": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {},
@@ -4800,43 +4719,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "el0.verus.io:17485": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "el1.verus.io:17485": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "el2.verus.io:17485": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "el0.verus.io:17486": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "el1.verus.io:17486": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "el2.verus.io:17486": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "el0.verus.io:17488": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "el1.verus.io:17488": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "el2.verus.io:17488": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4852,18 +4771,18 @@
         "electrums_working_wss": 1,
         "tcp": {
             "88.99.26.209:5028": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.javerity.com:5885": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "electrumx.javerity.com:5887": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4880,13 +4799,13 @@
         "tcp": {},
         "ssl": {
             "waifu-explorer.io:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "waifu-explorer.io:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4902,11 +4821,11 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx.widecoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.widecoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.widecoin.org:50001": {
@@ -4928,21 +4847,21 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx1.cointest.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.cointest.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrumx1.cointest.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.cointest.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -4960,21 +4879,21 @@
         "tcp": {},
         "ssl": {
             "ecash.stackwallet.com:59002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum.bitcoinabc.org:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "fulcrum.pepipierre.fr:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "ecash.stackwallet.com:59004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -4990,30 +4909,30 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrumx1.electraprotocol.eu:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.electraprotocol.eu:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.electraprotocol.eu:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {},
         "wss": {
             "electrumx1.electraprotocol.eu:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.electraprotocol.eu:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.electraprotocol.eu:50003": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5029,19 +4948,19 @@
         "electrums_working_wss": 1,
         "tcp": {
             "lenoir.ecoincore.com:10891": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "lenoir.ecoincore.com:10892": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "lenoir.ecoincore.com:10894": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5058,29 +4977,29 @@
         "tcp": {},
         "ssl": {
             "electrumx1.neurai.top:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.neurai.top:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.neurai.top:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrumx1.neurai.top:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.neurai.top:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx3.neurai.top:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5096,15 +5015,15 @@
         "electrums_working_wss": 0,
         "tcp": {
             "electrumx.gemmer.primecoin.org:50011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.mainnet.primecoin.org:50011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx.primecoin.org:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
@@ -5123,106 +5042,106 @@
         "tcp": {},
         "ssl": {
             "fulcrum.ergon.network:52138": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "la.ask.systems:52138": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "xrg_ful.googol.cash:52138": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "blackie.c3-soft.com:52138": {
                 "last_connection": 0,
-                "result": "[Errno -5] No address associated with hostname"
+                "result": "timed out"
             }
         },
         "wss": {
             "fulcrum.ergon.network:52140": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "la.ask.systems:52140": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "XVC": {
         "electrums_total_all": 7,
-        "electrums_working_all": 4,
+        "electrums_working_all": 6,
         "electrums_total_tcp": 4,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 3,
         "electrums_total_ssl": 1,
-        "electrums_working_ssl": 0,
+        "electrums_working_ssl": 1,
         "electrums_total_wss": 2,
         "electrums_working_wss": 2,
         "tcp": {
             "electrumx1.vanillacash.info:50011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.vanillacash.info:50011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "xvc-ex-seven.ewmci.online:50001": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "last_connection": 1716885371,
+                "result": "Passed"
             },
             "xvc-ex-seven.ewmci.online:50003": {
                 "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "result": ""
             }
         },
         "ssl": {
             "xvc-ex-seven.ewmci.online:50002": {
-                "last_connection": 0,
-                "result": "[Errno 111] Connection refused"
+                "last_connection": 1716885371,
+                "result": "Passed"
             }
         },
         "wss": {
             "electrumx1.vanillacash.info:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx2.vanillacash.info:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "XVG": {
         "electrums_total_all": 4,
-        "electrums_working_all": 4,
+        "electrums_working_all": 1,
         "electrums_total_tcp": 2,
-        "electrums_working_tcp": 2,
+        "electrums_working_tcp": 1,
         "electrums_total_ssl": 1,
-        "electrums_working_ssl": 1,
+        "electrums_working_ssl": 0,
         "electrums_total_wss": 1,
-        "electrums_working_wss": 1,
+        "electrums_working_wss": 0,
         "tcp": {
             "88.99.26.209:5036": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrumx-verge.cloud:50001": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "ssl": {
             "electrumx-verge.cloud:50002": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
             "electrumx-verge.cloud:50004": {
                 "last_connection": 1716048185,
-                "result": "Passed"
+                "result": "[Errno 111] Connect call failed ('68.183.133.16', 50004)"
             }
         }
     },
@@ -5237,43 +5156,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5289,92 +5208,92 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30065": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
     },
     "ZET": {
         "electrums_total_all": 8,
-        "electrums_working_all": 6,
+        "electrums_working_all": 4,
         "electrums_total_tcp": 2,
         "electrums_working_tcp": 2,
         "electrums_total_ssl": 3,
-        "electrums_working_ssl": 2,
+        "electrums_working_ssl": 1,
         "electrums_total_wss": 3,
-        "electrums_working_wss": 2,
+        "electrums_working_wss": 1,
         "tcp": {
             "207.180.252.200:50011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "zet-ex-three.ewmci.online:50011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "zet-ex-three.ewmci.online:50012": {
-                "last_connection": 1716048185,
-                "result": "Passed"
-            },
-            "zeta-seed-d.zetacoin.network:50012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "zeta-seed-c.zetacoin.tech:50012": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connection refused"
+            },
+            "zeta-seed-d.zetacoin.network:50012": {
+                "last_connection": 1716048185,
+                "result": "[Errno 111] Connection refused"
             }
         },
         "wss": {
             "zet-ex-three.ewmci.online:50013": {
-                "last_connection": 1716048185,
-                "result": "Passed"
-            },
-            "zeta-seed-d.zetacoin.network:50013": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "zeta-seed-c.zetacoin.tech:50013": {
                 "last_connection": 0,
                 "result": "[Errno 111] Connect call failed ('89.116.44.226', 50013)"
+            },
+            "zeta-seed-d.zetacoin.network:50013": {
+                "last_connection": 1716048185,
+                "result": "[Errno 111] Connect call failed ('89.116.210.4', 50013)"
             }
         }
     },
@@ -5389,19 +5308,19 @@
         "electrums_working_wss": 1,
         "tcp": {
             "electrum.zoincommunity.com:50001": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum.zoincommunity.com:50002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum.zoincommunity.com:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5417,31 +5336,31 @@
         "electrums_working_wss": 2,
         "tcp": {
             "zombie.dragonhound.info:10033": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "zombie.dragonhound.info:10133": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "zombie.dragonhound.info:20033": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "zombie.dragonhound.info:20133": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "zombie.dragonhound.info:30058": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "zombie.dragonhound.info:30059": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5458,15 +5377,15 @@
         "tcp": {},
         "ssl": {
             "electroncash.de:50004": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrs.electroncash.de:60002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "tbch.loping.net:60002": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "testnet.bitcoincash.network:60002": {
@@ -5487,43 +5406,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.blackcoin.nl:10011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blackcoin.nl:20011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blackcoin.nl:30011": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.blackcoin.nl:10012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blackcoin.nl:20012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blackcoin.nl:30012": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.blackcoin.nl:10014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.blackcoin.nl:20014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.blackcoin.nl:30014": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5539,19 +5458,19 @@
         "electrums_working_wss": 1,
         "tcp": {
             "electrum3.cipig.net:10071": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum3.cipig.net:20071": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum3.cipig.net:30071": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }
@@ -5567,43 +5486,43 @@
         "electrums_working_wss": 3,
         "tcp": {
             "electrum1.cipig.net:10009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:10009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:10009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "ssl": {
             "electrum1.cipig.net:20009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:20009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:20009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         },
         "wss": {
             "electrum1.cipig.net:30009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum2.cipig.net:30009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             },
             "electrum3.cipig.net:30009": {
-                "last_connection": 1716048185,
+                "last_connection": 1716885371,
                 "result": "Passed"
             }
         }

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -554,8 +554,6 @@ def parse_coins_repo():
         print(f"Errors:")
         for error in errors:
             print(error)
-    for coin in nodata:
-        del coins_config[coin]
     return coins_config, nodata
 
 
@@ -673,7 +671,7 @@ def filter_wss(coins_config):
 
 def generate_binance_api_ids(coins_config):
     mm2_coins = coins_config.keys()
-    r = requests.get("https://test.defi-stats.komodo.earth/api/v3/binance/ticker_price")
+    r = requests.get("https://defi-stats.komodo.earth/api/v3/binance/ticker_price")
     binance_tickers = r.json()
     pairs = []
     for ticker in binance_tickers:
@@ -711,9 +709,17 @@ def generate_binance_api_ids(coins_config):
 
 if __name__ == "__main__":
     coins_config, nodata = parse_coins_repo()
-    with open(f"{script_path}/coins_config.json", "w+") as f:
+    # Includes failing servers
+    with open(f"{script_path}/coins_config_unfiltered.json", "w+") as f:
         json.dump(coins_config, f, indent=4)
     generate_binance_api_ids(coins_config)
+
+    # Remove failing servers
+    for coin in nodata:
+        del coins_config[coin]
+    with open(f"{script_path}/coins_config.json", "w+") as f:
+        json.dump(coins_config, f, indent=4)
+        
     coins_config_ssl = filter_ssl(deepcopy(coins_config))
     coins_config_wss = filter_wss(deepcopy(coins_config))
     coins_config_tcp = filter_tcp(deepcopy(coins_config), coins_config_ssl)


### PR DESCRIPTION
Adds a version of coins_config which includes all listed electrums regardless of status. This will be used for status checks - previously other repo used a submodule, but including this file here will remove the need to update the submodule periodically and it eliminates some logic in the other repo which is already present here.