### PR TITLE
Update `chain_id` position to allow KDF breaking change transition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+coins_updated

--- a/coins
+++ b/coins
@@ -94,10 +94,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -119,8 +119,7 @@
     },
     "derivation_path": "m/44'/60'"
   },
-
-{
+  {
     "coin": "GNEISS-ERC20",
     "name": "gneiss_erc20",
     "fname": "GNEISS",
@@ -139,8 +138,7 @@
     },
     "derivation_path": "m/44'/60'"
   },
-
-{
+  {
     "coin": "1INCH-KRC20",
     "name": "1inch_krc20",
     "fname": "1Inch",
@@ -180,10 +178,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -207,10 +205,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -252,10 +250,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -362,10 +360,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -413,10 +411,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -439,10 +437,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -527,10 +525,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -701,10 +699,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -747,10 +745,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -794,10 +792,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -840,10 +838,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -866,10 +864,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -911,10 +909,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1000,10 +998,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1027,10 +1025,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1102,7 +1100,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 2.4,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 43113
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -1118,7 +1119,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 2.4,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 43114
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Avalanche C-Chain",
@@ -1146,10 +1150,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1255,10 +1259,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1422,10 +1426,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1466,10 +1470,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -1591,10 +1595,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -2132,7 +2136,10 @@
     "max_eth_tx_type": 2,
     "required_confirmations": 3,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 56
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Binance Smart Chain",
@@ -2195,7 +2202,10 @@
     "chain_id": 30,
     "required_confirmations": 1,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 30
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "RSK",
@@ -2214,7 +2224,10 @@
     "is_testnet": true,
     "required_confirmations": 3,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 97
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -2238,10 +2251,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -2369,10 +2382,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -2441,29 +2454,29 @@
     }
   },
   {
-	"coin": "BKC",
-	"name": "briskcoin",
-	"fname": "Briskcoin",
-	"rpcport": 8552,
-	"pubtype": 25,
-	"p2shtype": 33,
-	"wiftype": 153,
-	"txfee": 0,
-	"segwit": true,
-	"bech32_hrp": "bc",
-	"mm2": 1,
-	"required_confirmations": 5,
-	"avg_blocktime": 30,
-	"protocol": {
-		"type": "UTXO"
-	},
-	"derivation_path": "m/44'/1918'",
-	"sign_message_prefix": "Briskcoin Signed Message:\n",
-	"trezor_coin": "Briskcoin",
-   	"links": {
-      		"github": "https://github.com/briskcoin-project/briskcoin",
-      		"homepage": "https://briskcoin.org"
-    	}
+    "coin": "BKC",
+    "name": "briskcoin",
+    "fname": "Briskcoin",
+    "rpcport": 8552,
+    "pubtype": 25,
+    "p2shtype": 33,
+    "wiftype": 153,
+    "txfee": 0,
+    "segwit": true,
+    "bech32_hrp": "bc",
+    "mm2": 1,
+    "required_confirmations": 5,
+    "avg_blocktime": 30,
+    "protocol": {
+      "type": "UTXO"
+    },
+    "derivation_path": "m/44'/1918'",
+    "sign_message_prefix": "Briskcoin Signed Message:\n",
+    "trezor_coin": "Briskcoin",
+    "links": {
+      "github": "https://github.com/briskcoin-project/briskcoin",
+      "homepage": "https://briskcoin.org"
+    }
   },
   {
     "coin": "BTC-segwit",
@@ -2515,10 +2528,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -2654,10 +2667,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -2918,10 +2931,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -2944,10 +2957,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -3136,10 +3149,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -3163,10 +3176,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -3190,10 +3203,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -3467,10 +3480,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -3537,10 +3550,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -3664,10 +3677,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -3749,10 +3762,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -3925,10 +3938,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4012,10 +4025,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4123,10 +4136,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4242,10 +4255,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4403,10 +4416,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -4429,10 +4442,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4595,10 +4608,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4699,10 +4712,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4744,10 +4757,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4875,10 +4888,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -4893,7 +4906,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 61
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Ethereum Classic",
@@ -4930,7 +4946,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 1
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -4963,16 +4982,19 @@
     "required_confirmations": 10,
     "avg_blocktime": 0.25,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 42161
+      }
     },
     "derivation_path": "m/44'/60'",
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_coins": 300000,
-        "eth_payment": 700000,
-        "eth_receiver_spend": 600000,
-        "eth_sender_refund": 600000
+      "eth_send_coins": 300000,
+      "eth_payment": 700000,
+      "eth_receiver_spend": 600000,
+      "eth_sender_refund": 600000
     }
   },
   {
@@ -4995,10 +5017,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5081,10 +5103,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5127,10 +5149,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 90000,
-        "erc20_payment": 150000,
-        "erc20_receiver_spend": 120000,
-        "erc20_sender_refund": 120000
+      "eth_send_erc20": 90000,
+      "erc20_payment": 150000,
+      "erc20_receiver_spend": 120000,
+      "erc20_sender_refund": 120000
     }
   },
   {
@@ -5173,10 +5195,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5224,10 +5246,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5242,7 +5264,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 5,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 246
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Energy Web",
@@ -5315,10 +5340,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 70000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 70000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5417,10 +5442,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5505,10 +5530,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5622,10 +5647,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 85000,
-        "erc20_payment": 140000,
-        "erc20_receiver_spend": 110000,
-        "erc20_sender_refund": 110000
+      "eth_send_erc20": 85000,
+      "erc20_payment": 140000,
+      "erc20_receiver_spend": 110000,
+      "erc20_sender_refund": 110000
     }
   },
   {
@@ -5688,10 +5713,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5760,7 +5785,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 4002
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -5776,7 +5804,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 1.8,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 250
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Fantom Opera",
@@ -5846,10 +5877,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5892,10 +5923,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -5936,10 +5967,10 @@
     },
     "derivation_path": "m/44'/60'",
     "gas_limit": {
-        "eth_send_erc20": 1000000,
-        "erc20_payment": 1000000,
-        "erc20_receiver_spend": 1000000,
-        "erc20_sender_refund": 1000000
+      "eth_send_erc20": 1000000,
+      "erc20_payment": 1000000,
+      "erc20_receiver_spend": 1000000,
+      "erc20_sender_refund": 1000000
     }
   },
   {
@@ -6040,10 +6071,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6110,10 +6141,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6158,7 +6189,7 @@
     "derivation_path": "m/44'/141'",
     "trezor_coin": "Komodo"
   },
