### PR TITLE
set gas limits for MOVR and more tokens, enable access_lists

### DIFF
--- a/coins
+++ b/coins
@@ -72,7 +72,14 @@
         "contract_address": "0x111111111117dC0aa78b770fA6A738034120C302"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "1INCH-ERC20",
@@ -130,6 +137,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -155,6 +163,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -197,7 +206,14 @@
         "contract_address": "0xfb6115445Bff7b52FeB98650C87f44907E58f802"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "AAVE-ERC20",
@@ -298,6 +314,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -341,6 +358,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -445,6 +463,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -591,6 +610,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -634,7 +654,14 @@
         "contract_address": "0xC762043E211571eB34f1ef377e5e8e76914962f9"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "APE-FTM20",
@@ -672,7 +699,14 @@
         "contract_address": "0xB7b31a6BC18e48888545CE79e83E06003bE70930"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "ARB-ERC20",
@@ -711,6 +745,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -734,7 +769,14 @@
         "contract_address": "0x6F769E65c14Ebd1f68817F5f1DcDb61Cfa2D6f7e"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "ARPA-ERC20",
@@ -772,6 +814,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -859,6 +902,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -884,6 +928,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -996,7 +1041,14 @@
         "contract_address": "0x1CE0c2827e2eF14D5C4f29a091d735A204794041"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "AVN",
@@ -1096,6 +1148,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -1261,7 +1314,14 @@
         "contract_address": "0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "BANANO-BEP20",
@@ -1298,6 +1358,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -2167,6 +2228,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -2286,6 +2348,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -2410,6 +2473,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -2686,6 +2750,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -2709,7 +2774,14 @@
         "contract_address": "0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "CASE-BEP20",
@@ -2931,6 +3003,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -2976,6 +3049,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -3247,7 +3321,14 @@
         "contract_address": "0x52CE071Bd9b1C4B00A0b92D298c512478CaD67e8"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "COMP-ERC20",
@@ -3310,6 +3391,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3435,6 +3517,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -3517,6 +3600,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3691,6 +3775,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3773,6 +3858,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3900,6 +3986,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -4016,7 +4103,14 @@
         "contract_address": "0x99956D38059cf7bEDA96Ec91Aa7BB2477E0901DD"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },  
   {
     "coin": "DPC",
@@ -4319,6 +4413,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4455,7 +4550,14 @@
         "contract_address": "0xbF7c81FFF98BbE61B40Ed186e4AfD6DDd01337fe"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "EILN-ERC20",
@@ -4493,6 +4595,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4622,7 +4725,14 @@
         "contract_address": "0x56b6fB708fC5732DEC1Afc8D8556423A2EDcCbD6"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "ETC",
@@ -4707,6 +4817,7 @@
       "type": "ETH"
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_coins": 100000,
         "eth_payment": 250000,
@@ -4807,6 +4918,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -4851,6 +4963,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 90000,
         "erc20_payment": 150000,
@@ -4895,6 +5008,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -4944,6 +5058,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5080,7 +5195,14 @@
         "contract_address": "0x0D8Ce2A99Bb6e3B7Db580eD848240e4a0F9aE153"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "FIL-ERC20",
@@ -5159,6 +5281,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -5274,6 +5397,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 80000,
         "erc20_payment": 140000,
@@ -5338,6 +5462,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -5529,6 +5654,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5669,6 +5795,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5736,7 +5863,14 @@
         "contract_address": "0x72fF5742319eF07061836F5C924aC6D72c919080"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "GLC",
@@ -5816,6 +5950,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5878,6 +6013,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5903,6 +6039,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -5928,6 +6065,7 @@
       }
     },
     "derivation_path": "m/44'/9000'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 120000,
@@ -5995,6 +6133,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -6020,6 +6159,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6130,6 +6270,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -6217,6 +6358,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6323,6 +6465,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6540,6 +6683,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -6680,7 +6824,14 @@
         "contract_address": "0x4d5AC5cc4f8aBdf2EC2Cb986C00C382369f787D4"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "IMX-ERC20",
@@ -6718,6 +6869,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6760,6 +6912,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6784,6 +6937,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6847,6 +7001,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6889,7 +7044,14 @@
         "contract_address": "0xCB7F1Ef7246D1497b985f7FC45A1A31F04346133"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "JBRL-BEP20",
