### PR TITLE
remove requires_notarization from EMC2, MIL, AYA

### DIFF
--- a/coins
+++ b/coins
@@ -1237,8 +1237,7 @@
     "txfee": 100000,
     "dust": 54600,
     "mm2": 1,
-    "required_confirmations": 2,
-    "requires_notarization": true,
+    "required_confirmations": 5,
     "avg_blocktime": 30,
     "protocol": {
       "type": "UTXO"
@@ -4737,8 +4736,7 @@
     "txfee": 100000,
     "dust": 54600,
     "mm2": 1,
-    "required_confirmations": 2,
-    "requires_notarization": true,
+    "required_confirmations": 5,
     "avg_blocktime": 60,
     "protocol": {
       "type": "UTXO"
@@ -9136,8 +9134,7 @@
     "txfee": 100000,
     "dust": 54600,
     "mm2": 1,
-    "required_confirmations": 2,
-    "requires_notarization": true,
+    "required_confirmations": 5,
     "avg_blocktime": 60,
     "protocol": {
       "type": "UTXO"

--- a/coins
+++ b/coins
@@ -3158,8 +3158,7 @@
     "txfee": 10000,
     "segwit": true,
     "mm2": 1,
-    "required_confirmations": 2,
-    "requires_notarization": true,
+    "required_confirmations": 5,
     "avg_blocktime": 10,
     "protocol": {
       "type": "UTXO"


### PR DESCRIPTION
this coins will not be notarized any more in new season: https://github.com/KomodoPlatform/dPoW/pull/563