### PR TITLE
remove bad BTCZ electrums

### DIFF
--- a/electrums/BTCZ
+++ b/electrums/BTCZ
@@ -1,39 +1,12 @@
 [
     {
-        "url": "electrum2.btcz.rocks:50001",
-        "contact": [
-            {
-                "discord": "VandarGR#6065"
-            }
-        ],
-        "ws_url": "electrum2.btcz.rocks:50004"
-    },
-    {
-        "url": "electrum1.btcz.rocks:50001",
-        "contact": [
-            {
-                "discord": "VandarGR#6065"
-            }
-        ],
-        "ws_url": "electrum1.btcz.rocks:50004"
-    },
-    {
-        "url": "electrum3.btcz.rocks:50001",
-        "contact": [
-            {
-                "discord": "426842722436120577"
-            }
-        ],
-        "ws_url": "electrum3.btcz.rocks:50004"
-    },
-    {
-        "url": "electrum5.btcz.rocks:50002",
+        "url": "electrum3.btcz.rocks:50002",
         "protocol": "SSL",
         "contact": [
             {
                 "discord": "426842722436120577"
             }
         ],
-        "ws_url": "electrum5.btcz.rocks:50004"
+        "ws_url": "electrum3.btcz.rocks:50004"
     }
 ]

--- a/explorers/DOC
+++ b/explorers/DOC
@@ -1,4 +1,3 @@
 [
-    "https://doc.komodo.earth/",
     "https://doc.explorer.dexstats.info/"
 ]

--- a/explorers/MARTY
+++ b/explorers/MARTY
@@ -1,4 +1,3 @@
 [
-    "https://marty.komodo.earth/",
     "https://marty.explorer.dexstats.info/"
 ]

--- a/explorers/ZOMBIE
+++ b/explorers/ZOMBIE
@@ -1,4 +1,3 @@
 [
-    "https://zombie.komodo.earth/",
     "https://zombie.explorer.lordofthechains.com/"
 ]

--- a/utils/generate_app_configs.py
+++ b/utils/generate_app_configs.py
@@ -942,7 +942,7 @@ def filter_wss(coins_config):
 
 def generate_binance_api_ids(coins_config):
     kdf_coins = coins_config.keys()
-    r = requests.get("https://defi-stats.komodo.earth/api/v3/binance/ticker_price")
+    r = requests.get("https://defistats.gleec.com/api/v3/binance/ticker_price")
     binance_tickers = r.json()
     pairs = []
     for ticker in binance_tickers:


### PR DESCRIPTION
electrum1 and electrum5 are down
electrum2 is stuck on some old height and does not have the hardfork changes: https://github.com/GLEECBTC/coins/pull/1763