### PR TITLE
fix(dime): correct DIME rpcport to 8332 (was P2P port 11931)

### DIFF
--- a/coins
+++ b/coins
@@ -3709,7 +3709,7 @@
     "coin": "DIME",
     "name": "dimecoin",
     "fname": "Dimecoin",
-    "rpcport": 11931,
+    "rpcport": 8332,
     "pubtype": 15,
     "p2shtype": 9,
     "wiftype": 143,


### PR DESCRIPTION
## Summary
The DIME entry in `coins` lists `rpcport: 11931`, which is Dimecoin's **P2P** port. The real RPC port is **8332** (`src/chainparamsbase.cpp:36` in dime-coin/dimecoin).

- Breaks MM2 **native (full-node) mode** for DIME: `mm2` would try to reach `dimecoind` RPC on the wrong port.
- Electrum mode (current default via `electrums/DIME`) is unaffected, but native mode should also work for users running their own node.

## Change
```diff
-  "rpcport": 11931,
+  "rpcport": 8332,
```

Other DIME fields (pubtype 15, p2shtype 9, wiftype 143, bech32_hrp "vx", mm2:1) are correct.

## Verification
- Source: https://github.com/dime-coin/dimecoin/blob/master/src/chainparamsbase.cpp#L36 (`nRPCPort = 8332;`)
- P2P port 11931: https://github.com/dime-coin/dimecoin/blob/master/src/chainparams.cpp (nDefaultPort)

Part of broader Dimecoin non-custodial DEX enablement (dime-coin/dimecoin#99, #100). (Reposted here per @cipig — the canonical repo moved from KomodoPlatform/coins to GLEECBTC/coins.)