### PR TITLE
updates smk's dragon-seed nodes

### DIFF
--- a/seed-nodes.json
+++ b/seed-nodes.json
@@ -72,44 +72,8 @@
         ]
     },
     {
-        "name": "icefyre-dragon-seed",
-        "host": "icefyre.dragon-seed.com",
-        "type": "domain",
-        "wss": true,
-        "netid": 8762,
-        "contact": [
-            {
-                "email": ""
-            }
-        ]
-    },
-    {
-        "name": "kalessin-dragon-seed",
-        "host": "kalessin.dragon-seed.com",
-        "type": "domain",
-        "wss": true,
-        "netid": 8762,
-        "contact": [
-            {
-                "email": ""
-            }
-        ]
-    },
-    {
-        "name": "karrigvestrit-dragon-seed",
-        "host": "karrigvestrit.dragon-seed.com",
-        "type": "domain",
-        "wss": true,
-        "netid": 8762,
-        "contact": [
-            {
-                "email": ""
-            }
-        ]
-    },
-    {
-        "name": "relpda-dragon-seed",
-        "host": "relpda.dragon-seed.com",
+        "name": "mercor-dragon-seed",
+        "host": "mercor.dragon-seed.com",
         "type": "domain",
         "wss": true,
         "netid": 8762,
@@ -134,18 +98,6 @@
     {
         "name": "tintaglia-dragon-seed",
         "host": "tintaglia.dragon-seed.com",
-        "type": "domain",
-        "wss": true,
-        "netid": 8762,
-        "contact": [
-            {
-                "email": ""
-            }
-        ]
-    },
-    {
-        "name": "viserion-dragon-seed",
-        "host": "viserion.dragon-seed.com",
         "type": "domain",
         "wss": true,
         "netid": 8762,


### PR DESCRIPTION
Removes `dragon-seed` nodes which are no longer running. Those remaining are now running on my notary nodes, and will stay up for as long as these servers are required for dPoW.

To simplify the process of spinning up a seed node, I updated https://github.com/smk762/nn_mm2_seed 
Using this repo, all you need is a `.env` file to define a few variables, and docker will take care of the rest (KDF, SSL certs, MM2.json etc).

