### PR TITLE
RIN: point homepage at rincoin.org, add explorer.rincoin.org

### DIFF
--- a/coins
+++ b/coins
@@ -10227,7 +10227,7 @@
     "derivation_path": "m/44'/9555'",
     "links": {
       "github": "https://github.com/Rin-coin/rincoin",
-      "homepage": "https://rincoin.tech"
+      "homepage": "https://rincoin.org"
     }
   },
   {
@@ -10257,7 +10257,7 @@
     "derivation_path": "m/84'/9555'",
     "links": {
       "github": "https://github.com/Rin-coin/rincoin",
-      "homepage": "https://rincoin.tech"
+      "homepage": "https://rincoin.org"
     }
   },
   {

--- a/explorers/RIN
+++ b/explorers/RIN
@@ -1,4 +1,5 @@
 [ 
+    "https://explorer.rincoin.org/",
     "https://explorer.rincoin.tech/",
     "https://explorer-old.rincoin.tech/"
 ]


### PR DESCRIPTION
## Summary

Points the RIN `links.homepage` at `https://rincoin.org` and adds
`https://explorer.rincoin.org/` to the RIN explorer list. Three lines changed
in total.

## Changes

**`coins`** — sets `links.homepage` for `RIN` and `RIN-segwit`.

Both entries already list `https://github.com/Rin-coin/rincoin` as
`links.github`. `rincoin.org` is the project site for that repository, so the
two fields now refer to the same project.

**`explorers/RIN`** — adds `https://explorer.rincoin.org/`.

It is an eIquidus instance backed by a full node, tracking the chain tip.
Added, not replaced: the existing entries are unchanged.

## Notes

No generated files are included. `utils/coins_config*.json` is produced by
`gen_configs.yml` after merge, so this branch leaves it untouched.

`explorer.rincoin.org` is maintained by the submitter. If it goes down, the
contact below is the right place to report it, and it will be fixed or removed.

Both files validate as JSON.

Contact: info@rincoin.org