### PR TITLE
Update 2 XNA electrumx servers

### DIFF
--- a/electrums/XNA
+++ b/electrums/XNA
@@ -6,7 +6,7 @@
       { "email": "alarm@neurai.org" },
       { "discord": "456566604809895947" }
     ],
-    "ws_url": "electrumx1.neurai.top:50002"
+    "ws_url": "electrumx-dex-01.neuraiexplorer.com:50002"
   },
   {
     "url": "electrumx2.neurai.top:50001",
@@ -15,7 +15,7 @@
       { "email": "alarm@neurai.org" },
       { "discord": "456566604809895947" }
     ],
-    "ws_url": "electrumx2.neurai.top:50002"
+    "ws_url": "electrumx-dex-02.neuraiexplorer.com:50002"
   },
   {
     "url": "electrumx3.neurai.top:50001",

--- a/electrums/XNA
+++ b/electrums/XNA
@@ -1,6 +1,6 @@
 [
   {
-    "url": "electrumx1.neurai.top:50001",
+    "url": "electrumx-dex-01.neuraiexplorer.com:50001",
     "protocol": "SSL",
     "contact": [
       { "email": "alarm@neurai.org" },
@@ -9,7 +9,7 @@
     "ws_url": "electrumx-dex-01.neuraiexplorer.com:50002"
   },
   {
-    "url": "electrumx2.neurai.top:50001",
+    "url": "electrumx-dex-02.neuraiexplorer.com:50001",
     "protocol": "SSL",
     "contact": [
       { "email": "alarm@neurai.org" },


### PR DESCRIPTION
Due to problems with .top domains, we have upgraded the first two servers

electrumx-dex-01.neuraiexplorer.com:50001
electrumx-dex-02.neuraiexplorer.com:50001