### PR TITLE
Update NITO configuration: add legacy entry, fix parameters, add SSL cert options

### DIFF
--- a/coins
+++ b/coins
@@ -17091,29 +17091,56 @@
     }
   },
   {
-    "coin": "NITO-segwit",
+    "coin": "NITO",
     "name": "nito",
     "fname": "NITO",
-    "sign_message_prefix": "Nito Signed Message:\n",
     "rpcport": 8825,
     "pubtype": 0,
     "p2shtype": 5,
     "wiftype": 128,
+    "segwit": true,
+    "bech32_hrp": "nito",
     "txfee": 10000,
-    "wallet_only": true,
+    "dust": 10000,
+    "mm2": 1,
+    "required_confirmations": 3,
+    "mature_confirmations": 101,
+    "avg_blocktime": 60,
+    "protocol": {
+      "type": "UTXO"
+    },
+    "derivation_path": "m/44'/0'",
+    "sign_message_prefix": "Nito Signed Message:\n",
+    "links": {
+      "github": "https://github.com/NitoNetwork/Nito-core",
+      "homepage": "https://nito.network"
+    }
+  },
+  {
+    "coin": "NITO-segwit",
+    "name": "nito",
+    "fname": "NITO",
+    "rpcport": 8825,
+    "pubtype": 0,
+    "p2shtype": 5,
+    "wiftype": 128,
     "segwit": true,
     "bech32_hrp": "nito",
     "address_format": {
       "format": "segwit"
     },
     "orderbook_ticker": "NITO",
+    "txfee": 10000,
+    "dust": 10000,
     "mm2": 1,
     "required_confirmations": 3,
+    "mature_confirmations": 101,
     "avg_blocktime": 60,
     "protocol": {
       "type": "UTXO"
     },
     "derivation_path": "m/84'/0'",
+    "sign_message_prefix": "Nito Signed Message:\n",
     "links": {
       "github": "https://github.com/NitoNetwork/Nito-core",
       "homepage": "https://nito.network"

--- a/electrums/NITO
+++ b/electrums/NITO
@@ -1,50 +1,38 @@
- [
-           {
-                "url": "electrum1.nito.network:50001",
-                "contact": [
-                    {
-                        "email": "biigbang0001@zemzar.net"
-                    },
-                    {
-                        "discord": "biigbang0001"
-                    }
-                ]
-            },
-            {
-                "url": "electrum1.nito.network:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "biigbang0001@zemzar.net"
-                    },
-                    {
-                        "discord": "biigbang0001"
-                    }
-                ],
-                "ws_url": "electrum1.nito.network:50005"
-            },
-            {
-                "url": "electrum1.nitopool.fr:50001",
-                "contact": [
-                    {
-                        "email": "biigbang0001@zemzar.net"
-                    },
-                    {
-                        "discord": "biigbang0001"
-                    }
-                ]
-            },           
-            {
-                "url": "electrum1.nitopool.fr:50003",
-                "protocol": "SSL",
-                "contact": [
-                    {
-                        "email": "biigbang0001@zemzar.net"
-                    },
-                    {
-                        "discord": "biigbang0001"
-                    }
-                ],
-                "ws_url": "electrum1.nitopool.fr:50005"
-            }
+[
+    {
+        "url": "electrum1.nito.network:50001",
+        "protocol": "TCP",
+        "contact": [
+            {"email": "biigbang0001@zemzar.net"},
+            {"discord": "biigbang0001"}
         ]
+    },
+    {
+        "url": "electrum1.nito.network:50003",
+        "protocol": "SSL",
+        "disable_cert_verification": false,
+        "contact": [
+            {"email": "biigbang0001@zemzar.net"},
+            {"discord": "biigbang0001"}
+        ],
+        "ws_url": "electrum1.nito.network:50005"
+    },
+    {
+        "url": "electrum1.nitopool.fr:50001",
+        "protocol": "TCP",
+        "contact": [
+            {"email": "biigbang0001@zemzar.net"},
+            {"discord": "biigbang0001"}
+        ]
+    },
+    {
+        "url": "electrum1.nitopool.fr:50003",
+        "protocol": "SSL",
+        "disable_cert_verification": false,
+        "contact": [
+            {"email": "biigbang0001@zemzar.net"},
+            {"discord": "biigbang0001"}
+        ],
+        "ws_url": "electrum1.nitopool.fr:50005"
+    }
+]


### PR DESCRIPTION
## Summary

- Added `NITO` legacy coin entry (alongside existing `NITO-segwit`)
- Added missing parameters: `dust`, `mature_confirmations`
- Removed `wallet_only: true` to match other coins like FIX
- Added `"protocol": "TCP"` and `"disable_cert_verification": false` to electrums/NITO
- Aligned NITO configuration format with FIX/FIX-segwit

## Electrum Server Status

All 4 servers are online and responding:
- electrum1.nito.network:50001 (TCP) - Online
- electrum1.nito.network:50003 (SSL) - Online
- electrum1.nitopool.fr:50001 (TCP) - Online  
- electrum1.nitopool.fr:50003 (SSL) - Online

ElectrumX 1.18.0 (KomodoPlatform/electrumx-1), SSL via Let's Encrypt.

## Issue

NITO-segwit returns "NoSuchCoin" error on app.komodoplatform.com.
The SSL/WSS scan report appears outdated - servers are fully operational.
A rescan of NITO electrum servers would be appreciated.
