### PR TITLE
increase gas_limits for MOVR

### DIFF
--- a/coins
+++ b/coins
@@ -9529,6 +9529,8 @@
     "links": {
       "homepage": "https://moonbeam.network/networks/moonriver/"
     },
+    "use_access_list": true,
+    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_payment": 100000,
         "eth_receiver_spend": 100000,

--- a/coins
+++ b/coins
@@ -9533,8 +9533,8 @@
     "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_payment": 100000,
-        "eth_receiver_spend": 200000,
-        "eth_sender_refund": 200000
+        "eth_receiver_spend": 300000,
+        "eth_sender_refund": 300000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9533,8 +9533,8 @@
     "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_payment": 100000,
-        "eth_receiver_spend": 300000,
-        "eth_sender_refund": 300000
+        "eth_receiver_spend": 700000,
+        "eth_sender_refund": 700000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9529,12 +9529,10 @@
     "links": {
       "homepage": "https://moonbeam.network/networks/moonriver/"
     },
-    "use_access_list": true,
-    "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_payment": 100000,
-        "eth_receiver_spend": 700000,
-        "eth_sender_refund": 700000
+        "eth_receiver_spend": 100000,
+        "eth_sender_refund": 100000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9533,8 +9533,8 @@
     "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_payment": 100000,
-        "eth_receiver_spend": 150000,
-        "eth_sender_refund": 150000
+        "eth_receiver_spend": 200000,
+        "eth_sender_refund": 200000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9533,8 +9533,8 @@
     "max_eth_tx_type": 2,
     "gas_limit": {
         "eth_payment": 100000,
-        "eth_receiver_spend": 100000,
-        "eth_sender_refund": 100000
+        "eth_receiver_spend": 500000,
+        "eth_sender_refund": 500000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9532,9 +9532,9 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_payment": 100000,
-        "eth_receiver_spend": 100000,
-        "eth_sender_refund": 100000
+        "eth_payment": 200000,
+        "eth_receiver_spend": 200000,
+        "eth_sender_refund": 200000
     }
   },
   {

--- a/coins
+++ b/coins
@@ -9532,9 +9532,9 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_payment": 200000,
-        "eth_receiver_spend": 200000,
-        "eth_sender_refund": 200000
+        "eth_payment": 100000,
+        "eth_receiver_spend": 150000,
+        "eth_sender_refund": 150000
     }
   },
   {


### PR DESCRIPTION
swaps starting to fail with the 100k limit with out of gas errors
tried different values and 500k works in both directions