### PR TITLE
Remove some `signature_version`s from coins definitions

### DIFF
--- a/coins
+++ b/coins
@@ -1603,6 +1603,7 @@
     "txfee": 1000,
     "segwit": false,
     "fork_id": "0x40",
+    "signature_version": "fork_id",
     "address_format": {
       "format": "cashaddress",
       "network": "bitcoincash"
@@ -14885,6 +14886,7 @@
     "txfee": 10,
     "segwit": false,
     "fork_id": "0x40",
+    "signature_version": "fork_id",
     "address_format": {
       "format": "cashaddress",
       "network": "ergon"
@@ -16314,6 +16316,7 @@
     "estimate_fee_blocks": 2,
     "segwit": false,
     "fork_id": "0x40",
+    "signature_version": "fork_id",
     "address_format": {
       "format": "cashaddress",
       "network": "bchtest"
@@ -16420,6 +16423,7 @@
     "estimate_fee_blocks": 2,
     "segwit": false,
     "fork_id": "0x40",
+    "signature_version": "fork_id",
     "address_format": {
       "format": "cashaddress",
       "network": "ecash"

--- a/coins
+++ b/coins
@@ -8411,7 +8411,6 @@
     "p2shtype": 63,
     "wiftype": 128,
     "decimals": 8,
-    "signature_version": "base",
     "txfee": 10000,
     "segwit": true,
     "bech32_hrp": "frc",
@@ -14681,7 +14680,6 @@
     "dust": 100000,
     "mm2": 1,
     "segwit": true,
-    "signature_version": "witness_v0",
     "bech32_hrp": "ep",
     "address_format": {
       "format": "segwit"
@@ -16734,7 +16732,6 @@
     "p2shtype": 9,
     "wiftype": 244,
     "decimals": 8,
-    "signature_version": "base",
     "txfee": 10000,
     "segwit": true,
     "bech32_hrp": "maza",
@@ -16760,7 +16757,6 @@
     "p2shtype": 45,
     "wiftype": 176,
     "decimals": 8,
-    "signature_version": "base",
     "txfee": 10000,
     "segwit": true,
     "bech32_hrp": "crnc",


### PR DESCRIPTION
Removed `signature_version` fields from multiple coin configurations.

For `FRC`, `CRNC` & `MAZA`, such config wasn't needed since it's already implied because we have no `"fork_id": "0x40"` set for them.

For `CAS`, `AVN` & `LCC`, those are kept as is because the `signature_version` config actually has a purpose. If we remove the `signature_version: "base"` from there, those coins will default to `signature_version: "fork_id"` since the `"fork_id": "0x40"` option is set for those coins.

`LCC-segwit` configuration looks confusing. The signature version is set to `"base"` and it has a `"fork_id": "0x40"` option set, but arguablly, these options are all useless in signing because segwit coins always get signed as `"WitnessV0"`.