### PR TITLE
replace old tendermint servers

### DIFF
--- a/tendermint/ATOM
+++ b/tendermint/ATOM
@@ -1,17 +1,10 @@
 {
   "rpc_nodes": [
     {
-      "url": "https://cosmos-rpc.alpha.komodo.earth/",
-      "api_url": "https://cosmos-api.alpha.komodo.earth/",
-      "grpc_url": "https://cosmos-grpc.alpha.komodo.earth/",
-      "ws_url": "wss://cosmos-rpc.alpha.komodo.earth/websocket"
+      "url": "https://rpc.cosmos.directory/cosmoshub"
     },
     {
       "url": "https://cosmoshub.rpc.stakin-nodes.com/"
-    },
-    {
-      "url": "https://node.komodo.earth:8080/cosmos",
-      "komodo_proxy": true
     }
   ]
 }

--- a/tendermint/IRIS
+++ b/tendermint/IRIS
@@ -1,6 +1,5 @@
 {
-  "rpc_nodes": [
-    
+  "rpc_nodes": [    
     {
       "url": "https://rpc.cosmos.directory/irisnet"
     },

--- a/tendermint/IRIS
+++ b/tendermint/IRIS
@@ -1,5 +1,9 @@
 {
   "rpc_nodes": [
+    
+    {
+      "url": "https://rpc.cosmos.directory/irisnet"
+    },
     {
       "url": "https://iris-rpc.publicnode.com"
     },

--- a/tendermint/IRISTEST
+++ b/tendermint/IRISTEST
@@ -1,7 +1,7 @@
 {
   "rpc_nodes": [
     {
-      "url": "https://iristest-rpc.bravo.komodo.earth"
+      "url": "http://34.80.202.172:26657"
     }
   ]
 }

--- a/tendermint/OSMO
+++ b/tendermint/OSMO
@@ -1,6 +1,9 @@
 {
   "rpc_nodes": [
     {
+      "url": "https://rpc.cosmos.directory/osmosis"
+    },
+    {
       "url": "https://rpc.osmosis.zone/"
     },
     {

--- a/tendermint/tIRIS
+++ b/tendermint/tIRIS
@@ -1,8 +1,0 @@
-{
-  "swap_contract_address": "",
-  "rpc_nodes": [
-    {
-      "url": "http://34.80.202.172:26657"
-    }
-  ]
-}


### PR DESCRIPTION
Public proxy nodes sourced from https://cosmos.directory/