### PR TITLE
FLOP: add working WSS electrum endpoint for GleecDEX

### DIFF
--- a/electrums/FLOP
+++ b/electrums/FLOP
@@ -10,19 +10,15 @@
             "discord": "technovision"
         }
       ],
-      "ws_url": "electrumx1.flopcoin.net:10003"
+      "ws_url": "flop-electrum.wattxchange.app:443"
     },
     {
-      "url": "electrumx2.flopcoin.net:10001"
-    },
-    {
-      "url": "electrumx2.flopcoin.net:10004",
-      "protocol": "SSL",
+      "url": "flop-electrum.wattxchange.app:443",
+      "protocol": "WSS",
       "contact": [
         {
-            "discord": "technovision"
+            "discord": "nucash"
         }
-      ],
-      "ws_url": "electrumx2.flopcoin.net:10003"
+      ]
     }
   ]

--- a/electrums/FLOP
+++ b/electrums/FLOP
@@ -9,8 +9,7 @@
         {
             "discord": "technovision"
         }
-      ],
-      "ws_url": "flop-electrum.wattxchange.app:443"
+      ]
     },
     {
       "url": "flop-electrum.wattxchange.app:443",


### PR DESCRIPTION
GleecDEX (KDF/WASM) needs a secure wss:// electrum endpoint for FLOP, and the current config has none that works:

- The existing ws_url was electrumx1.flopcoin.net:10003, which is plain ws:// — browsers block it as mixed content on an HTTPS page.
- electrumx2.flopcoin.net (10001/10003/10004) is fully down (all ports closed).

This PR:
- Points electrumx1 ws_url at a live WSS endpoint: flop-electrum.wattxchange.app:443 (ElectrumX 1.16.0, valid Let's Encrypt cert, fully synced).
- Adds an explicit WSS entry for the same host.
- Removes the dead electrumx2 entries.

Verified live: server.version -> ["ElectrumX 1.16.0","1.4"]; blockchain.headers.subscribe returns tip 805,660 over wss://flop-electrum.wattxchange.app:443.

Contact: discord nucash.