### PR TITLE
update XEP electrums

### DIFF
--- a/electrums/XEP
+++ b/electrums/XEP
@@ -5,37 +5,11 @@
             {
                 "discord": "287952234317348865"
             }
-        ]
-    },
-    {
-        "url": "electrumx2.electraprotocol.eu:50001",
-        "contact": [
-            {
-                "discord": "287952234317348865"
-            }
-        ]
-    },
-    {
-        "url": "electrumx3.electraprotocol.eu:50001",
-        "contact": [
-            {
-                "discord": "287952234317348865"
-            }
-        ]
-    },
-    {
-        "url": "electrumx1.electraprotocol.eu:50002",
-        "protocol": "SSL",
-        "contact": [
-            {
-                "discord": "287952234317348865"
-            }
         ],
         "ws_url": "electrumx1.electraprotocol.eu:50003"
     },
     {
-        "url": "electrumx2.electraprotocol.eu:50002",
-        "protocol": "SSL",
+        "url": "electrumx2.electraprotocol.eu:50001",
         "contact": [
             {
                 "discord": "287952234317348865"
@@ -44,8 +18,7 @@
         "ws_url": "electrumx2.electraprotocol.eu:50003"
     },
     {
-        "url": "electrumx3.electraprotocol.eu:50002",
-        "protocol": "SSL",
+        "url": "electrumx3.electraprotocol.eu:50001",
         "contact": [
             {
                 "discord": "287952234317348865"

--- a/electrums/XEP_BKP
+++ b/electrums/XEP_BKP
@@ -1,0 +1,56 @@
+[
+    {
+        "url": "electrumx1.electraprotocol.eu:50001",
+        "contact": [
+            {
+                "discord": "287952234317348865"
+            }
+        ]
+    },
+    {
+        "url": "electrumx2.electraprotocol.eu:50001",
+        "contact": [
+            {
+                "discord": "287952234317348865"
+            }
+        ]
+    },
+    {
+        "url": "electrumx3.electraprotocol.eu:50001",
+        "contact": [
+            {
+                "discord": "287952234317348865"
+            }
+        ]
+    },
+    {
+        "url": "electrumx1.electraprotocol.eu:50002",
+        "protocol": "SSL",
+        "contact": [
+            {
+                "discord": "287952234317348865"
+            }
+        ],
+        "ws_url": "electrumx1.electraprotocol.eu:50003"
+    },
+    {
+        "url": "electrumx2.electraprotocol.eu:50002",
+        "protocol": "SSL",
+        "contact": [
+            {
+                "discord": "287952234317348865"
+            }
+        ],
+        "ws_url": "electrumx2.electraprotocol.eu:50003"
+    },
+    {
+        "url": "electrumx3.electraprotocol.eu:50002",
+        "protocol": "SSL",
+        "contact": [
+            {
+                "discord": "287952234317348865"
+            }
+        ],
+        "ws_url": "electrumx3.electraprotocol.eu:50003"
+    }
+]


### PR DESCRIPTION
SSL certs don't work:
```
25 00:11:22, coins::utxo::rpc_clients::electrum_rpc::client:433] WARN [coin=XEP-segwit], Error while sending request to electrumx1.electraprotocol.eu:50002: Transport("Failed to establish connection: Temporary(\"Couldn't connect to the electrum server: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) }\")")
25 00:11:22, coins::utxo::rpc_clients::electrum_rpc::client:433] WARN [coin=XEP-segwit], Error while sending request to electrumx3.electraprotocol.eu:50002: Transport("Failed to establish connection: Temporary(\"Couldn't connect to the electrum server: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) }\")")
25 00:11:22, coins::utxo::rpc_clients::electrum_rpc::client:433] WARN [coin=XEP-segwit], Error while sending request to electrumx2.electraprotocol.eu:50002: Transport("Failed to establish connection: Temporary(\"Couldn't connect to the electrum server: Custom { kind: InvalidData, error: InvalidCertificate(UnknownIssuer) }\")")
```
switching back to TCP