### PR TITLE
electrums/WJK: fix electrum1 ports (SSL 50102, WSS 50104)

### DIFF
--- a/electrums/WJK
+++ b/electrums/WJK
@@ -1,32 +1,32 @@
 [
-  {
-    "url": "electrum1.wojakcoin.cash:50103",
-    "ws_url": "electrum1.wojakcoin.cash:50102",
-    "protocol": "SSL",
-    "contact": [
-      { "discord": "danny_utxo" }
-    ]
-  },
-  {
-    "url": "electrum1.wojakcoin.cash:50101",
-    "protocol": "TCP",
-    "contact": [
-      { "discord": "danny_utxo" }
-    ]
-  },
-  {
-    "url": "electrum2.wojakcoin.cash:50002",
-    "ws_url": "electrum2.wojakcoin.cash:50003",
-    "protocol": "SSL",
-    "contact": [
-      { "discord": "danny_utxo" }
-    ]
-  },
-  {
-    "url": "electrum2.wojakcoin.cash:50001",
-    "protocol": "TCP",
-    "contact": [
-      { "discord": "danny_utxo" }
-    ]
-  }
+ {
+ "url": "electrum1.wojakcoin.cash:50102",
+ "ws_url": "electrum1.wojakcoin.cash:50104",
+ "protocol": "SSL",
+ "contact": [
+ { "discord": "danny_utxo" }
+ ]
+ },
+ {
+ "url": "electrum1.wojakcoin.cash:50101",
+ "protocol": "TCP",
+ "contact": [
+ { "discord": "danny_utxo" }
+ ]
+ },
+ {
+ "url": "electrum2.wojakcoin.cash:50002",
+ "ws_url": "electrum2.wojakcoin.cash:50003",
+ "protocol": "SSL",
+ "contact": [
+ { "discord": "danny_utxo" }
+ ]
+ },
+ {
+ "url": "electrum2.wojakcoin.cash:50001",
+ "protocol": "TCP",
+ "contact": [
+ { "discord": "danny_utxo" }
+ ]
+ }
 ]


### PR DESCRIPTION
Updates electrum1.wojakcoin.cash ports so wallets can connect:

- **url** (SSL): 50103 → **50102** (raw Electrum protocol)
- **ws_url** (WSS): 50102 → **50104** (WebSocket on separate port)

Electrum2 unchanged. JSON structure matches existing format.