### PR TITLE
add additional electrum server for MEWC

### DIFF
--- a/electrums/MEWC
+++ b/electrums/MEWC
@@ -16,5 +16,15 @@
         }
     ],
     "ws_url": "meowcoinelectrum.xyz:50004"
+},
+{
+    "url": "meowcoinelectrumcoms.xyz:50002",
+    "protocol": "SSL",
+    "contact": [
+        {
+            "discord": "Meowmancer#2099"
+        }
+    ],
+    "ws_url": "meowcoinelectrumcoms.xyz:50004"
 }
 ]


### PR DESCRIPTION
We are adding 1 additional electrum server. We might be deprecating one of the servers currently listed in the repo.

I know Komodo requires 2 electrum servers to be running at all times so I'll make sure to reach out to you again before we fully take one of our older servers offline.

Let me know if I can provide any additional info

Cheers