### PR TITLE
Add FLOP to coinpaprika_ids.json

### DIFF
--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -228,6 +228,7 @@
     "FJC": "fjc-fujicoin",
     "FJCB-BEP20": "fjcb-fjcb-fujicoin",
     "FLOKI-BEP20": "floki-floki-inu",
+    "FLOP": "flop-flopcoin",
     "FLOW-BEP20": "flow-flow",
     "FLUX-BEP20": "zel-zelcash",
     "FLUX-ERC20": "zel-zelcash",


### PR DESCRIPTION
Added Flopcoin (FLOP) to coinpaprika_ids.json for price tracking