### PR TITLE
swap_gas_fee_policy Medium for MVR20

### DIFF
--- a/coins
+++ b/coins
@@ -2699,9 +2699,9 @@
     "mm2": 1,
     "wallet_only": true,
     "chain_id": 1285,
-    "avg_blocktime": 15,
+    "avg_blocktime": 6,
     "decimals": 18,
-    "required_confirmations": 3,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
@@ -3889,9 +3889,9 @@
     "mm2": 1,
     "wallet_only": true,
     "chain_id": 1285,
-    "avg_blocktime": 15,
+    "avg_blocktime": 6,
     "decimals": 18,
-    "required_confirmations": 3,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
@@ -5907,8 +5907,8 @@
     "mm2": 1,
     "chain_id": 1285,
     "decimals": 18,
-    "avg_blocktime": 15,
-    "required_confirmations": 3,
+    "avg_blocktime": 6,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
@@ -9687,9 +9687,9 @@
     "mm2": 1,
     "wallet_only": true,
     "chain_id": 1285,
-    "avg_blocktime": 15,
+    "avg_blocktime": 6,
     "decimals": 18,
-    "required_confirmations": 3,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
@@ -9828,8 +9828,8 @@
     "rpcport": 80,
     "mm2": 1,
     "chain_id": 1285,
-    "required_confirmations": 3,
-    "avg_blocktime": 15,
+    "required_confirmations": 6,
+    "avg_blocktime": 6,
     "protocol": {
       "type": "ETH",
       "protocol_data": {
@@ -9843,6 +9843,7 @@
     },
     "use_access_list": true,
     "max_eth_tx_type": 2,
+    "swap_gas_fee_policy": "Medium",
     "gas_limit": {
       "eth_payment": 100000,
       "eth_receiver_spend": 500000,
@@ -12668,9 +12669,9 @@
     "mm2": 1,
     "wallet_only": true,
     "chain_id": 1285,
-    "avg_blocktime": 15,
+    "avg_blocktime": 6,
     "decimals": 18,
-    "required_confirmations": 3,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
@@ -14057,9 +14058,9 @@
     "mm2": 1,
     "wallet_only": true,
     "chain_id": 1285,
-    "avg_blocktime": 15,
+    "avg_blocktime": 6,
     "decimals": 6,
-    "required_confirmations": 3,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {
@@ -14161,9 +14162,9 @@
     "mm2": 1,
     "wallet_only": true,
     "chain_id": 1285,
-    "avg_blocktime": 15,
+    "avg_blocktime": 6,
     "decimals": 6,
-    "required_confirmations": 3,
+    "required_confirmations": 6,
     "protocol": {
       "type": "ERC20",
       "protocol_data": {

--- a/coins
+++ b/coins
@@ -2009,7 +2009,7 @@
     "chain_id": 56,
     "use_access_list": true,
     "max_eth_tx_type": 2,
-    "swap_gas_fee_policy": "Low",
+    "swap_gas_fee_policy": "Medium",
     "required_confirmations": 3,
     "protocol": {
       "type": "ETH",


### PR DESCRIPTION
https://moonbeam.network/news/support-for-ethereum-london-eip-1559-has-arrived-on-moonriver-will-follow-on-moonbeam-next-week/

also change blocktime to 6s for MVR20: https://docs.moonbeam.network/learn/platform/networks/moonriver/
and increase confirmations from 3 to 6 for MVR20: https://moonriver.moonscan.io/blocks_forked

<img width="654" height="487" alt="image" src="https://github.com/user-attachments/assets/d38f2c90-cb3f-49ca-ac4e-5775d696aa0b" />

