### PR TITLE
removes komodod.com explorer

### DIFF
--- a/explorers/KMD
+++ b/explorers/KMD
@@ -1,1 +1,1 @@
-["https://kmdexplorer.io/", "https://kmd.explorer.dexstats.info/", "https://komodod.com/", "https://www.kmdexplorer.ru/"]
+["https://kmdexplorer.io/", "https://kmd.explorer.dexstats.info/", "https://www.kmdexplorer.ru/"]


### PR DESCRIPTION
https://komodod.com/ is no longer a block explorer, it appears to be an Indonesian slot machine.