-  { 
+  {
     "coin": "GLEEC",
     "sign_message_prefix": "Komodo Signed Message:\n",
     "asset": "GLEEC",
@@ -6216,10 +6247,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6280,10 +6311,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6307,10 +6338,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -6334,10 +6365,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -6403,10 +6434,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -6430,10 +6461,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6542,10 +6573,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -6631,10 +6662,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6761,10 +6792,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -6815,7 +6846,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 3,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 128
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Huobi ECO Chain",
@@ -6984,10 +7018,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -7133,10 +7167,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7178,10 +7212,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7222,10 +7256,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7248,10 +7282,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7313,10 +7347,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7358,10 +7392,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7404,10 +7438,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7431,10 +7465,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7515,10 +7549,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7542,10 +7576,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7626,10 +7660,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7691,10 +7725,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7737,10 +7771,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7783,10 +7817,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7810,10 +7844,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7894,10 +7928,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -7977,10 +8011,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8042,10 +8076,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8127,10 +8161,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8145,7 +8179,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 3,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 321
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "KCC",
@@ -8199,10 +8236,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8267,10 +8304,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8331,10 +8368,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8512,10 +8549,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8558,10 +8595,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8761,10 +8798,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8853,10 +8890,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -8941,10 +8978,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -9126,10 +9163,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -9191,10 +9228,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -9208,7 +9245,10 @@
     "avg_blocktime": 1.8,
     "required_confirmations": 3,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 80001
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -9224,7 +9264,10 @@
     "avg_blocktime": 1.8,
     "required_confirmations": 20,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 137
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Polygon",
@@ -9252,10 +9295,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -9600,10 +9643,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -9802,10 +9845,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -9818,7 +9861,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 1285
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Moonriver",
@@ -9828,9 +9874,9 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_payment": 100000,
-        "eth_receiver_spend": 500000,
-        "eth_sender_refund": 500000
+      "eth_payment": 100000,
+      "eth_receiver_spend": 500000,
+      "eth_sender_refund": 500000
     }
   },
   {
@@ -9845,7 +9891,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 1284
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Moonbeam",
@@ -9913,10 +9962,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10018,10 +10067,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10138,10 +10187,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10351,10 +10400,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10378,10 +10427,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10439,7 +10488,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 1666600000
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -10463,10 +10515,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10612,10 +10664,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -10686,10 +10738,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -10796,10 +10848,10 @@
       "homepage": "https://www.pepe.vip"
     },
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -10930,10 +10982,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -11156,10 +11208,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -11242,10 +11294,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -11363,10 +11415,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -11679,10 +11731,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -11869,10 +11921,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12056,10 +12108,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12083,10 +12135,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12110,10 +12162,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12237,10 +12289,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12283,10 +12335,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12346,10 +12398,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -12429,10 +12481,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12456,10 +12508,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12641,10 +12693,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12715,7 +12767,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 6,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 10000
+      }
     }
   },
   {
@@ -12777,10 +12832,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -12956,10 +13011,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -13065,10 +13120,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -13092,10 +13147,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -13250,10 +13305,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -13277,10 +13332,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -13322,10 +13377,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -13771,10 +13826,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -13821,10 +13876,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -13909,10 +13964,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14014,10 +14069,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14177,10 +14232,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14204,10 +14259,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -14231,10 +14286,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 120000,
-        "erc20_receiver_spend": 90000,
-        "erc20_sender_refund": 90000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 120000,
+      "erc20_receiver_spend": 90000,
+      "erc20_sender_refund": 90000
     }
   },
   {
@@ -14277,10 +14332,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14323,7 +14378,7 @@
     "derivation_path": "m/44'/141'",
     "trezor_coin": "Komodo"
   },
