### PR TITLE
add BTCZ electrums, remove bad XEC electrum

### DIFF
--- a/electrums/BTCZ
+++ b/electrums/BTCZ
@@ -16,5 +16,13 @@
             }
         ],
         "ws_url": "electrum1.btcz.rocks:50004"
+    },
+    {
+        "url": "electrum3.btcz.rocks:50001",
+        "contact": [
+            {
+                "discord": "426842722436120577"
+            }
+        ]
     }
 ]

--- a/electrums/BTCZ
+++ b/electrums/BTCZ
@@ -24,5 +24,15 @@
                 "discord": "426842722436120577"
             }
         ]
+    },
+    {
+        "url": "electrum5.btcz.rocks:50002",
+        "protocol": "SSL",
+        "contact": [
+            {
+                "discord": "426842722436120577"
+            }
+        ],
+        "ws_url": "electrum5.btcz.rocks:50004"
     }
 ]

--- a/electrums/XEC
+++ b/electrums/XEC
@@ -1,14 +1,5 @@
 [
   {
-    "url": "electrum.bitcoinabc.org:50002",
-    "protocol": "SSL",
-    "disable_cert_verification": true,
-    "contact": [
-      { "email": "joey@e.cash" },
-      { "twitter": "bytesofman" }
-    ]
-  },
-  {
     "url": "fulcrum.pepipierre.fr:50002",
     "protocol": "SSL",
     "disable_cert_verification": true,

--- a/ethereum/MOVR
+++ b/ethereum/MOVR
@@ -3,10 +3,12 @@
   "fallback_swap_contract": "0x9130b257D37A52E52F21054c4DA3450c72f595CE",
   "rpc_nodes": [
     {
-      "url": "https://moonriver.public.blastapi.io"
+      "url": "https://moonriver.public.blastapi.io",
+      "ws_url": "wss://moonriver.public.blastapi.io"
     },
     {
-      "url": "https://rpc.api.moonriver.moonbeam.network"
+      "url": "https://rpc.api.moonriver.moonbeam.network",
+      "ws_url": "wss://wss.api.moonriver.moonbeam.network"
     }
   ]
 }


### PR DESCRIPTION
XEC electrum uses too old version of Fulcrum (1.5.0) and causes errors, see https://github.com/KomodoPlatform/komodo-defi-framework/issues/2134 ... the ones with more recent versions are fine