### PR TITLE
add dust for PEP

### DIFF
--- a/coins
+++ b/coins
@@ -10626,6 +10626,7 @@
     "wiftype": 158,
     "segwit": false,
     "txfee": 1000000,
+    "dust": 1000000,
     "mm2": 1,
     "sign_message_prefix": "Pepecoin Signed Message:\n",
     "required_confirmations": 5,


### PR DESCRIPTION
to avoid swap failing: `taker_swap:1337] mm2src/coins/utxo.rs:1783] utxo_common:4758] client:878] Rpc(ResponseParseError(JsonRpcError { client_info: "coin: PEP", request: JsonRpcRequest { jsonrpc: "2.0", id: 8473, method: "blockchain.transaction.broadcast", params: [String("01000000018bd2dc714907adc56a8931829e45b312cefd7968d4c2852de7086aaa42de4b7c020000006a47304402207bde72d79e73325db59dc7f1b577b2d906f6acaf8a2b86a5680af838f08f034402202db35fb1376c110125b8dcae4a2cd4ccf4d39cbac9f52515fecbafcc6bd127b30121023c5ba1d7ef6fa015eb33defb3aba2a961898a51bbb7ff30344d07ba75ad3f289ffffffff028abf0000000000001976a914ca1e04745e8ca0c60d8c5881531d51bec470743f88ac874a9502000000001976a91484c74592ed8ac05340906784d277ca4d4e0af08e88ac20fee567")] }, error: Response(electrum.pepe.tips:50002, Object({"code": Number(1), "message": String("the transaction was rejected by network rules.\n\n64: dust\n[01000000018bd2dc714907adc56a8931829e45b312cefd7968d4c2852de7086aaa42de4b7c020000006a47304402207bde72d79e73325db59dc7f1b577b2d906f6acaf8a2b86a5680af838f08f034402202db35fb1376c110125b8dcae4a2cd4ccf4d39cbac9f52515fecbafcc6bd127b30121023c5ba1d7ef6fa015eb33defb3aba2a961898a51bbb7ff30344d07ba75ad3f289ffffffff028abf0000000000001976a914ca1e04745e8ca0c60d8c5881531d51bec470743f88ac874a9502000000001976a91484c74592ed8ac05340906784d277ca4d4e0af08e88ac20fee567]")})) }))`