-  { 
+  {
     "coin": "vDEX",
     "sign_message_prefix": "Komodo Signed Message:\n",
     "asset": "vDEX",
@@ -14387,10 +14442,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14527,10 +14582,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14710,10 +14765,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14775,10 +14830,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 400000,
-        "erc20_payment": 800000,
-        "erc20_receiver_spend": 700000,
-        "erc20_sender_refund": 700000
+      "eth_send_erc20": 400000,
+      "erc20_payment": 800000,
+      "erc20_receiver_spend": 700000,
+      "erc20_sender_refund": 700000
     }
   },
   {
@@ -14860,10 +14915,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -14990,10 +15045,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15016,10 +15071,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15157,10 +15212,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15227,10 +15282,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15253,10 +15308,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15369,10 +15424,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15414,10 +15469,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15504,10 +15559,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 55000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 55000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15667,10 +15722,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -15822,10 +15877,10 @@
     "use_access_list": true,
     "max_eth_tx_type": 2,
     "gas_limit": {
-        "eth_send_erc20": 60000,
-        "erc20_payment": 110000,
-        "erc20_receiver_spend": 85000,
-        "erc20_sender_refund": 85000
+      "eth_send_erc20": 60000,
+      "erc20_payment": 110000,
+      "erc20_receiver_spend": 85000,
+      "erc20_sender_refund": 85000
     }
   },
   {
@@ -16086,7 +16141,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 11155111
+      }
     },
     "derivation_path": "m/44'/60'"
   },
@@ -16275,7 +16333,10 @@
     "required_confirmations": 3,
     "avg_blocktime": 15,
     "protocol": {
-      "type": "ETH"
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 8
+      }
     },
     "derivation_path": "m/44'/60'",
     "trezor_coin": "Ubiq",
@@ -17153,68 +17214,68 @@
     "mm2": 1,
     "wallet_only": false,
     "is_testnet": true,
