### PR TITLE
fix p2shtype for CAS

### DIFF
--- a/coins
+++ b/coins
@@ -17454,7 +17454,7 @@
     "sign_message_prefix": "Cascoin Signed Message:\n",
     "rpcport": 62457,
     "pubtype": 40,
-    "p2shtype": 8,
+    "p2shtype": 50,
     "wiftype": 188,
     "decimals": 7,
     "fork_id": "0x40",


### PR DESCRIPTION
```
        base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 8);
        base58Prefixes[SCRIPT_ADDRESS2] = std::vector<unsigned char>(1, 50);
```
from src/chainparams.cpp
needs to be set to 50 else withdraws can fail like this:
```
"rpc:198] RPC call failed: dispatcher_legacy:177] utxo_withdraw:164] utxo_common:392] Invalid address: Cannot determine format: [\"invalid address prefix\", \"bech32: missing human-readable separator, \\\"1\\\"\", \"cashaddress contains mixed upper and lowercase characters\"]"
```
with 50 the same withdraw works fine