### PR TITLE
Rm/trezor coins

### DIFF
--- a/coins
+++ b/coins
@@ -5485,7 +5485,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/75'",
-    "trezor_coin": "Fujicoin",
     "links": {
       "github": "https://github.com/fujicoin/fujicoin",
       "homepage": "https://fujicoin.org"
@@ -5668,7 +5667,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/8'",
-    "trezor_coin": "Feathercoin",
     "links": {
       "github": "https://github.com/FeatherCoin/Feathercoin",
       "homepage": "https://feathercoin.com"
@@ -8032,7 +8030,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/0'",
-    "trezor_coin": "Kylacoin",
     "links": {
       "github": "https://github.com/kylacoin/kylacoin",
       "homepage": "https://kylacoin.com"
@@ -8063,7 +8060,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/84'/0'",
-    "trezor_coin": "Kylacoin",
     "links": {
       "github": "https://github.com/kylacoin/kylacoin",
       "homepage": "https://kylacoin.com"
@@ -8420,7 +8416,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/0'",
-    "trezor_coin": "Lyncoin",
     "links": {
       "github": "https://github.com/lyncoin/lyncoin",
       "homepage": "https://lyncoin.com"
@@ -8451,7 +8446,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/84'/0'",
-    "trezor_coin": "Lyncoin",
     "links": {
       "github": "https://github.com/lyncoin/lyncoin",
       "homepage": "https://lyncoin.com"
@@ -8953,7 +8947,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/2'",
-    "trezor_coin": "Litecoin",
     "links": {
       "github": "https://github.com/litecoin-project/litecoin",
       "homepage": "https://litecoin.org"
@@ -9698,7 +9691,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/22'",
-    "trezor_coin": "Monacoin",
     "links": {
       "github": "https://github.com/monacoinproject/monacoin",
       "homepage": "https://monacoin.org"
@@ -10074,7 +10066,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/84'/7'",
-    "trezor_coin": "Namecoin",
     "links": {
       "github": "https://github.com/namecoin/namecoin-core",
       "homepage": "https://namecoin.org"
@@ -12849,7 +12840,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/57'",
-    "trezor_coin": "Syscoin",
     "links": {
       "github": "https://github.com/syscoin/syscoin",
       "homepage": "https://syscoin.org"
@@ -14484,7 +14474,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/14'",
-    "trezor_coin": "Viacoin",
     "links": {
       "github": "https://github.com/viacoin",
       "homepage": "https://viacoin.org"
@@ -14602,7 +14591,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/28'",
-    "trezor_coin": "Vertcoin",
     "links": {
       "github": "https://github.com/vertcoin-project/vertcoin-core",
       "homepage": "https://vertcoin.org"

--- a/coins
+++ b/coins
@@ -2611,7 +2611,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/160'",
-    "trezor_coin": "Bitcore",
     "links": {
       "github": "https://github.com/LIMXTEC/BitCore",
       "homepage": "https://bitcore.cc"

--- a/coins
+++ b/coins
@@ -2323,7 +2323,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/0'",
-    "trezor_coin": "Bitcoin",
     "links": {
       "github": "https://github.com/bitcoin/bitcoin",
       "homepage": "https://bitcoin.org"
@@ -4046,7 +4045,6 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/20'",
-    "trezor_coin": "DigiByte",
     "links": {
       "github": "https://github.com/DigiByte-Core/digibyte",
       "homepage": "https://digibyte.io"


### PR DESCRIPTION
[Recent testing revealed](https://github.com/KomodoPlatform/komodo-defi-framework/issues/2515#issuecomment-3030507925) that new address creation on a non-segwit variant of LTC/BTC would return something other than the expected, resulting on a mismatch on the device when confirming the address.

This was tracked down to the reference links below, which by Trezor defines whether their supported coins are sunning with segwit or not. Unlike this repo, there is no legacy/segwit duplication.

It was also noted that activation of LTC/BTC in Komodo Wallet and in Trezor suite would return a different balance/address for the same device.
Inversely, the LTC/BTC addresses in Trezor suite would match the LTC-segwit/BTC-segwit addresses in KDF.

To avoid user confusion and concern, we should only offer trezor support the variant within the KDF coins which matches which trezor is using. This means removing the `trezor_coin` fields for the unsupported variants.

There is potential that this change may separate users from funds deposited within the non-segwit addresses, though this is more likely to affect devs and qa. Support in such a case would be to launch KDF using an older or modified coins file to temporarily regain access, then withdraw to the supported address.

Refs:
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/bitcore.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/bitcoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/digibyte.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/feathercoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/fujicoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/litecoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/monacoin.json#25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/namecoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/syscoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/bitcoin_testnet.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/viacoin.json#L25
- https://github.com/trezor/trezor-common/blob/master/defs/bitcoin/vertcoin.json#L25

Of the above, all except NMC are using the segwit variant.