### PR TITLE
allow ws_url alongside tcp/no proto electrum

### DIFF
--- a/utils/scan_electrums.py
+++ b/utils/scan_electrums.py
@@ -354,18 +354,18 @@ def scan_electrums(electrum_dict):
                                 electrum["protocol"].lower()
                             )
                         )
-                elif "ws_url" not in electrum:
-                    protocol_lists['tcp'].append(coin)
-                    thread_list.append(
-                        scan_thread(
-                            coin,
-                            url,
-                            port,
-                            "blockchain.headers.subscribe",
-                            [],
-                            "tcp"
+                    else:
+                        protocol_lists['tcp'].append(coin)
+                        thread_list.append(
+                            scan_thread(
+                                coin,
+                                url,
+                                port,
+                                "blockchain.headers.subscribe",
+                                [],
+                                "tcp"
+                            )
                         )
-                    )
 
         
     for thread in thread_list:


### PR DESCRIPTION
Found bug where is `ws_url` was in same block as `url` but did not specify the protocol, the `url` values would not be scanned.
With this fix they will be, and be assumed to be protocol TCP.