### PR TITLE
update CONSENSUS_BRANCH_ID for ZEC

### DIFF
--- a/coins
+++ b/coins
@@ -15238,7 +15238,7 @@
     "txversion": 4,
     "overwintered": 1,
     "version_group_id": "0x892f2085",
-    "consensus_branch_id": "0xc2d6d0b4",
+    "consensus_branch_id": "0xc8e71055",
     "txfee": 100000,
     "mm2": 1,
     "required_confirmations": 3,


### PR DESCRIPTION
update https://zips.z.cash/zip-0253 activated couple hours ago, CONSENSUS_BRANCH_ID changed, txes with old id are failing `the transaction was rejected by network rules.\\n\\n16: old-consensus-branch-id (Expected c8e71055, found c2d6d0b4)`, so this PR updates id to the new one

![image](https://github.com/user-attachments/assets/562fd9a4-9bad-4de9-b1fe-42ac1a5d374e)
