### PR TITLE
increase txfee for ZEC

### DIFF
--- a/coins
+++ b/coins
@@ -15246,7 +15246,7 @@
     "overwintered": 1,
     "version_group_id": "0x892f2085",
     "consensus_branch_id": "0xc2d6d0b4",
-    "txfee": 10000,
+    "txfee": 100000,
     "mm2": 1,
     "required_confirmations": 3,
     "avg_blocktime": 75,


### PR DESCRIPTION
ZEC changed fees in latest update, swaps with old setting are failing
till https://github.com/KomodoPlatform/komodo-defi-framework/issues/2266 is implemented, this change will work for txes with up to 20 inputs