### PR TITLE
Add BITN electrum servers (bitn-electrumx.wattxchange.app)

### DIFF
--- a/electrums/BITN
+++ b/electrums/BITN
@@ -22,5 +22,18 @@
     "contact": [
       { "discord": "def#4726" }
     ]
+  },
+  {
+    "url": "bitn-electrumx.wattxchange.app:50012",
+    "protocol": "SSL",
+    "contact": [
+      { "discord": "nucash" }
+    ]
+  },
+  {
+    "url": "bitn-electrumx.wattxchange.app:50011",
+    "contact": [
+      { "discord": "nucash" }
+    ]
   }
 ]

--- a/electrums/BITN
+++ b/electrums/BITN
@@ -26,6 +26,7 @@
   {
     "url": "bitn-electrumx.wattxchange.app:50012",
     "protocol": "SSL",
+    "ws_url": "bitn-electrumx.wattxchange.app:50014",
     "contact": [
       { "discord": "nucash" }
     ]


### PR DESCRIPTION
Adds two new Bitnet (BITN) electrum servers to `electrums/BITN`:

| URL | Protocol |
|---|---|
| `bitn-electrumx.wattxchange.app:50012` | SSL (ws_url: `bitn-electrumx.wattxchange.app:50014` WSS) |
| `bitn-electrumx.wattxchange.app:50011` | TCP |

Server details:
- Qtum ElectrumX 1.16.0 (protocol 1.4) backed by a full, unpruned bitnetd node with `txindex=1`, fully synced to chain tip.
- SSL (50012) and WSS (50014) serve a valid Let's Encrypt certificate (CN=bitn-electrumx.wattxchange.app, auto-renewed) — WSS works from browsers/web clients.
- Existing BITN servers are untouched — this is an addition for redundancy, not a replacement.
- Contact: discord `nucash`

Verification against the live hostname:
```
$ printf '{"id":1,"method":"server.version","params":["test","1.4"]}\n' | nc bitn-electrumx.wattxchange.app 50011
{"jsonrpc": "2.0", "result": ["Qtum ElectrumX 1.16.0", "1.4"], "id": 1}
```
All three verified answering `server.version`: TCP 50011, SSL 50012, and WSS 50014 (WebSocket handshake + JSON-RPC over wss://).