### PR TITLE
feat: Allow manual dispatch of config generator for selected branch

### DIFF
--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -48,7 +48,7 @@ jobs:
           base: ${{ env.TARGET_BRANCH }}
           branch: config-generate/${{ env.TARGET_BRANCH }}
           delete-branch: true
-          title: '[BOT] Update coins config json'
+          title: "[BOT] Update coins config json for ${{ env.TARGET_BRANCH }}"
           body: |
             - Coins JSON config auto-generated from `${{ env.TARGET_BRANCH }}`
             - Electrum scan report updated

--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -46,7 +46,7 @@ jobs:
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           base: ${{ env.TARGET_BRANCH }}
-          branch: json-config-update
+          branch: json-config-update/${{ env.TARGET_BRANCH }}
           delete-branch: true
           title: '[BOT] Update coins config json'
           body: |

--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -13,12 +13,22 @@ on:
   schedule:
     - cron:  '0 0 * * *'
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to run against and target for PR
+        required: true
+        default: master
+        type: string
 
 jobs:
   update_configs:
     runs-on: ubuntu-22.04
+    env:
+      TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.target_branch || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
 
       - name: Create 128x128 images in icons dir
         shell: bash
@@ -35,11 +45,12 @@ jobs:
           commit-message: Update coins json file
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          base: ${{ env.TARGET_BRANCH }}
           branch: json-config-update
           delete-branch: true
           title: '[BOT] Update coins config json'
           body: |
-            - Coins JSON config auto-generated on merge to master
+            - Coins JSON config auto-generated from `${{ env.TARGET_BRANCH }}`
             - Electrum scan report updated
           labels: |
             config-update

--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -54,5 +54,5 @@ jobs:
             - Electrum scan report updated
           labels: |
             config-update
-          reviewers: cipig, smk762, gcharang
+          reviewers: cipig
           draft: false

--- a/.github/workflows/gen_configs.yml
+++ b/.github/workflows/gen_configs.yml
@@ -46,7 +46,7 @@ jobs:
           committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           base: ${{ env.TARGET_BRANCH }}
-          branch: json-config-update/${{ env.TARGET_BRANCH }}
+          branch: config-generate/${{ env.TARGET_BRANCH }}
           delete-branch: true
           title: '[BOT] Update coins config json'
           body: |


### PR DESCRIPTION
Tested in #1683.

## Summary
- add a `workflow_dispatch` input `target_branch` to `.github/workflows/gen_configs.yml`
- check out the selected branch for manual runs while preserving push/schedule behavior
- target PR creation in the workflow to the selected branch

## Why
This allows manually running the config generator workflow against a specific branch instead of being limited to `master`.
