### PR TITLE
Update Electrum server URLs and ports for rxd-radiant.com

### DIFF
--- a/electrums/RXD
+++ b/electrums/RXD
@@ -10,8 +10,13 @@
     "ws_url": "electrumx2.radiant4people.com:50022"
   },
   {
-    "url": "electrumx.rxd-radiant.com:50022",
+    "url": "electrumx.rxd-radiant.com:50012",
     "protocol": "SSL",
-    "ws_url": "electrumx.rxd-radiant.com:50023"
+    "ws_url": "electrumx.rxd-radiant.com:50011"
+  },
+  {
+    "url": "electrumx-eu.rxd-radiant.com:50012",
+    "protocol": "SSL",
+    "ws_url": "electrumx-eu.rxd-radiant.com:50011"
   }
 ]


### PR DESCRIPTION
This pull request updates the Electrum server configuration for RXD by changing the ports for an existing server and adding a new European server entry. These changes help improve connectivity and redundancy for RXD users.

Electrum server configuration updates:

* Changed the port numbers for the `electrumx.rxd-radiant.com` server from `50022` (SSL) and `50023` (WebSocket) to `50012` (SSL) and `50011` (WebSocket).
* Added a new European Electrum server entry: `electrumx-eu.rxd-radiant.com` with ports `50012` (SSL) and `50011` (WebSocket).