### PR TITLE
add s6.electrum.qtum.site to tQTUM electrums

### DIFF
--- a/electrums/tQTUM
+++ b/electrums/tQTUM
@@ -1,5 +1,22 @@
 [
     {
+        "url": "s6.electrum.qtum.site:51001",
+        "contact": [
+            {
+                "github": "https://github.com/qtumproject/qtum-electrum"
+            }
+        ]
+    },
+    {
+        "url": "s6.electrum.qtum.site:51002",
+        "protocol": "SSL",
+        "contact": [
+            {
+                "github": "https://github.com/qtumproject/qtum-electrum"
+            }
+        ]
+    },
+    {
         "url": "tqtum.electrum3.cipig.net:20071",
         "protocol": "SSL",
         "contact": [


### PR DESCRIPTION
cipig's testnet Qtum electrum (`tqtum.electrum3.cipig.net:10071/20071`) is currently down, leaving tQTUM with no live servers — this breaks KDF's QRC20/Qtum test suites (see GLEECBTC/kdf-internal#24).

Adds the Qtum project's own testnet ElectrumX `s6.electrum.qtum.site` (TCP 51001 / SSL 51002, from qtum-electrum's `servers_testnet.json`), verified live: testnet genesis hash, unpruned, full history, supports the Qtum receipt extension. The cipig entries are kept for when that server returns; its sibling `s2.electrum.qtum.site` is dead and not included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Q89dL8HH4mKUpVYaU4AFj