### PR TITLE
fix(config): generate TRX type for Tron platform assets

### DIFF
--- a/utils/coins_config.json
+++ b/utils/coins_config.json
@@ -41473,7 +41473,7 @@
     },
     "TRX": {
         "coin": "TRX",
-        "type": "TRC-20",
+        "type": "TRX",
         "name": "TRON",
         "coinpaprika_id": "",
         "coingecko_id": "",
@@ -41535,7 +41535,7 @@
     },
     "TRXT": {
         "coin": "TRXT",
-        "type": "TRC-20",
+        "type": "TRX",
         "name": "TRON Testnet",
         "coinpaprika_id": "",
         "coingecko_id": "",

--- a/utils/coins_config_unfiltered.json
+++ b/utils/coins_config_unfiltered.json
@@ -41473,7 +41473,7 @@
     },
     "TRX": {
         "coin": "TRX",
-        "type": "TRC-20",
+        "type": "TRX",
         "name": "TRON",
         "coinpaprika_id": "",
         "coingecko_id": "",
@@ -41535,7 +41535,7 @@
     },
     "TRXT": {
         "coin": "TRXT",
-        "type": "TRC-20",
+        "type": "TRX",
         "name": "TRON Testnet",
         "coinpaprika_id": "",
         "coingecko_id": "",

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -160,7 +160,7 @@ class CoinConfig:
             "QTUM": "QRC-20",
             "RBTC": "RSK Smart Bitcoin",
             "SBCH": "SmartBCH",
-            "TRX": "TRC-20",
+            "TRX": "TRX",
             "ATOM": "TENDERMINT",
             "OSMO": "TENDERMINT",
             "IRIS": "TENDERMINT",
@@ -174,7 +174,7 @@ class CoinConfig:
             "IRISTEST": "TENDERMINT",
             "NUCLEUSTEST": "TENDERMINT",
             "MATICTEST": "Matic",
-            "TRXT": "TRC-20",
+            "TRXT": "TRX",
             "UBQ": "Ubiq",
         }
         self.coin_type = coin_data["protocol"]["type"]
@@ -261,11 +261,14 @@ class CoinConfig:
 
             elif "platform" in protocol_data:
                 # TODO: ERC-like things
-                platform = protocol_data["platform"]
-                if self.is_testnet:
-                    coin_type = self.testnet_protocols[platform]
+                if self.coin_data["protocol"]["type"] == "TRC20":
+                    coin_type = "TRC-20"
                 else:
-                    coin_type = self.protocols[platform]
+                    platform = protocol_data["platform"]
+                    if self.is_testnet:
+                        coin_type = self.testnet_protocols[platform]
+                    else:
+                        coin_type = self.protocols[platform]
                 self.data[self.ticker].update({"type": coin_type})
                 if "contract_address" in protocol_data:
                     self.data[self.ticker].update(
@@ -413,6 +416,11 @@ class CoinConfig:
         token_type = self.data[self.ticker]["type"]
         if self.ticker == "RBTC":
             return "RSK"
+
+        if self.coin_type == "TRC20":
+            protocol_data = self.coin_data["protocol"].get("protocol_data", {})
+            if "platform" in protocol_data:
+                return protocol_data["platform"]
 
         if self.coin_type in ["TENDERMINTTOKEN", "TENDERMINT"]:
             for i in ["IRISTEST", "NUCLEUSTEST"]:


### PR DESCRIPTION
## Summary
- generate `TRX` as the top-level type for TRX/TRXT platform assets
- keep TRC20 tokens on `TRC-20` while preserving `parent_coin`
- regenerate the bundled `coins_config` artifacts with the corrected Tron shape

## Verification
- `python3 -m py_compile utils/generate_app_configs.py`
- verified the regenerated `utils/coins_config_unfiltered.json` contains `TRX`/`TRXT` platform types and `TRC-20` token types with the expected `parent_coin` values