@@ -6928,6 +7090,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6952,7 +7115,14 @@
         "contract_address": "0x8ca194A3b22077359b5732DE53373D4afC11DeE3"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "JCHF-AVX20",
@@ -7029,6 +7199,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7053,7 +7224,14 @@
         "contract_address": "0x84526c812D8f6c4fD6C1a5B68713AFF50733E772"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "JEUR-AVX20",
@@ -7130,6 +7308,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7192,7 +7371,14 @@
         "contract_address": "0x767058F11800FBA6A682E73A6e79ec5eB74Fac8c"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "JGOLD-PLG20",
@@ -7231,6 +7417,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7275,6 +7462,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7300,6 +7488,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7382,6 +7571,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7463,6 +7653,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7525,7 +7716,14 @@
         "contract_address": "0xeA998D307ACA04D4f0A3B3036Aba84AE2E409C0A"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "KCS",
@@ -7701,7 +7899,14 @@
         "contract_address": "0x1C954E8fe737F99f68Fa1CCda3e51ebDB291948C"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "KNC-AVX20",
@@ -7757,7 +7962,14 @@
         "contract_address": "0x2aa69E8D25C045B659787BC1f03ce47a388DB6E8"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "LABS",
@@ -7909,6 +8121,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -8128,6 +8341,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -8195,7 +8409,14 @@
         "contract_address": "0x66e4d38b20173F509A1fF5d82866949e4fE898da"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "LRC-PLG20",
@@ -8275,7 +8496,14 @@
         "contract_address": "0xE6Ce27025F13f5213bBc560dC275e292965a392F"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "LSWAP-BEP20",
@@ -8453,6 +8681,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -8515,7 +8744,14 @@
         "contract_address": "0x2B9E7ccDF0F4e5B24757c1E1a80e311E34Cb10c7"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "MATICTEST",
@@ -8882,6 +9118,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -9081,6 +9318,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -9181,6 +9419,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -9284,6 +9523,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -9599,6 +9839,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -9624,6 +9865,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -9846,6 +10088,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -9893,6 +10136,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -10062,6 +10306,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -10304,6 +10549,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -10387,7 +10633,14 @@
         "contract_address": "0x6f8a06447Ff6FcF75d803135a7de15CE88C1d4ec"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "QC-QRC20",
@@ -10477,7 +10730,14 @@
         "contract_address": "0xA1434F1FC3F437fa33F7a781E041961C0205B5Da"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "QKC-ERC20",
@@ -10766,6 +11026,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -10952,6 +11213,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11120,6 +11382,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11164,6 +11427,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -11287,7 +11551,14 @@
         "contract_address": "0x50B728D8D964fd00C2d0AAD81718b71311feF68a"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "SOL-BEP20",
@@ -11326,6 +11597,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11443,6 +11715,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11669,7 +11942,14 @@
         "contract_address": "0x0b3F868E0BE5597D5DB7fEB59E1CADBb0fdDa50a"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "SWAP-BEP20",
@@ -11798,6 +12078,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11992,6 +12273,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12096,7 +12378,14 @@
         "contract_address": "0xdF7837DE1F2Fa4631D716CF2502f8b230F1dcc32"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "TFT-BEP20",
@@ -12116,6 +12405,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -12270,7 +12560,14 @@
         "contract_address": "0xCE7de646e7208a4Ef112cb6ed5038FA6cC6b12e3"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "TRYB-AVX20",
@@ -12290,6 +12587,7 @@
       }
     },
     "derivation_path": "m/44'/9000'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 120000,
@@ -12333,6 +12631,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12763,7 +13062,14 @@
         "contract_address": "0xb33EaAd8d922B1083446DC23f610c2567fB5180f"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "UNO",
@@ -12806,6 +13112,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -12891,6 +13198,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12991,6 +13299,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13149,6 +13458,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13174,6 +13484,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -13199,6 +13510,7 @@
       }
     },
     "derivation_path": "m/44'/9000'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 120000,
