### PR TITLE
delist PAXG-BEP20

### DIFF
--- a/api_ids/binance_ids.json
+++ b/api_ids/binance_ids.json
@@ -208,7 +208,6 @@
     "OM-PLG20": "OM",
     "ONE": "ONE",
     "ONT-BEP20": "ONT",
-    "PAXG-BEP20": "PAXG",
     "PAXG-ERC20": "PAXG",
     "PAXG-PLG20": "PAXG",
     "PENDLE-ARB20": "PENDLE",

--- a/api_ids/coingecko_ids.json
+++ b/api_ids/coingecko_ids.json
@@ -438,7 +438,6 @@
     "PAX-ERC20": "paxos-standard",
     "PAX-KRC20": "paxos-standard",
     "PAX-PLG20": "paxos-standard",
-    "PAXG-BEP20": "pax-gold",
     "PAXG-ERC20": "pax-gold",
     "PAXG-PLG20": "pax-gold",
     "PEP": "pepecoin-network",

--- a/api_ids/coinpaprika_ids.json
+++ b/api_ids/coinpaprika_ids.json
@@ -422,7 +422,6 @@
     "PAX-ERC20": "pax-paxos-standard-token",
     "PAX-KRC20": "pax-paxos-standard-token",
     "PAX-PLG20": "pax-paxos-standard-token",
-    "PAXG-BEP20": "paxg-pax-gold",
     "PAXG-ERC20": "paxg-pax-gold",
     "PAXG-PLG20": "paxg-pax-gold",
     "PEP": "pepenet-pepecoin",

--- a/coins
+++ b/coins
@@ -10356,24 +10356,6 @@
     "derivation_path": "m/44'/60'"
   },
   {
-    "coin": "PAXG-BEP20",
-    "name": "paxg_bep20",
-    "fname": "PAX Gold",
-    "rpcport": 80,
-    "mm2": 1,
-    "chain_id": 56,
-    "avg_blocktime": 3,
-    "required_confirmations": 3,
-    "protocol": {
-      "type": "ERC20",
-      "protocol_data": {
-        "platform": "BNB",
-        "contract_address": "0x7950865a9140cB519342433146Ed5b40c6F210f7"
-      }
-    },
-    "derivation_path": "m/44'/60'"
-  },
-  {
     "coin": "PAXG-ERC20",
     "name": "paxg_erc20",
     "fname": "PAX Gold",


### PR DESCRIPTION
Binance never actually "launched" this, the contract still has 1 holder, which is likely Binance itself, see https://bscscan.com/token/0x7950865a9140cB519342433146Ed5b40c6F210f7
since it never was released to the users, nobody can have PAXG-BEP20, so we can safely remove it without fearing that some of our users could have some