### PR TITLE
rm obsolete ZOMBIE server

### DIFF
--- a/electrums/ZOMBIE
+++ b/electrums/ZOMBIE
@@ -1,29 +1,5 @@
 [
    {
-      "url":"zombie.dragonhound.info:10033",
-      "contact":[
-         {
-            "email":"smk@komodoplatform.com"
-         },
-         {
-            "discord":"smk#7640"
-         }
-      ]
-   },
-   {
-      "url":"zombie.dragonhound.info:20033",
-      "protocol":"SSL",
-      "contact":[
-         {
-            "email":"smk@komodoplatform.com"
-         },
-         {
-            "discord":"smk#7640"
-         }
-      ],
-      "ws_url":"zombie.dragonhound.info:30058"
-   },
-   {
       "url":"zombie.dragonhound.info:10133",
       "contact":[
          {

--- a/light_wallet_d/ZOMBIE
+++ b/light_wallet_d/ZOMBIE
@@ -1,1 +1,1 @@
-["https://zombie.dragonhound.info:443", "https://zombie.dragonhound.info:1443"]
+["https://zombie.dragonhound.info:1443"]


### PR DESCRIPTION
Service being removed was using https://github.com/KomodoPlatform/lightwalletd which is slightly different to https://github.com/PirateNetwork/lightwalletd (see https://github.com/KomodoPlatform/komodo-defi-framework/pull/1963 for more info).

This service was being run on same server/daemon as the one that is retained, so this duplication was superfluous. A second can be added on a separate server in future if required.