### PR TITLE
update IRISTEST url

### DIFF
--- a/tendermint/IRISTEST
+++ b/tendermint/IRISTEST
@@ -1,7 +1,7 @@
 {
   "rpc_nodes": [
     {
-      "url": "https://evmrpc.nyancat.irisnet.org"
+      "url": "http://34.80.202.172:26657"
     }
   ]
 }

--- a/tendermint/IRISTEST
+++ b/tendermint/IRISTEST
@@ -1,7 +1,7 @@
 {
   "rpc_nodes": [
     {
-      "url": "http://34.80.202.172:26657"
+      "url": "https://iristest-rpc.bravo.komodo.earth"
     }
   ]
 }


### PR DESCRIPTION
Replaces broken IRISTEST url with one that is functioning.

To test:
```json
{
    "userpass": "{{userpass}}",
    "method": "enable_tendermint_with_assets",
    "mmrpc": "2.0",
    "params": {
        "ticker": "IRISTEST",
        "tx_history": true,
        "get_balances": true,
        "nodes": [
          {
              "url": "https://iristest-rpc.bravo.komodo.earth/"
          }
        ],
        "tokens_params": [
        ]
    }
}
```

Use the above in https://react-atomicdex-wasm.pages.dev/

Expected result (indicative)
```json
{
    "mmrpc": "2.0",
    "result": {
        "ticker": "IRISTEST",
        "address": "iaa1p8t6fh9tuq5c9mmnlhuuwuy4hw70cmpdcs8sc6",
        "current_block": 24258993,
        "balance": {
            "spendable": "107.949908",
            "unspendable": "0"
        },
        "tokens_balances": {}
    },
    "id": null
}
```