@@ -13242,6 +13554,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13344,6 +13657,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -13482,6 +13796,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -13698,6 +14013,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13761,6 +14077,7 @@
       }
     },
     "derivation_path": "m/44'/60'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -13843,6 +14160,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13970,6 +14288,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13993,7 +14312,14 @@
         "contract_address": "0x43C934A845205F0b514417d757d7235B8f53f1B9"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "XMY",
@@ -14125,6 +14451,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14193,6 +14520,7 @@
       }
     },
     "derivation_path": "m/44'/966'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -14216,7 +14544,14 @@
         "contract_address": "0x16939ef78684453bfDFb47825F8a5F714f12623a"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "XVC",
@@ -14318,7 +14653,14 @@
         "contract_address": "0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "YFI-AVX20",
@@ -14355,7 +14697,14 @@
         "contract_address": "0x88f1A5ae2A3BF98AEAF342D26B30a79438c9142e"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "YFI-ERC20",
@@ -14436,7 +14785,14 @@
         "contract_address": "0xDA537104D6A5edd53c6fBba9A898708E465260b6"
       }
     },
-    "derivation_path": "m/44'/966'"
+    "derivation_path": "m/44'/966'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 55000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "YFII-BEP20",
@@ -14587,6 +14943,7 @@
       }
     },
     "derivation_path": "m/44'/714'",
+    "use_access_list": true,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14739,7 +15096,14 @@
         "contract_address": "0xaFF9084f2374585879e8B434C399E29E80ccE635"
       }
     },
