### PR TITLE
add Sepolia ETH coin config

### DIFF
--- a/coins
+++ b/coins
@@ -15756,6 +15756,21 @@
     }
   },
   {
+    "coin": "SEPOLIA-ETH",
+    "name": "sepolia",
+    "fname": "Sepolia",
+    "rpcport": 80,
+    "mm2": 1,
+    "chain_id": 11155111,
+    "sign_message_prefix": "Sepolia Signed Message:\n",
+    "required_confirmations": 3,
+    "avg_blocktime": 15,
+    "protocol": {
+      "type": "ETH"
+    },
+    "derivation_path": "m/44'/60'"
+  },
+  {
     "coin": "REV-ERC20",
     "name": "rev_erc20",
     "fname": "Revain",

--- a/coins
+++ b/coins
@@ -15756,7 +15756,7 @@
     }
   },
   {
-    "coin": "SEPOLIA-ETH",
+    "coin": "SEPOLIAETH",
     "name": "sepolia",
     "fname": "Sepolia",
     "rpcport": 80,


### PR DESCRIPTION
PR provides sepolia eth coin from Sepoia testnet

It mirrors ETH coin required_confirmations and avg_blocktime