### PR TITLE
update consensus-branch-id for ZEC

### DIFF
--- a/coins
+++ b/coins
@@ -15207,7 +15207,7 @@
     "txversion": 4,
     "overwintered": 1,
     "version_group_id": "0x892f2085",
-    "consensus_branch_id": "0x4dec4df0",
+    "consensus_branch_id": "0x5437f330",
     "txfee": 100000,
     "mm2": 1,
     "required_confirmations": 3,


### PR DESCRIPTION
`the transaction was rejected by network rules.\\n\\n16: old-consensus-branch-id (Expected 5437f330, found 4dec4df0)`
else it would be boring ... not having to update this stuff every other week

<img width="657" height="378" alt="image" src="https://github.com/user-attachments/assets/90d327dc-a575-46de-8d11-101522ca50af" />
