### PR TITLE
Updated SSL and WS_URL of BKC

### DIFF
--- a/coins
+++ b/coins
@@ -2320,7 +2320,7 @@
     "segwit": true,
     "bech32_hrp": "bc",
     "mm2": 1,
-    "required_confirmations": 5,
+    "required_confirmations": 1,
     "avg_blocktime": 30,
     "protocol": {
       "type": "UTXO"

--- a/coins
+++ b/coins
@@ -2320,7 +2320,7 @@
     "segwit": true,
     "bech32_hrp": "bc",
     "mm2": 1,
-    "required_confirmations": 1,
+    "required_confirmations": 5,
     "avg_blocktime": 30,
     "protocol": {
       "type": "UTXO"

--- a/electrums/BKC
+++ b/electrums/BKC
@@ -6,5 +6,15 @@
   {
     "url": "electrumx2.briskcoin.org:50001",
     "protocol": "TCP"
+  },
+  {
+      "url": "electrumx1.briskcoin.org:50002",
+      "protocol": "SSL",
+      "ws_url": "electrumx1.briskcoin.org:50003"
+  },
+  {
+      "url": "electrumx2.briskcoin.org:50002",
+      "protocol": "SSL",
+      "ws_url": "electrumx2.briskcoin.org:50003"
   }
 ]

--- a/electrums/BKC
+++ b/electrums/BKC
@@ -8,6 +8,10 @@
     "protocol": "TCP"
   },
   {
+    "url": "electrumx3.briskcoin.org:50001",
+    "protocol": "TCP"
+  },
+  {
       "url": "electrumx1.briskcoin.org:50002",
       "protocol": "SSL",
       "ws_url": "electrumx1.briskcoin.org:50003"
@@ -16,5 +20,10 @@
       "url": "electrumx2.briskcoin.org:50002",
       "protocol": "SSL",
       "ws_url": "electrumx2.briskcoin.org:50003"
+  },
+  {
+      "url": "electrumx3.briskcoin.org:50002",
+      "protocol": "SSL",
+      "ws_url": "electrumx3.briskcoin.org:50003"
   }
 ]


### PR DESCRIPTION
Updated SSL and WS_URL of BKC
Electrumx3 is reserved, so using the same IP for temporary.

A chain reorg deeper than 6 blocks is extremely rare and would require massive mining power (likely a 51% attack). That's why 6 confirmations has been the industry standard for over a decade.