-    "protocol":{
-        "type":"TENDERMINT",
-        "protocol_data": {
-            "decimals": 6,
-            "denom": "unucl",
-            "account_prefix": "nuc",
-            "chain_id": "nucleus-3"
-        }
+    "protocol": {
+      "type": "TENDERMINT",
+      "protocol_data": {
+        "decimals": 6,
+        "denom": "unucl",
+        "account_prefix": "nuc",
+        "chain_id": "nucleus-3"
+      }
     },
     "derivation_path": "m/44'/118'"
   },
   {
-    "coin":"IRISTEST-IBC_NUCLEUSTEST",
+    "coin": "IRISTEST-IBC_NUCLEUSTEST",
     "avg_blocktime": 5,
     "name": "iristest-ibc-nucleus-test",
     "fname": "Iris Test",
     "mm2": 1,
     "wallet_only": false,
     "is_testnet": true,
-    "protocol":{
-        "type":"TENDERMINTTOKEN",
-        "protocol_data": {
-            "platform": "NUCLEUSTEST",
-            "decimals": 6,
-            "denom": "ibc/F7F28FF3C09024A0225EDBBDB207E5872D2B4EF2FB874FE47B05EF9C9A7D211C"
-        }
+    "protocol": {
+      "type": "TENDERMINTTOKEN",
+      "protocol_data": {
+        "platform": "NUCLEUSTEST",
+        "decimals": 6,
+        "denom": "ibc/F7F28FF3C09024A0225EDBBDB207E5872D2B4EF2FB874FE47B05EF9C9A7D211C"
+      }
     },
     "derivation_path": "m/44'/118'"
   },
   {
-    "coin":"ATOM-IBC_NUCLEUSTEST",
+    "coin": "ATOM-IBC_NUCLEUSTEST",
     "avg_blocktime": 5,
     "name": "cosmos-ibc-nucleus-test",
     "fname": "Cosmos",
     "mm2": 1,
     "wallet_only": false,
     "is_testnet": true,
-    "protocol":{
-        "type":"TENDERMINTTOKEN",
-        "protocol_data": {
-            "platform": "NUCLEUSTEST",
-            "decimals": 6,
-            "denom": "ibc/9117A26BA81E29FA4F78F57DC2BD90CD3D26848101BA880445F119B22A1E254E"
-        }
+    "protocol": {
+      "type": "TENDERMINTTOKEN",
+      "protocol_data": {
+        "platform": "NUCLEUSTEST",
+        "decimals": 6,
+        "denom": "ibc/9117A26BA81E29FA4F78F57DC2BD90CD3D26848101BA880445F119B22A1E254E"
+      }
     },
     "derivation_path": "m/44'/118'"
   },
   {
-    "coin":"OSMO-IBC_NUCLEUSTEST",
+    "coin": "OSMO-IBC_NUCLEUSTEST",
     "avg_blocktime": 5,
     "name": "cosmos-ibc-nucleus-test",
     "fname": "Osmosis",
     "mm2": 1,
     "wallet_only": false,
     "is_testnet": true,
-    "protocol":{
-        "type":"TENDERMINTTOKEN",
-        "protocol_data": {
-            "platform": "NUCLEUSTEST",
-            "decimals": 6,
-            "denom": "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23"
-        }
+    "protocol": {
+      "type": "TENDERMINTTOKEN",
+      "protocol_data": {
+        "platform": "NUCLEUSTEST",
+        "decimals": 6,
+        "denom": "ibc/47BD209179859CDE4A2806763D7189B6E6FE13A17880FE2B42DE1E6C1E329E23"
+      }
     },
     "derivation_path": "m/44'/118'"
   },

--- a/coins
+++ b/coins
@@ -16842,8 +16842,11 @@
         "decimals": 6,
         "denom": "uatom",
         "account_prefix": "cosmos",
-        "chain_registry_name": "cosmoshub",
-        "chain_id": "cosmoshub-4"
+        "chain_id": "cosmoshub-4",
+        "ibc_channels": {
+          "iaa": 91,
+          "osmo": 141
+        }
       }
     },
     "derivation_path": "m/44'/118'"
@@ -16862,8 +16865,11 @@
         "denom": "uiris",
         "account_prefix": "iaa",
         "chain_id": "irishub-1",
-        "chain_registry_name": "irishub",
-        "gas_price": 0.5
+        "gas_price": 0.5,
+        "ibc_channels": {
+          "cosmos": 0,
+          "osmo": 3
+        }
       }
     },
     "derivation_path": "m/44'/118'"
@@ -16900,9 +16906,12 @@
         "decimals": 6,
         "denom": "uosmo",
         "account_prefix": "osmo",
-        "chain_registry_name": "osmosis",
         "chain_id": "osmosis-1",
-        "gas_price": 0.5
+        "gas_price": 0.5,
+        "ibc_channels": {
+          "cosmos": 0,
+          "iaa": 6
+        }
       }
     },
     "derivation_path": "m/44'/118'"
