### PR TITLE
rm iris server

### DIFF
--- a/tendermint/IRIS
+++ b/tendermint/IRIS
@@ -1,6 +1,9 @@
 {
   "rpc_nodes": [
     {
+      "url": "https://iris-rpc.publicnode.com"
+    },
+    {
       "url": "https://rpc.irishub-1.irisnet.org"
     }
   ]

--- a/tendermint/IRIS
+++ b/tendermint/IRIS
@@ -1,12 +1,6 @@
 {
   "rpc_nodes": [
     {
-      "url": "https://iris-rpc.alpha.komodo.earth/",
-      "api_url": "https://iris-api.alpha.komodo.earth/",
-      "grpc_url": "https://iris-grpc.alpha.komodo.earth/",
-      "ws_url": "wss://iris-rpc.alpha.komodo.earth/websocket"
-    },
-    {
       "url": "https://rpc.irishub-1.irisnet.org"
     }
   ]


### PR DESCRIPTION
removes failing server until it can be migrated.