### PR TITLE
Binance delists

### DIFF
--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -15,17 +15,20 @@ os.chdir(script_path)
 
 BINANCE_DELISTED_COINS = [
     "ANT",
+    "BIDR",
     "GRS",
     "NAV",
     "BTT",
     "BUSD",
     "MC",
     "MIR",
+    "OMG",
     "PAX",
     "QI",
     "REP",
     "SRM",
     "VIA",
+    "WAVES",
     "YFII",
 ]
 
@@ -63,7 +66,6 @@ binance_quote_tickers = [
     "USDT",
     "USDC",
     "TUSD",
-    "BIDR",
     "XRP",
     "TRX",
     "TRY",


### PR DESCRIPTION
- https://www.binance.com/en/support/announcement/binance-will-delist-omg-waves-wnxm-xem-on-2024-06-17-f65faeeefe07417a8b6dd2900ba8da7e
- https://www.binance.com/en/support/announcement/binance-encourages-users-to-convert-bidr-to-other-currencies-before-august-20-2024-92e725bfce644fbdb17f411db26c324b