-    "derivation_path": "m/44'/714'"
+    "derivation_path": "m/44'/714'",
+    "use_access_list": true,
+    "gas_limit": {
+        "eth_send_erc20": 60000,
+        "erc20_payment": 110000,
+        "erc20_receiver_spend": 80000,
+        "erc20_sender_refund": 80000
+    }
   },
   {
     "coin": "HPY-QRC20",

--- a/coins
+++ b/coins
@@ -4783,6 +4783,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 61,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
@@ -5121,6 +5123,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 246,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 5,
     "protocol": {
@@ -5598,6 +5602,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 250,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 1.8,
     "protocol": {
@@ -7815,6 +7821,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 321,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 3,
     "protocol": {
@@ -9428,6 +9436,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 1285,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
@@ -9446,6 +9456,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 1284,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
@@ -10022,6 +10034,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 1666600000,
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {

--- a/coins
+++ b/coins
@@ -3898,8 +3898,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 90000,
+        "erc20_sender_refund": 90000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9449,10 +9449,9 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_coins": 100000,
-        "eth_payment": 250000,
-        "eth_receiver_spend": 250000,
-        "eth_sender_refund": 250000
+        "eth_payment": 100000,
+        "eth_receiver_spend": 100000,
+        "eth_sender_refund": 100000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9445,6 +9445,14 @@
     "trezor_coin": "Moonriver",
     "links": {
       "homepage": "https://moonbeam.network/networks/moonriver/"
+    },
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
+    "gas_limit": {
+        "eth_send_coins": 100000,
+        "eth_payment": 250000,
+        "eth_receiver_spend": 250000,
+        "eth_sender_refund": 250000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9224,8 +9224,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -78,8 +78,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -143,8 +143,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -170,8 +170,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -215,8 +215,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -323,8 +323,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -368,8 +368,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -474,8 +474,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -622,8 +622,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -668,8 +668,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -714,8 +714,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -786,8 +786,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -831,8 +831,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -920,8 +920,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -947,8 +947,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -1064,8 +1064,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -1171,8 +1171,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -1339,8 +1339,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -1383,8 +1383,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -2377,8 +2377,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -2503,8 +2503,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -2807,8 +2807,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3036,8 +3036,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3083,8 +3083,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3357,8 +3357,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3427,8 +3427,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3638,8 +3638,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3814,8 +3814,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -3898,8 +3898,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -4027,8 +4027,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -4146,8 +4146,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },  
   {
@@ -4456,8 +4456,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -4595,8 +4595,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -4640,8 +4640,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -4772,8 +4772,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -4969,8 +4969,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5061,8 +5061,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5112,8 +5112,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5253,8 +5253,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5339,8 +5339,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5454,7 +5454,7 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 80000,
+        "eth_send_erc20": 85000,
         "erc20_payment": 140000,
         "erc20_receiver_spend": 110000,
         "erc20_sender_refund": 110000
@@ -5522,8 +5522,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5717,8 +5717,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5859,8 +5859,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -5929,8 +5929,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6016,8 +6016,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6080,8 +6080,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6230,8 +6230,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6431,8 +6431,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6539,8 +6539,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6901,8 +6901,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6946,8 +6946,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -6990,8 +6990,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7016,8 +7016,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7081,8 +7081,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7126,8 +7126,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7172,8 +7172,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7199,8 +7199,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7283,8 +7283,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7310,8 +7310,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7394,8 +7394,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7459,8 +7459,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7505,8 +7505,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7551,8 +7551,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7578,8 +7578,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7662,8 +7662,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7745,8 +7745,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7810,8 +7810,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -7996,8 +7996,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8060,8 +8060,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8219,8 +8219,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8440,8 +8440,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8510,8 +8510,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8598,8 +8598,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8783,8 +8783,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -8848,8 +8848,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -9531,8 +9531,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -9636,8 +9636,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -9953,8 +9953,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -9980,8 +9980,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -10206,8 +10206,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -10426,8 +10426,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -10756,8 +10756,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -10854,8 +10854,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11150,8 +11150,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11338,8 +11338,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11508,8 +11508,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11554,8 +11554,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11680,8 +11680,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11726,8 +11726,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -11845,8 +11845,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12074,8 +12074,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12210,8 +12210,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12406,8 +12406,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12513,8 +12513,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12540,8 +12540,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12697,8 +12697,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -12769,8 +12769,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13202,8 +13202,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13339,8 +13339,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13441,8 +13441,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13601,8 +13601,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13700,8 +13700,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13804,8 +13804,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -13944,8 +13944,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14162,8 +14162,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14311,8 +14311,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14440,8 +14440,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14466,8 +14466,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14605,8 +14605,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14675,8 +14675,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14701,8 +14701,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14811,8 +14811,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14856,8 +14856,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -14945,8 +14945,8 @@
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -15103,8 +15103,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {
@@ -15258,8 +15258,8 @@
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
-        "erc20_receiver_spend": 80000,
-        "erc20_sender_refund": 80000
+        "erc20_receiver_spend": 85000,
+        "erc20_sender_refund": 85000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -1015,6 +1015,7 @@
     "mm2": 1,
     "chain_id": 43114,
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 2.4,
     "protocol": {
@@ -1965,6 +1966,7 @@
     "mm2": 1,
     "chain_id": 56,
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "protocol": {
       "type": "ETH"
@@ -4820,6 +4822,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_coins": 100000,
         "eth_payment": 250000,
@@ -8777,6 +8780,7 @@
     "mm2": 1,
     "chain_id": 137,
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "avg_blocktime": 1.8,
     "required_confirmations": 20,
     "protocol": {

--- a/coins
+++ b/coins
@@ -1014,6 +1014,7 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 43114,
+    "use_access_list": true,
     "required_confirmations": 3,
     "avg_blocktime": 2.4,
     "protocol": {
@@ -1963,6 +1964,7 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 56,
+    "use_access_list": true,
     "required_confirmations": 3,
     "protocol": {
       "type": "ETH"
@@ -8774,6 +8776,7 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 137,
+    "use_access_list": true,
     "avg_blocktime": 1.8,
     "required_confirmations": 20,
     "protocol": {

--- a/coins
+++ b/coins
@@ -9436,8 +9436,6 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 1285,
-    "use_access_list": true,
-    "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {

--- a/coins
+++ b/coins
@@ -74,6 +74,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -138,6 +139,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -164,6 +166,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -208,6 +211,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -315,6 +319,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -359,6 +364,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -464,6 +470,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -611,6 +618,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -656,6 +664,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -701,6 +710,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -746,6 +756,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -771,6 +782,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -815,6 +827,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -903,6 +916,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -929,6 +943,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -1045,6 +1060,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -1151,6 +1167,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -1318,6 +1335,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -1361,6 +1379,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -2233,6 +2252,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -2353,6 +2373,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -2478,6 +2499,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -2755,6 +2777,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -2780,6 +2803,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -3008,6 +3032,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -3054,6 +3079,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -3327,6 +3353,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -3396,6 +3423,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3522,6 +3550,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -3605,6 +3634,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3780,6 +3810,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3863,6 +3894,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -3991,6 +4023,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -4109,6 +4142,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4418,6 +4452,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4556,6 +4591,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4600,6 +4636,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4731,6 +4768,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -4822,6 +4860,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_coins": 100000,
@@ -4924,6 +4963,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -4969,6 +5009,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 90000,
         "erc20_payment": 150000,
@@ -5014,6 +5055,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5064,6 +5106,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5202,6 +5245,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -5287,6 +5331,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -5403,6 +5448,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 80000,
         "erc20_payment": 140000,
@@ -5468,6 +5514,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -5660,6 +5707,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5801,6 +5849,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -5870,6 +5919,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -5956,6 +6006,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6019,6 +6070,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6045,6 +6097,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -6071,6 +6124,7 @@
     },
     "derivation_path": "m/44'/9000'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 120000,
@@ -6139,6 +6193,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -6165,6 +6220,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6276,6 +6332,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -6364,6 +6421,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6471,6 +6529,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -6689,6 +6748,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -6831,6 +6891,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6875,6 +6936,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6918,6 +6980,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -6943,6 +7006,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -7007,6 +7071,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -7051,6 +7116,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7096,6 +7162,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7122,6 +7189,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7205,6 +7273,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7231,6 +7300,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7314,6 +7384,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7378,6 +7449,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7423,6 +7495,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7468,6 +7541,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7494,6 +7568,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7577,6 +7652,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7659,6 +7735,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7723,6 +7800,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -7906,6 +7984,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -7969,6 +8048,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -8127,6 +8207,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -8347,6 +8428,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -8416,6 +8498,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -8503,6 +8586,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -8687,6 +8771,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -8751,6 +8836,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -9126,6 +9212,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -9326,6 +9413,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -9427,6 +9515,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -9531,6 +9620,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -9847,6 +9937,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -9873,6 +9964,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -10096,6 +10188,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -10144,6 +10237,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -10314,6 +10408,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -10557,6 +10652,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 120000,
@@ -10642,6 +10738,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -10739,6 +10836,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -11034,6 +11132,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11221,6 +11320,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11390,6 +11490,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11435,6 +11536,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -11560,6 +11662,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11605,6 +11708,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11723,6 +11827,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -11951,6 +12056,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12086,6 +12192,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12281,6 +12388,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12387,6 +12495,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -12413,6 +12522,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -12569,6 +12679,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -12595,6 +12706,7 @@
     },
     "derivation_path": "m/44'/9000'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 120000,
@@ -12639,6 +12751,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13071,6 +13184,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13120,6 +13234,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -13206,6 +13321,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13307,6 +13423,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13466,6 +13583,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13492,6 +13610,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -13518,6 +13637,7 @@
     },
     "derivation_path": "m/44'/9000'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 120000,
@@ -13562,6 +13682,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -13665,6 +13786,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -13804,6 +13926,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14021,6 +14144,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -14085,6 +14209,7 @@
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 150000,
         "erc20_payment": 300000,
@@ -14168,6 +14293,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -14296,6 +14422,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -14321,6 +14448,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14459,6 +14587,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14528,6 +14657,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -14553,6 +14683,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14662,6 +14793,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14706,6 +14838,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -14794,6 +14927,7 @@
     },
     "derivation_path": "m/44'/966'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 55000,
         "erc20_payment": 110000,
@@ -14951,6 +15085,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,
@@ -15105,6 +15240,7 @@
     },
     "derivation_path": "m/44'/714'",
     "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_send_erc20": 60000,
         "erc20_payment": 110000,

--- a/explorers/QTUM
+++ b/explorers/QTUM
@@ -1,1 +1,1 @@
-["https://explorer.qtum.org/"]
+["https://qtum.info/"]


### PR DESCRIPTION
- gas limits for MOVR need to be set, the default ones are not enough any more, txes fail with "out of gas"
- set more gas limits for tokens
- enabled access_lists for many tokens, which decreases gas usage by ~1% with https://github.com/KomodoPlatform/komodo-defi-framework/pull/2170 