### PR TITLE
Update PEP

### DIFF
--- a/electrums/PEP
+++ b/electrums/PEP
@@ -45,24 +45,5 @@
                 "discord": "emgi2"
             }
         ]
-    },
-    {
-        "url": "electrum.pepe.tips:50001",
-        "protocol": "TCP",
-        "contact": [
-            {
-                "discord": "squidicuz"
-            }
-        ]
-    },
-    {
-        "url": "electrum.pepe.tips:50002",
-        "protocol": "SSL",
-        "ws_url": "electrum.pepe.tips:50004",
-        "contact": [
-            {
-                "discord": "squidicuz"
-            }
-        ]
     }
 ]


### PR DESCRIPTION
<img width="3397" height="1564" alt="Screenshot 2025-08-10 233941" src="https://github.com/user-attachments/assets/fd3e0eaa-8da1-4672-b65a-3b199111a48f" />

electrum.pepe.tips:50004 has wrong blockheight/is on a fork. 