@@ -17125,7 +17134,6 @@
             "decimals": 6,
             "denom": "unucl",
             "account_prefix": "nuc",
-            "chain_registry_name": "nucleus",
             "chain_id": "nucleus-3"
         }
     },

--- a/coins
+++ b/coins
@@ -16929,6 +16929,7 @@
         "denom": "uatom",
         "account_prefix": "cosmos",
         "chain_id": "cosmoshub-4",
+        "chain_registry_name": "cosmoshub",
         "ibc_channels": {
           "iaa": 91,
           "osmo": 141
@@ -16951,6 +16952,7 @@
         "denom": "uiris",
         "account_prefix": "iaa",
         "chain_id": "irishub-1",
+        "chain_registry_name": "irishub",
         "gas_price": 0.5,
         "ibc_channels": {
           "cosmos": 0,
@@ -16993,6 +16995,7 @@
         "denom": "uosmo",
         "account_prefix": "osmo",
         "chain_id": "osmosis-1",
+        "chain_registry_name": "osmosis",
         "gas_price": 0.5,
         "ibc_channels": {
           "cosmos": 0,

--- a/coins
+++ b/coins
@@ -2501,7 +2501,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/0'",
+    "derivation_path": "m/84'/0'",
     "trezor_coin": "Bitcoin",
     "links": {
       "github": "https://github.com/bitcoin/bitcoin",
@@ -2762,7 +2762,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/160'",
+    "derivation_path": "m/84'/160'",
     "trezor_coin": "Bitcore",
     "links": {
       "github": "https://github.com/LIMXTEC/BitCore",
@@ -3045,7 +3045,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/34'"
+    "derivation_path": "m/84'/34'"
   },
   {
     "coin": "CDS-PLG20",
@@ -3870,7 +3870,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/802'",
+    "derivation_path": "m/84'/802'",
     "links": {
       "github": "https://github.com/cyberyen/cyberyen",
       "homepage": "https://cyberyen.org"
@@ -4190,7 +4190,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/20'",
+    "derivation_path": "m/84'/20'",
     "trezor_coin": "DigiByte",
     "links": {
       "github": "https://github.com/digibyte/digibyte",
@@ -5584,7 +5584,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/75'",
+    "derivation_path": "m/84'/75'",
     "trezor_coin": "Fujicoin",
     "links": {
       "github": "https://github.com/fujicoin/fujicoin",
@@ -5767,7 +5767,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/8'",
+    "derivation_path": "m/84'/8'",
     "trezor_coin": "Feathercoin",
     "links": {
       "github": "https://github.com/FeatherCoin/Feathercoin",
@@ -8133,7 +8133,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/0'",
+    "derivation_path": "m/84'/0'",
     "trezor_coin": "Kylacoin",
     "links": {
       "github": "https://github.com/kylacoin/kylacoin",
@@ -8417,7 +8417,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/140'"
+    "derivation_path": "m/84'/140'"
   },
   {
     "coin": "LCC",
@@ -8468,7 +8468,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/192'"
+    "derivation_path": "m/84'/192'"
   },
   {
     "coin": "LCN",
@@ -8521,7 +8521,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/0'",
+    "derivation_path": "m/84'/0'",
     "trezor_coin": "Lyncoin",
     "links": {
       "github": "https://github.com/lyncoin/lyncoin",
@@ -9053,7 +9053,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/2'",
+    "derivation_path": "m/84'/2'",
     "trezor_coin": "Litecoin",
     "links": {
       "github": "https://github.com/litecoin-project/litecoin",
@@ -9798,7 +9798,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/22'",
+    "derivation_path": "m/84'/22'",
     "trezor_coin": "Monacoin",
     "links": {
       "github": "https://github.com/monacoinproject/monacoin",
@@ -10137,7 +10137,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/7'",
+    "derivation_path": "m/84'/7'",
     "trezor_coin": "Namecoin",
     "links": {
       "github": "https://github.com/namecoin/namecoin-core",
@@ -11780,7 +11780,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/143'"
+    "derivation_path": "m/84'/143'"
   },
   {
     "coin": "RIC-BEP20",
@@ -12926,7 +12926,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/57'",
+    "derivation_path": "m/84'/57'",
     "trezor_coin": "Syscoin",
     "links": {
       "github": "https://github.com/syscoin/syscoin",
@@ -14555,7 +14555,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/14'",
+    "derivation_path": "m/84'/14'",
     "trezor_coin": "Viacoin",
     "links": {
       "github": "https://github.com/viacoin",
@@ -14672,7 +14672,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/28'",
+    "derivation_path": "m/84'/28'",
     "trezor_coin": "Vertcoin",
     "links": {
       "github": "https://github.com/vertcoin-project/vertcoin-core",
@@ -14984,7 +14984,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/597'"
+    "derivation_path": "m/84'/597'"
   },
   {
     "coin": "XEP-BEP20",
@@ -15120,7 +15120,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/90'"
+    "derivation_path": "m/84'/90'"
   },
   {
     "coin": "XNA",
@@ -17093,7 +17093,7 @@
     "protocol": {
       "type": "UTXO"
     },
-    "derivation_path": "m/44'/0'",
+    "derivation_path": "m/84'/0'",
     "links": {
       "github": "https://github.com/NitoNetwork/",
       "homepage": "https://nito.network/"

--- a/tendermint/ATOM
+++ b/tendermint/ATOM
@@ -8,6 +8,10 @@
     },
     {
       "url": "https://cosmoshub.rpc.stakin-nodes.com/"
+    },
+    {
+      "url": "https://node.komodo.earth:8080/cosmos",
+      "komodo_proxy": true
     }
   ]
 }

--- a/utils/update_chain_ids.py
+++ b/utils/update_chain_ids.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import json
+
+# Load the JSON data from file
+with open('../coins', 'r') as f:
+    coins = json.load(f)
+
+# Process each coin in the list
+for coin in coins:
+    protocol = coin.get("protocol", {})
+    if protocol.get("type") in ["ETH", "AVAX", "MATIC", "BNB", "KCS", "FTM", "HT"]:
+        # Ensure protocol_data exists
+        protocol_data = protocol.setdefault("protocol_data", {})
+        # Duplicate chain_id if it exists at top level
+        if "chain_id" in coin:
+            protocol_data["chain_id"] = coin["chain_id"]
+
+# Write the updated data back to file or print to stdout
+with open('../coins_updated', 'w') as f:
+    json.dump(coins, f, indent=2)
+
+print("Transformation complete. Output saved to coins_updated")


### PR DESCRIPTION
Closes https://github.com/KomodoPlatform/coins/issues/1350 and https://github.com/KomodoPlatform/coins/issues/1354

This PR includes changes from https://github.com/KomodoPlatform/coins/pull/1335

Due to recent breaking changes in the KDF RPC, the position of the `chain_id` param has changed for ETH/Tendermint coins.

This PR applies a partial update to the coins file which should allow it to be used with both the latest and the last most recent KDF releases. As the web wallet will auto update coins file, we need to cover both while testing prior to v0.9.0 release. Once v0.9.0 is released, `chain_id` values for EVM tokens and at the object root for parent coins will also be removed, resulting in a significantly smaller coins file.

**To test:**
- Launch KDF with the coins file from this branch
- Confirm successful activation of 
  - [ ] EVM coins and tokens
  - [ ] Tendermint coins and IBC tokens

**Note:**
- `chain_registry_name` was removed in https://github.com/KomodoPlatform/coins/pull/1351/commits/afc2a14448666e054ac313b0879c2e411e09e14f and may need to be restored to maintain (temporary) backwards functionality
- There is a chance some users may have deposited funds on a segwit address using an older derivation path. While testing this, please check: 
    - [ ] non-HD / legacy activation of segwit coins still results in same address as `master`coins file
    - [ ] HD/v2 activation of segwit coins matches address returned in 3rd party wallets.
    - [ ] Does HD/v2 activation of segwit coins matches address returned in KDF using `master` branch of coins 

It is expected that in the 3rd case, the updated derivation path will result in a different address when using HD mode. cc: @gcharang @KomodoPlatform/qa keep this in mind for support queries. Recovery should be simple enough with an older coins file. 

Alternatively, we can add "COIN-segwit_OLD" with the non-segwit derivation path as a fallback  to make resolution simpler, tho ideally there should be a toggle in app settings to hide `_OLD` tickers by default to demotivate their use. cc: @CharlVS 
