### PR TITLE
fix: add Tronscan explorer URLs for TRX and TRXT

### DIFF
--- a/explorers/TRX
+++ b/explorers/TRX
@@ -1,0 +1,1 @@
+["https://tronscan.org/"]

--- a/explorers/TRXT
+++ b/explorers/TRXT
@@ -1,0 +1,1 @@
+["https://nile.tronscan.org/"]

--- a/explorers/explorer_paths.json
+++ b/explorers/explorer_paths.json
@@ -216,5 +216,15 @@
 		"explorer_tx_url": "tx/",
 		"explorer_address_url": "address/",
 		"explorer_block_url": "block/"
+	},
+	"https://tronscan.org/": {
+		"explorer_tx_url": "#/transaction/",
+		"explorer_address_url": "#/address/",
+		"explorer_block_url": "#/block/"
+	},
+	"https://nile.tronscan.org/": {
+		"explorer_tx_url": "#/transaction/",
+		"explorer_address_url": "#/address/",
+		"explorer_block_url": "#/block/"
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `explorers/TRX` and `explorers/TRXT` pointing to `tronscan.org` and `nile.tronscan.org` respectively
- Adds Tronscan URL path patterns to `explorer_paths.json` with correct hash-based routing (`#/transaction/`, `#/address/`, `#/block/`)
- Fixes empty explorer URLs for `TRX`, `USDT-TRC20`, `TRXT`, and `TESTUSDT-TRC20`

## Test plan
- [x] Verified `https://tronscan.org/#/address/TEeYEGwYW8UFNi9TNeCfT7F5yhS84ybamJ` resolves correctly
- [x] Ran `generate_app_configs.py` and confirmed all 4 TRON coins now have populated explorer URLs
- [ ] Verify explorer links work in the wallet UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)