### PR TITLE
feat: add GLEECT (Gleec EVM testnet) coin config

### DIFF
--- a/coins
+++ b/coins
@@ -6312,6 +6312,24 @@
     "trezor_coin": "Komodo"
   },
   {
+    "coin": "GLEECT",
+    "name": "gleect",
+    "fname": "Gleec Testnet",
+    "is_testnet": true,
+    "rpcport": 80,
+    "mm2": 1,
+    "chain_id": 11169,
+    "required_confirmations": 3,
+    "avg_blocktime": 2.6,
+    "protocol": {
+      "type": "ETH",
+      "protocol_data": {
+        "chain_id": 11169
+      }
+    },
+    "derivation_path": "m/44'/60'"
+  },
+  {
     "coin": "GLM-ERC20",
     "name": "glm_erc20",
     "fname": "Golem",

--- a/ethereum/GLEECT
+++ b/ethereum/GLEECT
@@ -1,0 +1,9 @@
+{
+  "swap_contract_address": "0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D",
+  "fallback_swap_contract": "0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D",
+  "rpc_nodes": [
+    {
+      "url": "https://rpc.gleec.dev"
+    }
+  ]
+}

--- a/explorers/GLEECT
+++ b/explorers/GLEECT
@@ -1,0 +1,1 @@
+["https://explorer.gleec.dev/"]


### PR DESCRIPTION
## Summary
- Add GLEECT coin entry for GLEEC 2.0 EVM testnet (chain ID 11169)
- Add ethereum config with swap contract address and RPC node
- Add explorer config

**Swap contract:** `0x51d9EfFc20F6965bc8DFD37E797ac52a72fcdb9D`
**RPC:** `https://rpc.gleec.dev`
**Explorer:** `https://explorer.gleec.dev/`