### PR TITLE
Add trezor_coin for Radiant (RXD)

### DIFF
--- a/coins
+++ b/coins
@@ -10520,6 +10520,7 @@
       "type": "UTXO"
     },
     "derivation_path": "m/44'/512'",
+    "trezor_coin": "Radiant",
     "links": {
       "github": "https://github.com/Radiant-Core/Radiant-Core",
       "homepage": "https://radiantblockchain.org"


### PR DESCRIPTION
Adds the `trezor_coin` field to the Radiant (RXD) entry so RXD can be
used with Trezor hardware wallets.

- Coin: Radiant (RXD), UTXO, derivation path `m/44'/512'`
- Field added: `"trezor_coin": "Radiant"`

Note: Radiant is not present in trezor-common's `coins_details.json`, so
`utils/parse_trezor_coins.py` will not derive this value automatically.
Radiant requires `sighash_forkid` support (the entry already carries
`"fork_id": "0x40"` and `"signature_version": "fork_id_rxd"`), which is a
larger change than a coin definition, so upstream Trezor support is
unlikely in the near term. This targets custom/self-maintained firmware
where the coin is registered under the name "Radiant". The field is
inert for users without such firmware, and reruns of
`parse_trezor_coins.py` leave it in place.