### PR TITLE
feat: update ETH swap contract to SafeERC20 and enable USDT trading

### DIFF
--- a/coins
+++ b/coins
@@ -14219,7 +14219,6 @@
     "fname": "Tether",
     "rpcport": 80,
     "mm2": 1,
-    "wallet_only": true,
     "chain_id": 1,
     "avg_blocktime": 15,
     "required_confirmations": 3,

--- a/ethereum/ETH
+++ b/ethereum/ETH
@@ -1,6 +1,6 @@
 {
-    "swap_contract_address": "0x24ABE4c71FC658C91313b6552cd40cD808b3Ea80",
-    "fallback_swap_contract": "0x8500AFc0bc5214728082163326C2FF0C73f4a871",
+    "swap_contract_address": "0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1",
+    "fallback_swap_contract": "0x24ABE4c71FC658C91313b6552cd40cD808b3Ea80",
     "rpc_nodes": [
         {
             "url": "https://ethereum-rpc.publicnode.com",


### PR DESCRIPTION
## Summary
- Update `ethereum/ETH` swap contract to the new SafeERC20-enabled EtomicSwap V1 (applies to all ETH-chain coins)
- Remove `wallet_only` from USDT-ERC20 in the master `coins` file to enable atomic swaps

## Changes

### `ethereum/ETH`
| Field | Before | After |
|-------|--------|-------|
| `swap_contract_address` | `0x24ABE4c71FC658C91313b6552cd40cD808b3Ea80` | `0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1` |
| `fallback_swap_contract` | `0x8500AFc0bc5214728082163326C2FF0C73f4a871` | `0x24ABE4c71FC658C91313b6552cd40cD808b3Ea80` |

### `coins`
- Removed `"wallet_only": true` from USDT-ERC20

## Why?
USDT's `transfer`/`transferFrom` don't return a boolean, which caused the old V1 contract to revert. The new contract uses OpenZeppelin SafeERC20 to handle non-standard ERC20 tokens correctly. It is fully backward compatible with standard ERC20 tokens.

## New Contract
- Address: `0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1`
- Verified: [etherscan.io](https://etherscan.io/address/0x61EEC68Cf64d1b31e41EA713356De2563fB6D3F1#code)
- Deployed via CREATE2 (same address on all EVM chains)

## Related
- Contract PR: https://github.com/GLEECBTC/etomic-swap/pull/11
- KDF PR: https://github.com/GLEECBTC/komodo-defi-framework/pull/2711